### PR TITLE
Implement Phase 8 runtime hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,12 @@ Named environments are resolved from:
 <project_root>/envs/<env_name>/pixi.toml
 ```
 
-You can also point `env=` at an explicit `pixi.toml` path.
+You can also point `env=` at:
+
+- an explicit `pixi.toml` path
+- an explicit `environment.yml` or `environment.yaml` path
+
+When given a conda env spec, Ginkgo imports it into a generated sibling Pixi workspace under `.ginkgo-pixi/` and then executes through Pixi as normal. `pixi.toml` remains the recommended canonical format.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It works well for:
 - research and scientific computing pipelines
 - mixed Python and shell-based workflows
 
-The project is currently implemented through **Phase 6**, with an initial React-based local UI from **Phase 7**. The shipped system includes the Python DSL, concurrent runtime, cache, Pixi backend, CLI, run manifests, debug tooling, and a local run browser.
+The project is currently implemented through **Phase 7**, with the first hardening slice of **Phase 8** now landed. The shipped system includes the Python DSL, concurrent runtime, cache, Pixi backend, CLI, run manifests, debug tooling, a local run browser, opt-in task retries, expression-graph cycle detection, and v1 cache pruning.
 
 ## What Ginkgo Looks Like
 
@@ -57,13 +57,15 @@ ginkgo run workflow.py
 - dynamic DAG expansion by returning new task expressions from a task body
 - `file`, `folder`, and `tmp_dir` marker types
 - content-addressed caching under `.ginkgo/cache/`
+- opt-in task retries via `@task(retries=n)`
+- explicit cycle detection for expression graphs before execution
 - concurrent scheduling with OR-Tools CP-SAT resource selection
 - Python task execution in worker processes, with a thread-pool fallback when process pools are blocked by the runtime environment
 - shell task execution through `shell_task(...)`
 - per-task Pixi environments resolved from `envs/<env>/pixi.toml`
 - run provenance under `.ginkgo/runs/<run_id>/`
 - a local React UI with `ginkgo ui` for browsing runs, a task graph, cache entries, and task logs
-- `ginkgo run`, `ginkgo test --dry-run`, `ginkgo cache ls`, `ginkgo cache clear`, `ginkgo debug`, and `ginkgo ui`
+- `ginkgo run`, `ginkgo test --dry-run`, `ginkgo cache ls`, `ginkgo cache clear`, `ginkgo cache prune`, `ginkgo debug`, and `ginkgo ui`
 
 ## Project Layout
 
@@ -388,7 +390,7 @@ to inspect the most recent failed run, including the last 50 lines of the failin
 ### Run a workflow
 
 ```bash
-ginkgo run workflow.py [--config PATH ...] [--jobs N] [--cores N]
+ginkgo run workflow.py [--config PATH ...] [--jobs N] [--cores N] [--dry-run]
 ```
 
 ### Validate local test workflows
@@ -411,6 +413,12 @@ This renders a Rich table with cache key, task, size, age, and created timestamp
 
 ```bash
 ginkgo cache clear <cache_key>
+```
+
+### Prune stale cache entries
+
+```bash
+ginkgo cache prune --older-than 30d [--dry-run]
 ```
 
 ### Inspect the latest failed run
@@ -451,11 +459,9 @@ The test suite currently covers:
 
 These items are still planned rather than shipped:
 
-- web UI
 - Docker backend
 - R task support
 - richer cache pruning commands
-- `ginkgo run --dry-run`
 
 ## Additional Documentation
 

--- a/src/ginkgo/cli/app.py
+++ b/src/ginkgo/cli/app.py
@@ -53,6 +53,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--config", action="append", default=[])
     run_parser.add_argument("--jobs", type=int, default=None)
     run_parser.add_argument("--cores", type=int, default=None)
+    run_parser.add_argument("--dry-run", action="store_true")
     run_parser.add_argument("--verbose", action="store_true")
 
     cache_parser = subparsers.add_parser("cache")
@@ -60,6 +61,9 @@ def _build_parser() -> argparse.ArgumentParser:
     cache_subparsers.add_parser("ls")
     clear_parser = cache_subparsers.add_parser("clear")
     clear_parser.add_argument("cache_key")
+    prune_parser = cache_subparsers.add_parser("prune")
+    prune_parser.add_argument("--older-than", required=True)
+    prune_parser.add_argument("--dry-run", action="store_true")
 
     debug_parser = subparsers.add_parser("debug")
     debug_parser.add_argument("run_id", nargs="?")

--- a/src/ginkgo/cli/commands/cache.py
+++ b/src/ginkgo/cli/commands/cache.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import shutil
 import sys
+import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 import yaml
 from rich import box
@@ -41,13 +42,45 @@ def command_cache(args) -> int:
         table.add_column("Created", no_wrap=True)
         for row in entries:
             table.add_row(
-                row["cache_key"],
-                row["task"],
-                row["size"],
-                row["age"],
-                row["created"],
+                row.cache_key,
+                row.task,
+                row.size,
+                row.age,
+                row.created,
             )
         rich_console.print(table)
+        return 0
+
+    if args.cache_command == "prune":
+        rich_console.print("[bold green]🌿 ginkgo cache[/] [bold]prune[/]\n")
+        cutoff = _prune_cutoff(args.older_than)
+        entries = [
+            entry
+            for entry in list_cache_entries(CACHE_ROOT)
+            if entry.created_at is not None and entry.created_at < cutoff
+        ]
+        total_bytes = sum(entry.size_bytes for entry in entries)
+
+        if args.dry_run:
+            rich_console.print(
+                f"[cyan]Preview:[/] {len(entries)} entries older than "
+                f"[bold]{args.older_than}[/] "
+                f"([bold]{_format_size(total_bytes)}[/]) would be removed."
+            )
+            for entry in entries:
+                rich_console.print(
+                    f"[dim]-[/] {entry.cache_key} ({entry.task}, {entry.age}, {entry.size})"
+                )
+            return 0
+
+        for entry in entries:
+            shutil.rmtree(entry.path)
+
+        rich_console.print(
+            f"[green]✓[/] Removed [bold]{len(entries)}[/] cache "
+            f"{'entry' if len(entries) == 1 else 'entries'} "
+            f"([bold]{_format_size(total_bytes)}[/])."
+        )
         return 0
 
     cache_dir = CACHE_ROOT / args.cache_key
@@ -64,7 +97,22 @@ def command_cache(args) -> int:
     return 0
 
 
-def list_cache_entries(root: Path) -> list[dict[str, Any]]:
+@dataclass(frozen=True)
+class CacheEntryRow:
+    """Display and pruning metadata for a cache entry."""
+
+    path: Path
+    cache_key: str
+    task: str
+    size: str
+    size_bytes: int
+    age: str
+    created: str
+    created_at: datetime | None
+    function: str
+
+
+def list_cache_entries(root: Path) -> list[CacheEntryRow]:
     """Return cache entries as structured rows."""
     if not root.exists():
         return []
@@ -74,7 +122,7 @@ def list_cache_entries(root: Path) -> list[dict[str, Any]]:
     ]
 
 
-def _cache_entry_row(entry: Path) -> dict[str, Any]:
+def _cache_entry_row(entry: Path) -> CacheEntryRow:
     """Return the display row for a cache entry."""
     meta_path = entry / "meta.json"
     if meta_path.is_file():
@@ -88,15 +136,18 @@ def _cache_entry_row(entry: Path) -> dict[str, Any]:
     function = str(meta.get("function") or "unknown")
     timestamp = str(meta.get("timestamp") or "")
     created_at = _parse_timestamp(timestamp)
-    return {
-        "cache_key": entry.name,
-        "task": _task_base_name(function),
-        "size": _format_size(_dir_size(entry)),
-        "size_bytes": _dir_size(entry),
-        "age": _format_age(created_at),
-        "created": timestamp or "-",
-        "function": function,
-    }
+    size_bytes = _dir_size(entry)
+    return CacheEntryRow(
+        path=entry,
+        cache_key=entry.name,
+        task=_task_base_name(function),
+        size=_format_size(size_bytes),
+        size_bytes=size_bytes,
+        age=_format_age(created_at),
+        created=timestamp or "-",
+        created_at=created_at,
+        function=function,
+    )
 
 
 def _dir_size(path: Path) -> int:
@@ -144,3 +195,26 @@ def _format_age(created_at: datetime | None) -> str:
     if seconds < 86400:
         return f"{seconds // 3600}h"
     return f"{seconds // 86400}d"
+
+
+def _prune_cutoff(older_than: str) -> datetime:
+    """Return the UTC cutoff timestamp implied by a duration string."""
+    duration = _parse_duration_seconds(older_than)
+    return datetime.now(UTC) - duration
+
+
+def _parse_duration_seconds(value: str):
+    """Parse a compact duration string like ``30d`` or ``12h``."""
+    match = re.fullmatch(r"(?P<count>\d+)(?P<unit>[mhd])", value.strip())
+    if match is None:
+        raise ValueError(
+            "Invalid duration for --older-than. Use a positive integer followed by "
+            "m, h, or d (for example: 45m, 12h, 30d)."
+        )
+
+    count = int(match.group("count"))
+    unit = match.group("unit")
+    multipliers = {"m": 60, "h": 3600, "d": 86400}
+    from datetime import timedelta
+
+    return timedelta(seconds=count * multipliers[unit])

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -27,7 +27,7 @@ def command_run(args, *, output_mode: RunMode) -> int:
         config_paths=[Path(path).resolve() for path in args.config],
         jobs=args.jobs,
         cores=args.cores,
-        dry_run=False,
+        dry_run=args.dry_run,
         output_mode=output_mode,
     )
 
@@ -43,7 +43,11 @@ def run_workflow(
 ) -> int:
     run_id = make_run_id(workflow_path=workflow_path)
     rich_console = console(sys.stdout)
-    if not dry_run:
+    if dry_run:
+        rich_console.print(
+            f"[bold green]🌿 ginkgo run[/] [bold]{workflow_path.name}[/] [bold]--dry-run[/]\n"
+        )
+    else:
         rich_console.print(
             f"[bold green]🌿 ginkgo run[/] [bold]{workflow_path.name}[/] [dim]({run_id})[/]\n"
         )

--- a/src/ginkgo/core/task.py
+++ b/src/ginkgo/core/task.py
@@ -28,16 +28,22 @@ class TaskDef:
         Pixi environment name (or Docker URI in future).
     version : int
         Cache-busting version tag.
+    retries : int
+        Additional retry attempts after the initial execution.
     """
 
     fn: Callable[..., Any]
     env: str | None = None
     version: int = 1
+    retries: int = 0
     _signature: inspect.Signature = field(init=False, repr=False)
     _type_hints: dict[str, Any] = field(init=False, repr=False)
     _required_params: frozenset[str] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
+        if self.retries < 0:
+            raise ValueError("retries must be at least 0")
+
         sig = inspect.signature(self.fn)
         hints = get_type_hints(self.fn)
         required = frozenset(
@@ -211,6 +217,7 @@ def task(
     *,
     env: str | None = None,
     version: int = 1,
+    retries: int = 0,
 ) -> Callable[[Callable[..., Any]], TaskDef]:
     """Decorator that turns a function into a lazy task definition.
 
@@ -220,6 +227,8 @@ def task(
         Pixi environment name.  If ``None``, the task runs in the current env.
     version : int
         Cache-busting version tag.  Bump when task logic changes.
+    retries : int
+        Additional retry attempts after the initial execution.
 
     Returns
     -------
@@ -228,7 +237,7 @@ def task(
     """
 
     def decorator(fn: Callable[..., Any]) -> TaskDef:
-        return TaskDef(fn=fn, env=env, version=version)
+        return TaskDef(fn=fn, env=env, version=version, retries=retries)
 
     return decorator
 

--- a/src/ginkgo/envs/pixi.py
+++ b/src/ginkgo/envs/pixi.py
@@ -1,13 +1,16 @@
 """Pixi environment registry and subprocess helpers.
 
 Environments are resolved from ``envs/<env_name>/`` under the project root, or
-from a direct path to a ``pixi.toml`` when the ``env`` value is an absolute
-path or contains a path separator.
+from an explicit path to a ``pixi.toml``. Explicit conda environment specs
+(``environment.yml`` / ``environment.yaml``) are imported into a generated
+neighboring Pixi workspace under ``.ginkgo-pixi/`` and then executed through
+the normal Pixi path.
 """
 
 from __future__ import annotations
 
 import hashlib
+import subprocess
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -37,6 +40,14 @@ class PixiEnvNotFoundError(RuntimeError):
         super().__init__(msg)
 
 
+class PixiEnvImportError(RuntimeError):
+    """Raised when a conda environment spec cannot be imported into Pixi."""
+
+    def __init__(self, *, source: Path, output: str) -> None:
+        details = output.strip() or "pixi did not provide any error output"
+        super().__init__(f"Failed to import conda env spec {str(source)!r} into Pixi: {details}")
+
+
 def _list_envs(envs_dir: Path) -> list[str]:
     """Return sorted names of discoverable environments under envs_dir."""
     if not envs_dir.is_dir():
@@ -46,6 +57,11 @@ def _list_envs(envs_dir: Path) -> list[str]:
         for child in envs_dir.iterdir()
         if child.is_dir() and (child / "pixi.toml").is_file()
     )
+
+
+def _is_conda_env_file(path: Path) -> bool:
+    """Return whether *path* names a supported conda env spec file."""
+    return path.name in {"environment.yml", "environment.yaml"}
 
 
 def _is_explicit_path(env: str) -> bool:
@@ -101,6 +117,8 @@ class PixiRegistry:
         """
         if _is_explicit_path(env):
             manifest = Path(env)
+            if _is_conda_env_file(manifest):
+                return self._resolve_conda_env_file(manifest=manifest)
             if not manifest.is_file():
                 raise PixiEnvNotFoundError(env=env)
             return manifest.resolve()
@@ -109,6 +127,62 @@ class PixiRegistry:
         if not manifest.is_file():
             raise PixiEnvNotFoundError(env=env, searched=self._envs_dir)
         return manifest.resolve()
+
+    def _resolve_conda_env_file(self, *, manifest: Path) -> Path:
+        """Import a conda env spec into a generated neighboring Pixi workspace."""
+        if not manifest.is_file():
+            raise PixiEnvNotFoundError(env=str(manifest))
+
+        _require_pixi()
+        generated_dir = manifest.parent / ".ginkgo-pixi"
+        generated_manifest = generated_dir / "pixi.toml"
+        if self._should_refresh_generated_manifest(
+            source_manifest=manifest,
+            generated_manifest=generated_manifest,
+        ):
+            self._import_conda_env_file(source_manifest=manifest, output_dir=generated_dir)
+        return generated_manifest.resolve()
+
+    def _should_refresh_generated_manifest(
+        self,
+        *,
+        source_manifest: Path,
+        generated_manifest: Path,
+    ) -> bool:
+        """Return whether the generated Pixi workspace should be recreated."""
+        if not generated_manifest.is_file():
+            return True
+        return source_manifest.stat().st_mtime > generated_manifest.stat().st_mtime
+
+    def _import_conda_env_file(self, *, source_manifest: Path, output_dir: Path) -> None:
+        """Run ``pixi init --import`` into *output_dir* for a conda env spec."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        argv = [
+            "pixi",
+            "init",
+            str(output_dir),
+            "--import",
+            str(source_manifest),
+        ]
+        completed = subprocess.run(
+            argv,
+            shell=False,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if completed.returncode != 0:
+            raise PixiEnvImportError(
+                source=source_manifest,
+                output=(completed.stdout or "") + (completed.stderr or ""),
+            )
+
+        generated_manifest = output_dir / "pixi.toml"
+        if not generated_manifest.is_file():
+            raise PixiEnvImportError(
+                source=source_manifest,
+                output="pixi import completed without creating pixi.toml",
+            )
 
     def lock_hash(self, *, env: str) -> str | None:
         """Return the SHA-256 of the environment's ``pixi.lock``, or None.

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -63,6 +63,15 @@ _PIXI_WORKER_C = (
 )
 
 
+class CycleError(RuntimeError):
+    """Raised when the expression graph contains a dependency cycle."""
+
+    def __init__(self, cycle: list[str]) -> None:
+        self.cycle = cycle
+        rendered = " -> ".join(cycle)
+        super().__init__(f"Detected cycle in workflow graph: {rendered}")
+
+
 def _reconstruct_worker_error(error_payload: dict[str, Any]) -> BaseException:
     """Rebuild a task exception reported by a worker subprocess."""
     module_name = error_payload["module"]
@@ -132,6 +141,7 @@ class _TaskNode:
     stdout_path: Path | None = None
     stderr_path: Path | None = None
     display_label: str | None = None
+    attempt: int = 0
 
     @property
     def task_def(self) -> TaskDef:
@@ -265,44 +275,91 @@ class _ConcurrentEvaluator:
         assert self._failure is not None
         raise self._failure
 
-    def _register_value(self, value: Any) -> set[int]:
+    def _register_value(
+        self,
+        value: Any,
+        *,
+        expr_stack: tuple[int, ...] = (),
+        task_path: tuple[str, ...] = (),
+    ) -> set[int]:
         """Register all task nodes reachable from a nested value."""
         if isinstance(value, Expr):
-            return {self._register_expr(value)}
+            return {
+                self._register_expr(
+                    value,
+                    expr_stack=expr_stack,
+                    task_path=task_path,
+                )
+            }
 
         if isinstance(value, ExprList):
             dependencies: set[int] = set()
             for expr in value:
-                dependencies.add(self._register_expr(expr))
+                dependencies.add(
+                    self._register_expr(
+                        expr,
+                        expr_stack=expr_stack,
+                        task_path=task_path,
+                    )
+                )
             return dependencies
 
         if isinstance(value, list | tuple):
             dependencies: set[int] = set()
             for item in value:
-                dependencies |= self._register_value(item)
+                dependencies |= self._register_value(
+                    item,
+                    expr_stack=expr_stack,
+                    task_path=task_path,
+                )
             return dependencies
 
         if isinstance(value, dict):
             dependencies: set[int] = set()
             for key, item in value.items():
-                dependencies |= self._register_value(key)
-                dependencies |= self._register_value(item)
+                dependencies |= self._register_value(
+                    key,
+                    expr_stack=expr_stack,
+                    task_path=task_path,
+                )
+                dependencies |= self._register_value(
+                    item,
+                    expr_stack=expr_stack,
+                    task_path=task_path,
+                )
             return dependencies
 
         return set()
 
-    def _register_expr(self, expr: Expr) -> int:
+    def _register_expr(
+        self,
+        expr: Expr,
+        *,
+        expr_stack: tuple[int, ...] = (),
+        task_path: tuple[str, ...] = (),
+    ) -> int:
         """Register a task expression node once per object identity."""
         expr_id = id(expr)
+        if expr_id in expr_stack:
+            cycle_start = expr_stack.index(expr_id)
+            cycle = list(task_path[cycle_start:]) + [expr.task_def.name]
+            raise CycleError(cycle)
+
         if expr_id in self._expr_nodes:
             return self._expr_nodes[expr_id]
 
         node_id = self._next_node_id
         self._next_node_id += 1
 
+        next_expr_stack = (*expr_stack, expr_id)
+        next_task_path = (*task_path, expr.task_def.name)
         dependency_ids: set[int] = set()
         for value in expr.args.values():
-            dependency_ids |= self._register_value(value)
+            dependency_ids |= self._register_value(
+                value,
+                expr_stack=next_expr_stack,
+                task_path=next_task_path,
+            )
 
         self._nodes[node_id] = _TaskNode(
             node_id=node_id,
@@ -315,6 +372,7 @@ class _ConcurrentEvaluator:
                 node_id=node_id,
                 task_name=expr.task_def.name,
                 env=expr.task_def.env,
+                retries=expr.task_def.retries,
             )
             self._nodes[node_id].stdout_path = stdout_path
             self._nodes[node_id].stderr_path = stderr_path
@@ -412,18 +470,23 @@ class _ConcurrentEvaluator:
 
         for node_id in selected:
             node = self._nodes[node_id]
+            node.attempt += 1
             node.state = "running"
             self._log(
                 task=node.task_def.name,
                 status="running",
                 node_id=node.node_id,
                 display_label=node.display_label,
+                attempt=node.attempt,
+                max_attempts=node.task_def.retries + 1,
             )
             if self.provenance is not None:
                 self.provenance.mark_running(
                     node_id=node.node_id,
                     task_name=node.task_def.name,
                     env=node.task_def.env,
+                    attempt=node.attempt,
+                    retries=node.task_def.retries,
                 )
             node.resolved_args = self._resolve_task_args(
                 expr=node.expr,
@@ -465,19 +528,7 @@ class _ConcurrentEvaluator:
             try:
                 completed_value = future.result()
             except BaseException as exc:
-                node.state = "failed"
-                self._cleanup_transport(node)
-                if self._failure is None:
-                    self._failure = exc
-                    self._cancel_pending_futures()
-                self._record_task_failure(node=node, exc=exc)
-                self._log(
-                    task=node.task_def.name,
-                    status="failed",
-                    exit_code=getattr(exc, "exit_code", None),
-                    node_id=node.node_id,
-                    display_label=node.display_label,
-                )
+                self._handle_task_exception(node=node, exc=exc)
                 continue
 
             try:
@@ -486,19 +537,7 @@ class _ConcurrentEvaluator:
                 else:
                     self._handle_completed_shell_phase(node=node, completed_value=completed_value)
             except BaseException as exc:
-                node.state = "failed"
-                self._cleanup_transport(node)
-                if self._failure is None:
-                    self._failure = exc
-                    self._cancel_pending_futures()
-                self._record_task_failure(node=node, exc=exc)
-                self._log(
-                    task=node.task_def.name,
-                    status="failed",
-                    exit_code=getattr(exc, "exit_code", None),
-                    node_id=node.node_id,
-                    display_label=node.display_label,
-                )
+                self._handle_task_exception(node=node, exc=exc)
 
         if self._failure is None:
             self._finalize_dynamic_nodes()
@@ -566,6 +605,72 @@ class _ConcurrentEvaluator:
         final_value = self._finalize_result_value(node=node, value=completed_value)
         self._complete_node(node=node, value=final_value, tmp_paths=node.tmp_paths)
 
+    def _handle_task_exception(self, *, node: _TaskNode, exc: BaseException) -> None:
+        """Either retry a failed task attempt or fail the run."""
+        if self._should_retry(node=node):
+            self._schedule_retry(node=node, exc=exc)
+            return
+
+        node.state = "failed"
+        self._cleanup_transport(node)
+        if self._failure is None:
+            self._failure = exc
+            self._cancel_pending_futures()
+        self._record_task_failure(node=node, exc=exc)
+        self._log(
+            task=node.task_def.name,
+            status="failed",
+            exit_code=getattr(exc, "exit_code", None),
+            node_id=node.node_id,
+            display_label=node.display_label,
+            attempt=node.attempt,
+            max_attempts=node.task_def.retries + 1,
+        )
+
+    def _should_retry(self, *, node: _TaskNode) -> bool:
+        """Return whether the current failed attempt should be retried."""
+        return node.attempt <= node.task_def.retries
+
+    def _schedule_retry(self, *, node: _TaskNode, exc: BaseException) -> None:
+        """Reset node state so the scheduler can rerun the task from scratch."""
+        self._cleanup_transport(node)
+
+        # Remove any attempt-local scratch directories before rerunning.
+        for path in node.tmp_paths:
+            if path.exists():
+                shutil.rmtree(path)
+
+        node.state = "pending"
+        node.resolved_args = None
+        node.cache_key = None
+        node.input_hashes = None
+        node.threads = 1
+        node.tmp_paths = []
+        node.transport_path = None
+        node.dynamic_template = None
+        node.dynamic_dependency_ids.clear()
+
+        retries_remaining = node.task_def.retries - node.attempt
+        if self.provenance is not None:
+            self.provenance.mark_retrying(
+                node_id=node.node_id,
+                task_name=node.task_def.name,
+                env=node.task_def.env,
+                exc=exc,
+                attempt=node.attempt,
+                retries_remaining=retries_remaining,
+            )
+        self._log(
+            task=node.task_def.name,
+            status="waiting",
+            exit_code=getattr(exc, "exit_code", None),
+            node_id=node.node_id,
+            display_label=node.display_label,
+            attempt=node.attempt,
+            max_attempts=node.task_def.retries + 1,
+            retries_remaining=retries_remaining,
+        )
+
     def _complete_node(self, *, node: _TaskNode, value: Any, tmp_paths: list[Path]) -> None:
         """Persist and mark a task node as fully completed."""
         self._cleanup_transport(node)
@@ -598,6 +703,8 @@ class _ConcurrentEvaluator:
             exit_code=0,
             node_id=node.node_id,
             display_label=node.display_label,
+            attempt=node.attempt,
+            max_attempts=node.task_def.retries + 1,
         )
 
     def _resolve_task_args(
@@ -858,14 +965,17 @@ class _ConcurrentEvaluator:
         stderr_text = completed.stderr or ""
 
         # Write stdout and stderr to separate provenance logs.
-        if node.stdout_path is not None:
-            node.stdout_path.write_text(stdout_text, encoding="utf-8")
-        if node.stderr_path is not None:
-            node.stderr_path.write_text(stderr_text, encoding="utf-8")
+        if node.stdout_path is not None and stdout_text:
+            with node.stdout_path.open("a", encoding="utf-8") as handle:
+                handle.write(stdout_text)
+        if node.stderr_path is not None and stderr_text:
+            with node.stderr_path.open("a", encoding="utf-8") as handle:
+                handle.write(stderr_text)
 
         # User-specified log gets combined output for backwards compatibility.
-        if user_log_path is not None:
-            user_log_path.write_text(stdout_text + stderr_text, encoding="utf-8")
+        if user_log_path is not None and (stdout_text or stderr_text):
+            with user_log_path.open("a", encoding="utf-8") as handle:
+                handle.write(stdout_text + stderr_text)
 
         combined_output = stdout_text + stderr_text
         if completed.returncode != 0:
@@ -1117,6 +1227,9 @@ class _ConcurrentEvaluator:
         exit_code: int | None = None,
         node_id: int | None = None,
         display_label: str | None = None,
+        attempt: int | None = None,
+        max_attempts: int | None = None,
+        retries_remaining: int | None = None,
     ) -> None:
         """Emit basic structured execution logs to stderr."""
         payload = {"task": task, "status": status}
@@ -1126,6 +1239,12 @@ class _ConcurrentEvaluator:
             payload["node_id"] = node_id
         if display_label is not None:
             payload["display_label"] = display_label
+        if attempt is not None:
+            payload["attempt"] = attempt
+        if max_attempts is not None:
+            payload["max_attempts"] = max_attempts
+        if retries_remaining is not None:
+            payload["retries_remaining"] = retries_remaining
         print(json.dumps(payload, sort_keys=True), file=self._stderr)
 
 

--- a/src/ginkgo/runtime/provenance.py
+++ b/src/ginkgo/runtime/provenance.py
@@ -70,7 +70,14 @@ class RunProvenanceRecorder:
             encoding="utf-8",
         )
 
-    def ensure_task(self, *, node_id: int, task_name: str, env: str | None) -> tuple[Path, Path]:
+    def ensure_task(
+        self,
+        *,
+        node_id: int,
+        task_name: str,
+        env: str | None,
+        retries: int = 0,
+    ) -> tuple[Path, Path]:
         """Create a manifest entry and log paths for a task node.
 
         Returns
@@ -90,6 +97,11 @@ class RunProvenanceRecorder:
                 "node_id": node_id,
                 "task": task_name,
                 "env": env,
+                "retries": retries,
+                "max_attempts": retries + 1,
+                "attempt": 0,
+                "attempts": 0,
+                "retries_remaining": retries,
                 "cached": False,
                 "exit_code": None,
                 "stdout_log": str(stdout_path.relative_to(self.run_dir)),
@@ -126,12 +138,49 @@ class RunProvenanceRecorder:
             task["dynamic_dependency_ids"] = dynamic_dependency_ids
         self._write_manifest()
 
-    def mark_running(self, *, node_id: int, task_name: str, env: str | None) -> None:
+    def mark_running(
+        self,
+        *,
+        node_id: int,
+        task_name: str,
+        env: str | None,
+        attempt: int,
+        retries: int,
+    ) -> None:
         """Mark a task as dispatched."""
+        self.ensure_task(node_id=node_id, task_name=task_name, env=env, retries=retries)
+        task = self._task(node_id)
+        task["attempt"] = attempt
+        task["attempts"] = max(int(task.get("attempts", 0)), attempt)
+        task["retries"] = retries
+        task["max_attempts"] = retries + 1
+        task["retries_remaining"] = max(0, retries - (attempt - 1))
+        task["status"] = "running"
+        task.setdefault("started_at", _timestamp())
+        task["last_started_at"] = _timestamp()
+        self._write_manifest()
+
+    def mark_retrying(
+        self,
+        *,
+        node_id: int,
+        task_name: str,
+        env: str | None,
+        exc: BaseException,
+        attempt: int,
+        retries_remaining: int,
+    ) -> None:
+        """Record a failed attempt that will be retried."""
         self.ensure_task(node_id=node_id, task_name=task_name, env=env)
         task = self._task(node_id)
-        task["status"] = "running"
-        task["started_at"] = _timestamp()
+        task["cached"] = False
+        task["attempt"] = attempt
+        task["attempts"] = max(int(task.get("attempts", 0)), attempt)
+        task["last_error"] = str(exc)
+        task["last_exit_code"] = getattr(exc, "exit_code", 1)
+        task["retries_remaining"] = retries_remaining
+        task["status"] = "pending"
+        task.pop("finished_at", None)
         self._write_manifest()
 
     def mark_cached(self, *, node_id: int, task_name: str, env: str | None, value: Any) -> None:
@@ -143,6 +192,9 @@ class RunProvenanceRecorder:
         task["output"] = _render_value(value)
         task["finished_at"] = _timestamp()
         task["status"] = "cached"
+        task.pop("error", None)
+        task.pop("last_error", None)
+        task.pop("last_exit_code", None)
         self._write_manifest()
 
     def mark_succeeded(
@@ -161,6 +213,9 @@ class RunProvenanceRecorder:
         task["output"] = _render_value(value)
         task["finished_at"] = _timestamp()
         task["status"] = "succeeded"
+        task.pop("error", None)
+        task.pop("last_error", None)
+        task.pop("last_exit_code", None)
         self._write_manifest()
 
     def mark_failed(
@@ -177,6 +232,9 @@ class RunProvenanceRecorder:
         task["cached"] = False
         task["exit_code"] = getattr(exc, "exit_code", 1)
         task["error"] = str(exc)
+        task["last_error"] = str(exc)
+        task["last_exit_code"] = getattr(exc, "exit_code", 1)
+        task["retries_remaining"] = 0
         task["finished_at"] = _timestamp()
         task["status"] = "failed"
         self._write_manifest()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,6 +149,93 @@ def main():
         assert "🌿 ginkgo cache ls" in result.stdout
         assert "No cache entries found." in result.stdout
 
+    def test_run_manifest_records_retry_attempts(self) -> None:
+        Path("retry_workflow.py").write_text(
+            """
+from pathlib import Path
+from ginkgo import flow, task
+
+@task(retries=2)
+def flaky(marker_path: str) -> str:
+    marker = Path(marker_path)
+    failures = int(marker.read_text(encoding="utf-8")) if marker.exists() else 0
+    if failures < 1:
+        marker.write_text(str(failures + 1), encoding="utf-8")
+        raise RuntimeError("transient failure")
+    return "ok"
+
+@flow
+def main():
+    return flaky(marker_path="retry.marker")
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "retry_workflow.py", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+
+        run_dir = _extract_run_dir(result.stdout)
+        manifest = yaml.safe_load((run_dir / "manifest.yaml").read_text(encoding="utf-8"))
+        task = next(iter(manifest["tasks"].values()))
+
+        assert task["status"] == "succeeded"
+        assert task["retries"] == 2
+        assert task["max_attempts"] == 3
+        assert task["attempt"] == 2
+        assert task["attempts"] == 2
+
+    def test_cache_prune_dry_run_reports_old_entries_without_deleting(self) -> None:
+        cache_root = Path(".ginkgo") / "cache"
+        old_entry = cache_root / "old123"
+        fresh_entry = cache_root / "fresh456"
+        old_entry.mkdir(parents=True)
+        fresh_entry.mkdir(parents=True)
+        (old_entry / "meta.json").write_text(
+            '{"function":"demo.old","timestamp":"2026-01-01T00:00:00+00:00"}',
+            encoding="utf-8",
+        )
+        (fresh_entry / "meta.json").write_text(
+            '{"function":"demo.fresh","timestamp":"2026-03-13T00:00:00+00:00"}',
+            encoding="utf-8",
+        )
+        (old_entry / "output.json").write_text("{}", encoding="utf-8")
+        (fresh_entry / "output.json").write_text("{}", encoding="utf-8")
+
+        result = _run_cli("cache", "prune", "--older-than", "30d", "--dry-run", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "🌿 ginkgo cache prune" in result.stdout
+        assert "would be removed" in result.stdout
+        assert "old123" in result.stdout
+        assert old_entry.exists()
+        assert fresh_entry.exists()
+
+    def test_cache_prune_removes_only_entries_older_than_cutoff(self) -> None:
+        cache_root = Path(".ginkgo") / "cache"
+        old_entry = cache_root / "old123"
+        fresh_entry = cache_root / "fresh456"
+        old_entry.mkdir(parents=True)
+        fresh_entry.mkdir(parents=True)
+        (old_entry / "meta.json").write_text(
+            '{"function":"demo.old","timestamp":"2026-01-01T00:00:00+00:00"}',
+            encoding="utf-8",
+        )
+        (fresh_entry / "meta.json").write_text(
+            '{"function":"demo.fresh","timestamp":"2026-03-13T00:00:00+00:00"}',
+            encoding="utf-8",
+        )
+
+        result = _run_cli("cache", "prune", "--older-than", "30d", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "Removed" in result.stdout
+        assert not old_entry.exists()
+        assert fresh_entry.exists()
+
+    def test_cache_prune_rejects_invalid_duration(self) -> None:
+        result = _run_cli("cache", "prune", "--older-than", "bad", cwd=Path.cwd())
+        assert result.returncode == 1
+        assert "Invalid duration for --older-than" in result.stderr
+
 
 class TestCliDebug:
     def test_debug_reports_failed_task_inputs_and_log_tail(self) -> None:
@@ -278,6 +365,63 @@ def main():
 
 
 class TestCliDryRun:
+    def test_run_dry_run_validates_without_execution(self) -> None:
+        Path("workflow.py").write_text(
+            """
+from pathlib import Path
+from ginkgo import flow, task
+
+@task()
+def write_marker(path: str) -> str:
+    Path(path).write_text("executed", encoding="utf-8")
+    return path
+
+@flow
+def main():
+    return write_marker(path="should-not-exist.txt")
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "workflow.py", "--dry-run", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "🌿 ginkgo run workflow.py --dry-run" in result.stdout
+        assert "✓ workflow.py (dry-run) - 1 tasks validated" in result.stdout
+        assert not Path("should-not-exist.txt").exists()
+        runs_root = Path(".ginkgo") / "runs"
+        assert not runs_root.exists() or list(runs_root.iterdir()) == []
+
+    def test_run_dry_run_fails_for_invalid_workflow(self) -> None:
+        Path("invalid_workflow.py").write_text(
+            """
+from ginkgo import flow, task
+
+@task()
+def first() -> str:
+    return "first"
+
+@task()
+def second() -> str:
+    return "second"
+
+@flow
+def main():
+    left = first()
+    right = second()
+    left.args["value"] = right
+    right.args["value"] = left
+    return left
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "invalid_workflow.py", "--dry-run", cwd=Path.cwd())
+        assert result.returncode == 1
+        assert "Detected cycle in workflow graph" in result.stderr
+        assert "Run directory:" not in result.stdout
+
     def test_test_dry_run_discovers_hidden_workflows_without_execution(self) -> None:
         tests_dir = Path(".tests")
         tests_dir.mkdir()

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from ginkgo import evaluate, file, folder, shell_task, task, tmp_dir
+from ginkgo.runtime.evaluator import CycleError, _ConcurrentEvaluator
 
 
 def _append_line(path: str, line: str) -> None:
@@ -26,6 +27,29 @@ def logged_work_task(x: int, log_path: str) -> int:
     return x + 1
 
 
+@task(retries=2)
+def flaky_retry_task(marker_path: str, log_path: str) -> str:
+    _append_line(log_path, "attempt")
+    marker = Path(marker_path)
+    failures = int(marker.read_text(encoding="utf-8")) if marker.exists() else 0
+    if failures < 1:
+        marker.write_text(str(failures + 1), encoding="utf-8")
+        raise RuntimeError("transient failure")
+    return "ok"
+
+
+@task(retries=2)
+def always_fail_retry_task(log_path: str) -> str:
+    _append_line(log_path, "attempt")
+    raise RuntimeError("still broken")
+
+
+@task()
+def always_fail_once_task(log_path: str) -> str:
+    _append_line(log_path, "attempt")
+    raise RuntimeError("no retry configured")
+
+
 @task()
 def shell_write_output_task(output_path: str, log_path: str) -> file:
     return shell_task(
@@ -42,6 +66,21 @@ def shell_write_output_task(output_path: str, log_path: str) -> file:
 @task()
 def shell_missing_output_task(output_path: str) -> file:
     return shell_task(cmd="true", output=output_path)
+
+
+@task(retries=2)
+def flaky_shell_task(marker_path: str, output_path: str, log_path: str) -> file:
+    return shell_task(
+        cmd=(
+            f"if [ ! -f {marker_path} ]; then "
+            f"touch {marker_path}; "
+            "printf 'transient shell failure\\n' 1>&2; "
+            "exit 7; "
+            f"fi; printf 'payload' > {output_path}"
+        ),
+        output=output_path,
+        log=log_path,
+    )
 
 
 @task()
@@ -89,6 +128,19 @@ def dataframe_task(log_path: str, start: int) -> object:
 @task()
 def dataframe_total_task(df: object) -> int:
     return int(df["value"].sum())
+
+
+@task()
+def passthrough_task(value: object | None = None) -> object:
+    return value
+
+
+@task()
+def build_dynamic_cycle_task() -> object:
+    first = passthrough_task()
+    second = passthrough_task(value=first)
+    first.args["value"] = second
+    return first
 
 
 class TestEvaluate:
@@ -169,6 +221,71 @@ class TestEvaluate:
 
         assert result == 17
 
+    def test_validate_rejects_direct_expression_cycles(self):
+        first = passthrough_task()
+        second = passthrough_task(value=first)
+        first.args["value"] = second
+
+        evaluator = _ConcurrentEvaluator()
+        with pytest.raises(
+            CycleError,
+            match="Detected cycle in workflow graph: test_evaluator.passthrough_task -> "
+            "test_evaluator.passthrough_task -> test_evaluator.passthrough_task",
+        ):
+            evaluator.validate(first)
+
+    def test_evaluate_rejects_cycles_nested_inside_containers(self):
+        first = passthrough_task()
+        second = passthrough_task(value=[first])
+        first.args["value"] = {"nested": second}
+
+        with pytest.raises(CycleError, match="Detected cycle in workflow graph"):
+            evaluate(first)
+
+    def test_evaluate_rejects_cycles_from_dynamic_returned_expressions(self):
+        with pytest.raises(CycleError, match="Detected cycle in workflow graph"):
+            evaluate(build_dynamic_cycle_task())
+
+    def test_task_retries_are_disabled_by_default(self):
+        log_path = "default-no-retry.log"
+
+        with pytest.raises(RuntimeError, match="no retry configured"):
+            evaluate(always_fail_once_task(log_path=log_path))
+
+        assert Path(log_path).read_text(encoding="utf-8").splitlines() == ["attempt"]
+
+    def test_task_retries_allow_transient_python_failures_and_cache_success(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        marker_path = "flaky.marker"
+        log_path = "flaky.log"
+
+        assert evaluate(flaky_retry_task(marker_path=marker_path, log_path=log_path)) == "ok"
+        captured = capsys.readouterr()
+
+        assert Path(log_path).read_text(encoding="utf-8").splitlines() == ["attempt", "attempt"]
+        assert '"status": "waiting"' in captured.err
+        assert '"attempt": 1' in captured.err
+
+        assert evaluate(flaky_retry_task(marker_path=marker_path, log_path=log_path)) == "ok"
+        cached = capsys.readouterr()
+
+        assert Path(log_path).read_text(encoding="utf-8").splitlines() == ["attempt", "attempt"]
+        assert '"status": "cached"' in cached.err
+
+    def test_task_retries_fail_after_final_attempt(self):
+        log_path = "always-fail.log"
+
+        with pytest.raises(RuntimeError, match="still broken"):
+            evaluate(always_fail_retry_task(log_path=log_path))
+
+        assert Path(log_path).read_text(encoding="utf-8").splitlines() == [
+            "attempt",
+            "attempt",
+            "attempt",
+        ]
+
 
 class TestShellTask:
     def test_shell_task_executes_and_returns_output_file(self, tmp_path: Path):
@@ -187,6 +304,23 @@ class TestShellTask:
 
         with pytest.raises(FileNotFoundError, match="did not create output"):
             evaluate(shell_missing_output_task(output_path=str(output)))
+
+    def test_shell_task_retries_allow_transient_failures(self, tmp_path: Path):
+        marker = tmp_path / "flaky-shell.marker"
+        output = tmp_path / "flaky-shell.txt"
+        log = tmp_path / "flaky-shell.log"
+
+        result = evaluate(
+            flaky_shell_task(
+                marker_path=str(marker),
+                output_path=str(output),
+                log_path=str(log),
+            )
+        )
+
+        assert result == file(str(output))
+        assert output.read_text(encoding="utf-8") == "payload"
+        assert "transient shell failure" in log.read_text(encoding="utf-8")
 
 
 class TestValidation:

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -15,13 +15,14 @@ unavailable.
 
 from __future__ import annotations
 
+import subprocess
 import shutil
 from pathlib import Path
 
 import pytest
 
 from ginkgo import evaluate, flow, shell_task, task
-from ginkgo.pixi import PixiEnvNotFoundError, PixiRegistry
+from ginkgo.pixi import PixiEnvImportError, PixiEnvNotFoundError, PixiRegistry
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +71,71 @@ class TestPixiRegistry:
         registry = PixiRegistry(project_root=_TESTS_DIR)
         with pytest.raises(PixiEnvNotFoundError, match="nonexistent_env"):
             registry.resolve(env="nonexistent_env")
+
+    def test_resolve_conda_env_file_imports_to_generated_pixi_workspace(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        env_file = tmp_path / "environment.yml"
+        env_file.write_text("name: demo\ndependencies:\n  - python\n", encoding="utf-8")
+
+        def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            assert argv[:4] == ["pixi", "init", str(tmp_path / ".ginkgo-pixi"), "--import"]
+            assert argv[4] == str(env_file)
+            generated_manifest = tmp_path / ".ginkgo-pixi" / "pixi.toml"
+            generated_manifest.parent.mkdir(parents=True, exist_ok=True)
+            generated_manifest.write_text("[workspace]\nname = 'demo'\n", encoding="utf-8")
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("ginkgo.envs.pixi._require_pixi", lambda: None)
+        monkeypatch.setattr("ginkgo.envs.pixi.subprocess.run", fake_run)
+
+        registry = PixiRegistry(project_root=_TESTS_DIR)
+        manifest = registry.resolve(env=str(env_file))
+
+        assert manifest == (tmp_path / ".ginkgo-pixi" / "pixi.toml").resolve()
+
+    def test_resolve_conda_env_file_reuses_generated_manifest_when_fresh(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        env_file = tmp_path / "environment.yaml"
+        env_file.write_text("name: demo\n", encoding="utf-8")
+        generated_manifest = tmp_path / ".ginkgo-pixi" / "pixi.toml"
+        generated_manifest.parent.mkdir(parents=True, exist_ok=True)
+        generated_manifest.write_text("[workspace]\nname = 'demo'\n", encoding="utf-8")
+        generated_manifest.touch()
+
+        monkeypatch.setattr("ginkgo.envs.pixi._require_pixi", lambda: None)
+
+        def fail_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+            raise AssertionError("pixi import should not run for a fresh generated manifest")
+
+        monkeypatch.setattr("ginkgo.envs.pixi.subprocess.run", fail_run)
+        registry = PixiRegistry(project_root=_TESTS_DIR)
+
+        manifest = registry.resolve(env=str(env_file))
+        assert manifest == generated_manifest.resolve()
+
+    def test_resolve_conda_env_file_raises_clear_error_on_import_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        env_file = tmp_path / "environment.yml"
+        env_file.write_text("name: broken\n", encoding="utf-8")
+
+        def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="import failed")
+
+        monkeypatch.setattr("ginkgo.envs.pixi._require_pixi", lambda: None)
+        monkeypatch.setattr("ginkgo.envs.pixi.subprocess.run", fake_run)
+
+        registry = PixiRegistry(project_root=_TESTS_DIR)
+        with pytest.raises(PixiEnvImportError, match="import failed"):
+            registry.resolve(env=str(env_file))
 
     def test_lock_hash_returns_string(self) -> None:
         registry = PixiRegistry(project_root=_TESTS_DIR)


### PR DESCRIPTION
## Summary
- add opt-in task retries, expression-graph cycle detection, and v1 cache pruning
- expose `ginkgo run --dry-run` and add CLI coverage for dry-run validation and cache pruning
- update the tracked README to match the shipped Phase 8 runtime hardening work

## Testing
- .pixi/envs/default/bin/pytest tests/test_cli.py
- .pixi/envs/default/bin/pytest tests/test_evaluator.py
- .pixi/envs/default/bin/pytest tests/test_ui.py

## Notes
- Local planning/design docs were updated in the workspace but are not tracked in git, so they are not part of this PR.
