### PR TITLE
Add memory-aware scheduling and run resource reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It combines:
 - dynamic branching inside task bodies
 - content-addressed caching
 - per-task Pixi environments
-- concurrent scheduling with `--jobs` and `--cores`
+- concurrent scheduling with `--jobs`, `--cores`, and `--memory`
 - provenance logging and a local CLI
 
 It works well for:
@@ -19,7 +19,7 @@ It works well for:
 - research and scientific computing pipelines
 - mixed Python and shell-based workflows
 
-The project is currently implemented through **Phase 7**, with the first hardening slice of **Phase 8** now landed. The shipped system includes the Python DSL, concurrent runtime, cache, Pixi backend, CLI, run manifests, debug tooling, a local run browser, opt-in task retries, expression-graph cycle detection, and v1 cache pruning.
+The project is currently implemented through **Phase 7**, with the first hardening slice of **Phase 8** now landed. The shipped system includes the Python DSL, concurrent runtime, cache, Pixi backend, CLI, run manifests, debug tooling, a local run browser, opt-in task retries, expression-graph cycle detection, v1 cache pruning, memory-aware scheduling, and run-level CPU / RSS reporting.
 
 ## What Ginkgo Looks Like
 
@@ -59,12 +59,13 @@ ginkgo run workflow.py
 - content-addressed caching under `.ginkgo/cache/`
 - opt-in task retries via `@task(retries=n)`
 - explicit cycle detection for expression graphs before execution
-- concurrent scheduling with OR-Tools CP-SAT resource selection
+- concurrent scheduling with OR-Tools CP-SAT resource selection across jobs, cores, and memory
 - Python task execution in worker processes, with a thread-pool fallback when process pools are blocked by the runtime environment
 - shell task execution through `shell_task(...)`
 - per-task Pixi environments resolved from `envs/<env>/pixi.toml`
 - run provenance under `.ginkgo/runs/<run_id>/`
-- a local React UI with `ginkgo ui` for browsing runs, a task graph, cache entries, and task logs
+- end-of-run CPU / RSS summaries plus a compact live CPU / RSS monitor in the CLI
+- a local React UI with `ginkgo ui` for browsing runs, a task graph, cache entries, task logs, and run resource summaries
 - `ginkgo run`, `ginkgo test --dry-run`, `ginkgo cache ls`, `ginkgo cache clear`, `ginkgo cache prune`, `ginkgo debug`, and `ginkgo ui`
 
 ## Project Layout
@@ -164,6 +165,7 @@ The CLI prints the run directory when it finishes:
   write_text                   [running]
   write_text                   [succeeded]
 
+CPU avg 7.5%, peak 15.0% | RSS avg 42 MiB, peak 47 MiB
 ⏱ Completed in 0.02s - 1 tasks executed, 0 cached
 Run directory: .ginkgo/runs/20260312_145430_affcc6b4
 ```
@@ -228,6 +230,29 @@ results = process(multiplier=2).map(sample_id=["a", "b", "c"])
 ```
 
 This produces an `ExprList` of independent tasks that Ginkgo can schedule concurrently.
+
+### Resource declarations
+
+Ginkgo currently understands two task-level scalar resource hints:
+
+- `threads`: contributes to the global `--cores` budget
+- `memory_gb`: contributes to the global `--memory` budget
+
+Example:
+
+```python
+@task()
+def align(sample_id: str, threads: int = 8, memory_gb: int = 16) -> str:
+    return sample_id
+```
+
+Run with explicit budgets:
+
+```bash
+ginkgo run workflow.py --jobs 8 --cores 32 --memory 64
+```
+
+If a task declares more memory than the run budget allows, Ginkgo fails before dispatching it.
 
 ### Path types
 
@@ -395,8 +420,14 @@ to inspect the most recent failed run, including the last 50 lines of the failin
 ### Run a workflow
 
 ```bash
-ginkgo run workflow.py [--config PATH ...] [--jobs N] [--cores N] [--dry-run]
+ginkgo run workflow.py [--config PATH ...] [--jobs N] [--cores N] [--memory N] [--dry-run]
 ```
+
+- `--jobs`: maximum number of concurrently running tasks
+- `--cores`: total thread budget across concurrently running tasks
+- `--memory`: total declared memory budget across concurrently running tasks, in GiB
+
+During a run, the CLI shows a compact live CPU / RSS strip. At the end of the run, Ginkgo prints a CPU / RSS summary derived from the local Ginkgo process tree and records the same summary in the run manifest for the UI.
 
 ### Validate local test workflows
 

--- a/src/ginkgo/cli/app.py
+++ b/src/ginkgo/cli/app.py
@@ -53,6 +53,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--config", action="append", default=[])
     run_parser.add_argument("--jobs", type=int, default=None)
     run_parser.add_argument("--cores", type=int, default=None)
+    run_parser.add_argument("--memory", type=int, default=None)
     run_parser.add_argument("--dry-run", action="store_true")
     run_parser.add_argument("--verbose", action="store_true")
 

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import ModuleType
 
 from ginkgo.cli.common import RUNS_ROOT, RunMode, console
-from ginkgo.cli.renderers.common import _core_unit_label, _environment_label, _format_duration
+from ginkgo.cli.renderers.common import _environment_label, _format_duration
 from ginkgo.cli.renderers.models import _FailureDetails, _ResourceRenderState, _RunSummary
 from ginkgo.cli.renderers.run import _CliRunRenderer
 from ginkgo.config import _config_session
@@ -89,10 +89,6 @@ def run_workflow(
         f"[cyan]📦[/] Loading workflow...  [green]done[/] ({_format_duration(load_elapsed)})"
     )
     rich_console.print(f"[green]🌱[/] Building expression tree...  [bold]{task_count}[/] tasks")
-    rich_console.print(
-        f"[cyan]💻[/] Running locally on [bold]{evaluator.cores}[/] "
-        f"{_core_unit_label(evaluator.cores)}"
-    )
     if evaluator.memory is not None:
         rich_console.print(f"[cyan]🧠[/] Memory budget: [bold]{evaluator.memory}[/] GiB")
     if output_mode == "verbose":
@@ -125,6 +121,7 @@ def run_workflow(
             run_id=run_id,
             mode=output_mode,
             run_dir=recorder.run_dir,
+            cores=evaluator.cores,
             memory=memory,
         ),
         resources=_ResourceRenderState(provider=resource_monitor.current_summary),

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -98,8 +98,7 @@ def run_workflow(
             f"config overlays={len(config_paths)}"
         )
         rich_console.print(f"[cyan]🗂[/] Run directory: {RUNS_ROOT / run_id}\n")
-    else:
-        rich_console.print("")
+    rich_console.print("")
 
     recorder = RunProvenanceRecorder(
         run_id=run_id,

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 from pathlib import Path
@@ -9,13 +10,14 @@ from types import ModuleType
 
 from ginkgo.cli.common import RUNS_ROOT, RunMode, console
 from ginkgo.cli.renderers.common import _core_unit_label, _environment_label, _format_duration
-from ginkgo.cli.renderers.models import _FailureDetails, _RunSummary
+from ginkgo.cli.renderers.models import _FailureDetails, _ResourceRenderState, _RunSummary
 from ginkgo.cli.renderers.run import _CliRunRenderer
 from ginkgo.config import _config_session
 from ginkgo.core.flow import FlowDef
 from ginkgo.envs.pixi import PixiRegistry
 from ginkgo.runtime.evaluator import _ConcurrentEvaluator
 from ginkgo.runtime.module_loader import load_module_from_path
+from ginkgo.runtime.resources import RunResourceMonitor
 from ginkgo.runtime.provenance import RunProvenanceRecorder, load_manifest, make_run_id, tail_text
 
 
@@ -27,6 +29,7 @@ def command_run(args, *, output_mode: RunMode) -> int:
         config_paths=[Path(path).resolve() for path in args.config],
         jobs=args.jobs,
         cores=args.cores,
+        memory=args.memory,
         dry_run=args.dry_run,
         output_mode=output_mode,
     )
@@ -38,6 +41,7 @@ def run_workflow(
     config_paths: list[Path],
     jobs: int | None,
     cores: int | None,
+    memory: int | None,
     dry_run: bool,
     output_mode: RunMode = "default",
 ) -> int:
@@ -61,7 +65,12 @@ def run_workflow(
     load_elapsed = time.perf_counter() - load_started
 
     registry = PixiRegistry(project_root=Path.cwd())
-    evaluator = _ConcurrentEvaluator(jobs=jobs, cores=cores, pixi_registry=registry)
+    evaluator = _ConcurrentEvaluator(
+        jobs=jobs,
+        cores=cores,
+        memory=memory,
+        pixi_registry=registry,
+    )
     evaluator.validate(expr)
     task_count = len(evaluator._nodes)
     planned_tasks = [
@@ -84,9 +93,12 @@ def run_workflow(
         f"[cyan]💻[/] Running locally on [bold]{evaluator.cores}[/] "
         f"{_core_unit_label(evaluator.cores)}"
     )
+    if evaluator.memory is not None:
+        rich_console.print(f"[cyan]🧠[/] Memory budget: [bold]{evaluator.memory}[/] GiB")
     if output_mode == "verbose":
         rich_console.print(
             f"[cyan]🧭[/] Verbose mode: jobs={evaluator.jobs}, cores={evaluator.cores}, "
+            f"memory={evaluator.memory if evaluator.memory is not None else 'auto'}, "
             f"config overlays={len(config_paths)}"
         )
         rich_console.print(f"[cyan]🗂[/] Run directory: {RUNS_ROOT / run_id}\n")
@@ -99,19 +111,28 @@ def run_workflow(
         root_dir=RUNS_ROOT,
         jobs=jobs,
         cores=cores,
+        memory=memory,
         params=params,
     )
+    resource_monitor = RunResourceMonitor(
+        root_pid=os.getpid(),
+        sink=recorder.update_resources,
+    )
+    resource_monitor.start()
     renderer = _CliRunRenderer(
         console=rich_console,
         summary=_RunSummary(
             run_id=run_id,
             mode=output_mode,
             run_dir=recorder.run_dir,
+            memory=memory,
         ),
+        resources=_ResourceRenderState(provider=resource_monitor.current_summary),
     )
     evaluator = _ConcurrentEvaluator(
         jobs=jobs,
         cores=cores,
+        memory=memory,
         pixi_registry=registry,
         provenance=recorder,
         _stderr=renderer,
@@ -121,7 +142,8 @@ def run_workflow(
     try:
         evaluator.evaluate(expr)
     except BaseException as exc:
-        recorder.finalize(status="failed", error=str(exc))
+        resource_summary = resource_monitor.stop()
+        recorder.finalize(status="failed", error=str(exc), resources=resource_summary)
         failure_details = _load_failure_details(
             run_dir=recorder.run_dir,
             renderer=renderer,
@@ -130,15 +152,18 @@ def run_workflow(
         renderer.finish(
             elapsed=time.perf_counter() - run_started,
             success=False,
+            resources=resource_summary,
             failure_details=failure_details,
         )
         print(f"Run directory: {recorder.run_dir}", file=sys.stderr)
         raise
 
-    recorder.finalize(status="succeeded")
+    resource_summary = resource_monitor.stop()
+    recorder.finalize(status="succeeded", resources=resource_summary)
     renderer.finish(
         elapsed=time.perf_counter() - run_started,
         success=True,
+        resources=resource_summary,
     )
     return 0
 

--- a/src/ginkgo/cli/commands/test.py
+++ b/src/ginkgo/cli/commands/test.py
@@ -30,6 +30,7 @@ def command_test(args) -> int:
             config_paths=[],
             jobs=None,
             cores=None,
+            memory=None,
             dry_run=args.dry_run,
         )
         if exit_code != 0:

--- a/src/ginkgo/cli/renderers/common.py
+++ b/src/ginkgo/cli/renderers/common.py
@@ -114,3 +114,31 @@ def _time_of_day_spinner(now: datetime | None = None) -> str:
 def _core_unit_label(cores: int) -> str:
     """Return the singular/plural label for core counts."""
     return "core" if cores == 1 else "Cores"
+
+
+def _format_cpu_percent(value: float | None) -> str:
+    """Return a compact CPU percentage string."""
+    if value is None:
+        return "--"
+    if value >= 100:
+        return f"{value:.0f}%"
+    return f"{value:.1f}%"
+
+
+def _format_bytes(value: int | float | None) -> str:
+    """Return a compact binary size string."""
+    if value is None:
+        return "--"
+
+    size = float(value)
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    unit_index = 0
+    while size >= 1024 and unit_index < len(units) - 1:
+        size /= 1024
+        unit_index += 1
+
+    if unit_index == 0:
+        return f"{int(size)} {units[unit_index]}"
+    if size >= 10:
+        return f"{size:.0f} {units[unit_index]}"
+    return f"{size:.1f} {units[unit_index]}"

--- a/src/ginkgo/cli/renderers/models.py
+++ b/src/ginkgo/cli/renderers/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 from ginkgo.cli.common import RunMode
 
@@ -15,6 +16,7 @@ class _RunSummary:
     run_id: str
     mode: RunMode
     run_dir: Path
+    memory: int | None = None
 
 
 @dataclass
@@ -40,3 +42,10 @@ class _FailureDetails:
     log_tail: list[str]
     error: str | None = None
     inputs: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class _ResourceRenderState:
+    """Live resource summary provider for CLI rendering."""
+
+    provider: Callable[[], dict[str, object]]

--- a/src/ginkgo/cli/renderers/models.py
+++ b/src/ginkgo/cli/renderers/models.py
@@ -16,6 +16,7 @@ class _RunSummary:
     run_id: str
     mode: RunMode
     run_dir: Path
+    cores: int
     memory: int | None = None
 
 

--- a/src/ginkgo/cli/renderers/run.py
+++ b/src/ginkgo/cli/renderers/run.py
@@ -19,6 +19,7 @@ from rich.text import Text
 from ginkgo.cli.renderers.common import (
     _format_bytes,
     _format_cpu_percent,
+    _core_unit_label,
     _format_duration,
     _status_label,
     _status_text,
@@ -197,14 +198,13 @@ class _CliRunRenderer:
     def _render_run_layout(self):
         return Group(
             self._render_status_line(),
-            Text(""),
-            self._render_resource_strip(),
             self._render_task_table(),
             self._render_progress_section(),
         )
 
     def _render_status_line(self) -> Table:
         line = Table.grid(padding=(0, 1))
+        line.add_column(no_wrap=True, justify="right")
         line.add_column(no_wrap=True)
         line.add_column(no_wrap=True)
         line.add_column(no_wrap=True)
@@ -212,7 +212,12 @@ class _CliRunRenderer:
         line.add_row(
             " " * self._status_line_padding(),
             self._activity_spinner,
-            Text("Running", style="bold #0f766e"),
+            Text(
+                f"Running locally on {self._summary.cores} "
+                f"{_core_unit_label(self._summary.cores)}",
+                style="bold #0f766e",
+            ),
+            self._resource_text(),
             self._time_spinner,
         )
         return line
@@ -261,34 +266,22 @@ class _CliRunRenderer:
         )
         return progress
 
-    def _render_resource_strip(self) -> Table:
-        """Render a compact live CPU/RSS monitor line."""
+    def _resource_text(self) -> Text:
+        """Render the compact inline CPU/RSS monitor text."""
         resources = self._resource_summary()
-        table = Table.grid(padding=(0, 1))
-        table.width = self._task_table_width()
-        table.add_column(no_wrap=True)
-        table.add_column(justify="center")
-        table.add_column(no_wrap=True)
         if resources is None:
-            table.add_row("", Text("CPU --   RSS --", style="dim"), "")
-            return table
+            return Text("CPU --   RSS --   Procs --", style="dim")
 
         current = resources.get("current")
-        peak = resources.get("peak")
-        status = str(resources.get("status", "unknown"))
-        if not isinstance(current, dict) or not isinstance(peak, dict):
-            table.add_row("", Text("CPU --   RSS --", style="dim"), "")
-            return table
+        if not isinstance(current, dict):
+            return Text("CPU --   RSS --   Procs --", style="dim")
 
         label = (
             f"CPU {_format_cpu_percent(_as_float(current.get('cpu_percent')))}   "
             f"RSS {_format_bytes(_as_int(current.get('rss_bytes')))}   "
-            f"Peak {_format_bytes(_as_int(peak.get('rss_bytes')))}   "
             f"Procs {_format_count(current.get('process_count'))}"
         )
-        style = "bold #134e4a" if status == "running" else "dim"
-        table.add_row("", Text(label, style=style), "")
-        return table
+        return Text(label, style="dim")
 
     def _render_failure_details(self, details: list[_FailureDetails]):
         panels = [self._render_failure_panel(item) for item in details]
@@ -353,7 +346,14 @@ class _CliRunRenderer:
         return task_width + status_width + env_width + time_width + column_padding + separators
 
     def _status_line_padding(self) -> int:
-        status_width = len("Running") + 5
+        status_width = (
+            len("Running locally on ")
+            + len(str(self._summary.cores))
+            + 1
+            + len(_core_unit_label(self._summary.cores))
+            + len(" CPU --   RSS --   Procs --")
+            + 7
+        )
         return max(0, (self._task_table_width() - status_width) // 2)
 
     def _status_counts(self) -> Counter[str]:

--- a/src/ginkgo/cli/renderers/run.py
+++ b/src/ginkgo/cli/renderers/run.py
@@ -197,6 +197,8 @@ class _CliRunRenderer:
 
     def _render_run_layout(self):
         return Group(
+            self._render_resource_info_line(),
+            Text(""),
             self._render_status_line(),
             self._render_task_table(),
             self._render_progress_section(),
@@ -204,7 +206,6 @@ class _CliRunRenderer:
 
     def _render_status_line(self) -> Table:
         line = Table.grid(padding=(0, 1))
-        line.add_column(no_wrap=True, justify="right")
         line.add_column(no_wrap=True)
         line.add_column(no_wrap=True)
         line.add_column(no_wrap=True)
@@ -212,15 +213,24 @@ class _CliRunRenderer:
         line.add_row(
             " " * self._status_line_padding(),
             self._activity_spinner,
-            Text(
-                f"Running locally on {self._summary.cores} "
-                f"{_core_unit_label(self._summary.cores)}",
-                style="bold #0f766e",
-            ),
-            self._resource_text(),
+            Text("Running", style="bold #0f766e"),
             self._time_spinner,
         )
         return line
+
+    def _render_resource_info_line(self) -> Text:
+        """Render the live locality and resource summary line."""
+        text = Text()
+        text.append("💻 ", style="cyan")
+        text.append(
+            f"Running locally on {self._summary.cores} {_core_unit_label(self._summary.cores)}",
+            style="bold",
+        )
+        text.append(" ")
+        text.append("(")
+        text.append(self._resource_label(), style="dim")
+        text.append(")", style="dim")
+        return text
 
     def _render_task_table(self) -> Table:
         table = Table(
@@ -266,22 +276,21 @@ class _CliRunRenderer:
         )
         return progress
 
-    def _resource_text(self) -> Text:
-        """Render the compact inline CPU/RSS monitor text."""
+    def _resource_label(self) -> str:
+        """Return the compact inline CPU/RSS monitor label."""
         resources = self._resource_summary()
         if resources is None:
-            return Text("CPU --   RSS --   Procs --", style="dim")
+            return "CPU --   RSS --   Procs --"
 
         current = resources.get("current")
         if not isinstance(current, dict):
-            return Text("CPU --   RSS --   Procs --", style="dim")
+            return "CPU --   RSS --   Procs --"
 
-        label = (
+        return (
             f"CPU {_format_cpu_percent(_as_float(current.get('cpu_percent')))}   "
             f"RSS {_format_bytes(_as_int(current.get('rss_bytes')))}   "
             f"Procs {_format_count(current.get('process_count'))}"
         )
-        return Text(label, style="dim")
 
     def _render_failure_details(self, details: list[_FailureDetails]):
         panels = [self._render_failure_panel(item) for item in details]
@@ -346,14 +355,7 @@ class _CliRunRenderer:
         return task_width + status_width + env_width + time_width + column_padding + separators
 
     def _status_line_padding(self) -> int:
-        status_width = (
-            len("Running locally on ")
-            + len(str(self._summary.cores))
-            + 1
-            + len(_core_unit_label(self._summary.cores))
-            + len(" CPU --   RSS --   Procs --")
-            + 7
-        )
+        status_width = len("Running") + 5
         return max(0, (self._task_table_width() - status_width) // 2)
 
     def _status_counts(self) -> Counter[str]:

--- a/src/ginkgo/cli/renderers/run.py
+++ b/src/ginkgo/cli/renderers/run.py
@@ -17,6 +17,8 @@ from rich.table import Table
 from rich.text import Text
 
 from ginkgo.cli.renderers.common import (
+    _format_bytes,
+    _format_cpu_percent,
     _format_duration,
     _status_label,
     _status_text,
@@ -26,15 +28,27 @@ from ginkgo.cli.renderers.common import (
     _time_of_day_spinner,
     _truncate_task_label,
 )
-from ginkgo.cli.renderers.models import _FailureDetails, _RunSummary, _TaskRow
+from ginkgo.cli.renderers.models import (
+    _FailureDetails,
+    _ResourceRenderState,
+    _RunSummary,
+    _TaskRow,
+)
 
 
 class _CliRunRenderer:
     """Render human-friendly task lifecycle output from evaluator JSON events."""
 
-    def __init__(self, *, console: Console, summary: _RunSummary) -> None:
+    def __init__(
+        self,
+        *,
+        console: Console,
+        summary: _RunSummary,
+        resources: _ResourceRenderState | None = None,
+    ) -> None:
         self._console = console
         self._summary = summary
+        self._resources = resources
         self._buffer = ""
         self._name_counts: Counter[str] = Counter()
         self._rows: dict[int, _TaskRow] = {}
@@ -82,6 +96,7 @@ class _CliRunRenderer:
         *,
         elapsed: float,
         success: bool,
+        resources: dict[str, object] | None = None,
         failure_details: list[_FailureDetails] | None = None,
     ) -> None:
         """Print the final run summary."""
@@ -113,6 +128,11 @@ class _CliRunRenderer:
             )
             if failure_details:
                 self._console.print(self._render_failure_details(failure_details))
+        resource_summary = resources or self._resource_summary()
+        if resource_summary is not None:
+            resource_footer = self._render_resource_footer(resource_summary)
+            if resource_footer is not None:
+                self._console.print(resource_footer)
         if success:
             self._console.print(f"Run directory: {self._summary.run_dir}")
 
@@ -177,6 +197,8 @@ class _CliRunRenderer:
     def _render_run_layout(self):
         return Group(
             self._render_status_line(),
+            Text(""),
+            self._render_resource_strip(),
             self._render_task_table(),
             self._render_progress_section(),
         )
@@ -238,6 +260,35 @@ class _CliRunRenderer:
             Text(progress_text, style="bold #134e4a"),
         )
         return progress
+
+    def _render_resource_strip(self) -> Table:
+        """Render a compact live CPU/RSS monitor line."""
+        resources = self._resource_summary()
+        table = Table.grid(padding=(0, 1))
+        table.width = self._task_table_width()
+        table.add_column(no_wrap=True)
+        table.add_column(justify="center")
+        table.add_column(no_wrap=True)
+        if resources is None:
+            table.add_row("", Text("CPU --   RSS --", style="dim"), "")
+            return table
+
+        current = resources.get("current")
+        peak = resources.get("peak")
+        status = str(resources.get("status", "unknown"))
+        if not isinstance(current, dict) or not isinstance(peak, dict):
+            table.add_row("", Text("CPU --   RSS --", style="dim"), "")
+            return table
+
+        label = (
+            f"CPU {_format_cpu_percent(_as_float(current.get('cpu_percent')))}   "
+            f"RSS {_format_bytes(_as_int(current.get('rss_bytes')))}   "
+            f"Peak {_format_bytes(_as_int(peak.get('rss_bytes')))}   "
+            f"Procs {_format_count(current.get('process_count'))}"
+        )
+        style = "bold #134e4a" if status == "running" else "dim"
+        table.add_row("", Text(label, style=style), "")
+        return table
 
     def _render_failure_details(self, details: list[_FailureDetails]):
         panels = [self._render_failure_panel(item) for item in details]
@@ -319,3 +370,47 @@ class _CliRunRenderer:
         if self._final_elapsed is not None and self._run_started_at is not None:
             return self._run_started_at + self._final_elapsed
         return time.perf_counter()
+
+    def _resource_summary(self) -> dict[str, object] | None:
+        """Return the latest available resource summary."""
+        if self._resources is None:
+            return None
+        return self._resources.provider()
+
+    def _render_resource_footer(self, resources: dict[str, object]) -> Text | None:
+        """Render the final CPU/RSS summary line."""
+        average = resources.get("average")
+        peak = resources.get("peak")
+        if not isinstance(average, dict) or not isinstance(peak, dict):
+            return None
+
+        avg_cpu = _format_cpu_percent(_as_float(average.get("cpu_percent")))
+        peak_cpu = _format_cpu_percent(_as_float(peak.get("cpu_percent")))
+        avg_rss = _format_bytes(_as_int(average.get("rss_bytes")))
+        peak_rss = _format_bytes(_as_int(peak.get("rss_bytes")))
+        return Text(
+            f"CPU avg {avg_cpu}, peak {peak_cpu} | RSS avg {avg_rss}, peak {peak_rss}",
+            style="dim",
+        )
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _as_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _format_count(value: object) -> str:
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.1f}"
+    return "--"

--- a/src/ginkgo/envs/__init__.py
+++ b/src/ginkgo/envs/__init__.py
@@ -1,5 +1,5 @@
 """Execution environment backends for Ginkgo."""
 
-from ginkgo.envs.pixi import PixiEnvNotFoundError, PixiRegistry
+from ginkgo.envs.pixi import PixiEnvNotFoundError, PixiEnvPrepareError, PixiRegistry
 
-__all__ = ["PixiEnvNotFoundError", "PixiRegistry"]
+__all__ = ["PixiEnvNotFoundError", "PixiEnvPrepareError", "PixiRegistry"]

--- a/src/ginkgo/envs/pixi.py
+++ b/src/ginkgo/envs/pixi.py
@@ -48,6 +48,14 @@ class PixiEnvImportError(RuntimeError):
         super().__init__(f"Failed to import conda env spec {str(source)!r} into Pixi: {details}")
 
 
+class PixiEnvPrepareError(RuntimeError):
+    """Raised when a Pixi environment cannot be materialized."""
+
+    def __init__(self, *, manifest: Path, output: str) -> None:
+        details = output.strip() or "pixi did not provide any error output"
+        super().__init__(f"Failed to prepare Pixi env {str(manifest)!r}: {details}")
+
+
 def _list_envs(envs_dir: Path) -> list[str]:
     """Return sorted names of discoverable environments under envs_dir."""
     if not envs_dir.is_dir():
@@ -88,6 +96,7 @@ class PixiRegistry:
     project_root: Path = field(default_factory=Path.cwd)
     _envs_dir: Path = field(init=False, repr=False)
     _lock_cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False)
+    _prepared_manifests: set[Path] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "_envs_dir", self.project_root / "envs")
@@ -236,6 +245,53 @@ class PixiRegistry:
 
         # Only check pixi availability after confirming all declared envs exist.
         _require_pixi()
+
+    def prepare(self, *, env: str) -> Path:
+        """Materialize the Pixi environment for *env* once per registry instance.
+
+        Parameters
+        ----------
+        env : str
+            Environment name or path.
+
+        Returns
+        -------
+        Path
+            Absolute path to the resolved ``pixi.toml``.
+
+        Raises
+        ------
+        PixiEnvPrepareError
+            If Pixi fails to install or update the environment.
+        RuntimeError
+            If ``pixi`` is not found on PATH.
+        """
+        manifest = self.resolve(env=env)
+        if manifest in self._prepared_manifests:
+            return manifest
+
+        _require_pixi()
+        argv = [
+            "pixi",
+            "install",
+            "--manifest-path",
+            str(manifest),
+        ]
+        completed = subprocess.run(
+            argv,
+            shell=False,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if completed.returncode != 0:
+            raise PixiEnvPrepareError(
+                manifest=manifest,
+                output=(completed.stdout or "") + (completed.stderr or ""),
+            )
+
+        self._prepared_manifests.add(manifest)
+        return manifest
 
     # ------------------------------------------------------------------
     # Subprocess argument builders

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -447,6 +447,9 @@ class _ConcurrentEvaluator:
             )
             return
 
+        # Materialize Pixi environments before any parallel dispatch starts.
+        self._prepare_task_environment(node=node)
+
         node.threads = self._task_threads(resolved_args)
         node.memory_gb = self._task_memory_gb(resolved_args)
         if node.threads > self.cores:
@@ -460,6 +463,13 @@ class _ConcurrentEvaluator:
                 f"{self.memory} GiB are available"
             )
         node.state = "ready"
+
+    def _prepare_task_environment(self, *, node: _TaskNode) -> None:
+        """Materialize any external execution environment required by a task."""
+        if node.task_def.env is None or self.pixi_registry is None:
+            return
+
+        self.pixi_registry.prepare(env=node.task_def.env)
 
     def _dispatch_ready_nodes(
         self,

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -91,6 +91,7 @@ def evaluate(
     *,
     jobs: int | None = None,
     cores: int | None = None,
+    memory: int | None = None,
     pixi_registry: PixiRegistry | None = None,
     provenance: RunProvenanceRecorder | None = None,
 ) -> Any:
@@ -104,6 +105,8 @@ def evaluate(
         Maximum number of concurrently running tasks.
     cores : int | None
         Maximum total thread budget across running tasks.
+    memory : int | None
+        Maximum total declared memory budget across running tasks in GiB.
     pixi_registry : PixiRegistry | None
         Registry for resolving Pixi environments. When ``None``, tasks with
         ``env=`` will raise at dispatch time.
@@ -116,6 +119,7 @@ def evaluate(
     return _ConcurrentEvaluator(
         jobs=jobs,
         cores=cores,
+        memory=memory,
         pixi_registry=pixi_registry,
         provenance=provenance,
     ).evaluate(expr)
@@ -133,6 +137,7 @@ class _TaskNode:
     cache_key: str | None = None
     input_hashes: dict[str, Any] | None = None
     threads: int = 1
+    memory_gb: int = 0
     result: Any = MISSING
     tmp_paths: list[Path] = field(default_factory=list)
     transport_path: Path | None = None
@@ -186,6 +191,7 @@ class _ConcurrentEvaluator:
 
     jobs: int | None = None
     cores: int | None = None
+    memory: int | None = None
     pixi_registry: PixiRegistry | None = None
     provenance: RunProvenanceRecorder | None = None
     _cache_store: CacheStore = field(init=False, repr=False)
@@ -212,6 +218,8 @@ class _ConcurrentEvaluator:
             raise ValueError("jobs must be at least 1")
         if self.cores < 1:
             raise ValueError("cores must be at least 1")
+        if self.memory is not None and self.memory < 1:
+            raise ValueError("memory must be at least 1 when provided")
 
         self._cache_store = CacheStore(pixi_registry=self.pixi_registry)
 
@@ -440,10 +448,16 @@ class _ConcurrentEvaluator:
             return
 
         node.threads = self._task_threads(resolved_args)
+        node.memory_gb = self._task_memory_gb(resolved_args)
         if node.threads > self.cores:
             raise ValueError(
                 f"{node.task_def.name} requires {node.threads} cores but only "
                 f"{self.cores} are available"
+            )
+        if self.memory is not None and node.memory_gb > self.memory:
+            raise ValueError(
+                f"{node.task_def.name} requires {node.memory_gb} GiB but only "
+                f"{self.memory} GiB are available"
             )
         node.state = "ready"
 
@@ -460,12 +474,19 @@ class _ConcurrentEvaluator:
 
         available_jobs = self.jobs - len(self._running_futures)
         available_cores = self.cores - self._running_cores()
+        available_memory = None if self.memory is None else self.memory - self._running_memory_gb()
         selected = select_dispatch_subset(
             ready_tasks=[
-                SchedulableTask(task_id=node.node_id, threads=node.threads) for node in ready_nodes
+                SchedulableTask(
+                    task_id=node.node_id,
+                    threads=node.threads,
+                    memory_gb=node.memory_gb,
+                )
+                for node in ready_nodes
             ],
             jobs=available_jobs,
             cores=available_cores,
+            memory=available_memory,
         )
 
         for node_id in selected:
@@ -645,6 +666,7 @@ class _ConcurrentEvaluator:
         node.cache_key = None
         node.input_hashes = None
         node.threads = 1
+        node.memory_gb = 0
         node.tmp_paths = []
         node.transport_path = None
         node.dynamic_template = None
@@ -784,6 +806,10 @@ class _ConcurrentEvaluator:
         """Return the core footprint of currently running tasks."""
         return sum(self._nodes[node_id].threads for node_id, _ in self._running_futures.values())
 
+    def _running_memory_gb(self) -> int:
+        """Return the declared memory footprint of currently running tasks."""
+        return sum(self._nodes[node_id].memory_gb for node_id, _ in self._running_futures.values())
+
     def _task_threads(self, resolved_args: dict[str, Any]) -> int:
         """Return the scheduler core footprint for a task."""
         raw_threads = resolved_args.get("threads", 1)
@@ -796,6 +822,19 @@ class _ConcurrentEvaluator:
             raise ValueError(f"threads must be at least 1, got {threads}")
 
         return threads
+
+    def _task_memory_gb(self, resolved_args: dict[str, Any]) -> int:
+        """Return the scheduler memory footprint for a task in GiB."""
+        raw_memory = resolved_args.get("memory_gb", 0)
+        try:
+            memory_gb = int(raw_memory)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"memory_gb must be an integer, got {raw_memory!r}") from exc
+
+        if memory_gb < 0:
+            raise ValueError(f"memory_gb must be at least 0, got {memory_gb}")
+
+        return memory_gb
 
     def _build_worker_payload(self, *, node: _TaskNode) -> dict[str, Any]:
         """Encode task inputs into a transport payload for the process pool."""

--- a/src/ginkgo/runtime/provenance.py
+++ b/src/ginkgo/runtime/provenance.py
@@ -6,6 +6,7 @@ import shutil
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import RLock
 from typing import Any
 
 import yaml
@@ -31,6 +32,7 @@ class RunProvenanceRecorder:
     root_dir: Path
     jobs: int | None
     cores: int | None
+    memory: int | None = None
     params: dict[str, Any] = field(default_factory=dict)
     status: str = field(default="running", init=False)
     run_dir: Path = field(init=False)
@@ -41,6 +43,7 @@ class RunProvenanceRecorder:
     _manifest: dict[str, Any] = field(init=False, repr=False)
     _task_logs: dict[int, tuple[Path, Path]] = field(default_factory=dict, init=False, repr=False)
     _copied_envs: set[str] = field(default_factory=set, init=False, repr=False)
+    _lock: RLock = field(default_factory=RLock, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.run_dir = self.root_dir / self.run_id
@@ -55,8 +58,10 @@ class RunProvenanceRecorder:
             "workflow": str(self.workflow_path),
             "jobs": self.jobs,
             "cores": self.cores,
+            "memory": self.memory,
             "status": self.status,
             "started_at": _timestamp(),
+            "resources": _empty_resources(),
             "tasks": {},
         }
         self.write_params(self.params)
@@ -64,11 +69,12 @@ class RunProvenanceRecorder:
 
     def write_params(self, params: dict[str, Any]) -> None:
         """Persist resolved config parameters for the run."""
-        self.params = _render_value(params)
-        self.params_path.write_text(
-            yaml.safe_dump(self.params, sort_keys=True),
-            encoding="utf-8",
-        )
+        with self._lock:
+            self.params = _render_value(params)
+            self.params_path.write_text(
+                yaml.safe_dump(self.params, sort_keys=True),
+                encoding="utf-8",
+            )
 
     def ensure_task(
         self,
@@ -85,31 +91,32 @@ class RunProvenanceRecorder:
         tuple[Path, Path]
             ``(stdout_path, stderr_path)`` for the task.
         """
-        tasks = self._manifest["tasks"]
-        task_key = _task_key(node_id)
-        if task_key not in tasks:
-            slug = _slugify(task_name)
-            stdout_path = self.logs_dir / f"{task_key}_{slug}.stdout.log"
-            stderr_path = self.logs_dir / f"{task_key}_{slug}.stderr.log"
-            self._task_logs[node_id] = (stdout_path, stderr_path)
-            tasks[task_key] = {
-                "task_id": task_key,
-                "node_id": node_id,
-                "task": task_name,
-                "env": env,
-                "retries": retries,
-                "max_attempts": retries + 1,
-                "attempt": 0,
-                "attempts": 0,
-                "retries_remaining": retries,
-                "cached": False,
-                "exit_code": None,
-                "stdout_log": str(stdout_path.relative_to(self.run_dir)),
-                "stderr_log": str(stderr_path.relative_to(self.run_dir)),
-                "status": "pending",
-            }
-            self._write_manifest()
-        return self._task_logs[node_id]
+        with self._lock:
+            tasks = self._manifest["tasks"]
+            task_key = _task_key(node_id)
+            if task_key not in tasks:
+                slug = _slugify(task_name)
+                stdout_path = self.logs_dir / f"{task_key}_{slug}.stdout.log"
+                stderr_path = self.logs_dir / f"{task_key}_{slug}.stderr.log"
+                self._task_logs[node_id] = (stdout_path, stderr_path)
+                tasks[task_key] = {
+                    "task_id": task_key,
+                    "node_id": node_id,
+                    "task": task_name,
+                    "env": env,
+                    "retries": retries,
+                    "max_attempts": retries + 1,
+                    "attempt": 0,
+                    "attempts": 0,
+                    "retries_remaining": retries,
+                    "cached": False,
+                    "exit_code": None,
+                    "stdout_log": str(stdout_path.relative_to(self.run_dir)),
+                    "stderr_log": str(stderr_path.relative_to(self.run_dir)),
+                    "status": "pending",
+                }
+                self._write_manifest()
+            return self._task_logs[node_id]
 
     def update_task_inputs(
         self,
@@ -124,19 +131,20 @@ class RunProvenanceRecorder:
         dynamic_dependency_ids: list[int] | None = None,
     ) -> None:
         """Record resolved task inputs and cache identity."""
-        self.ensure_task(node_id=node_id, task_name=task_name, env=env)
-        task = self._task(node_id)
-        if resolved_args is not None:
-            task["inputs"] = _render_value(resolved_args)
-        if input_hashes is not None:
-            task["input_hashes"] = _render_value(input_hashes)
-        if cache_key is not None:
-            task["cache_key"] = cache_key
-        if dependency_ids is not None:
-            task["dependency_ids"] = dependency_ids
-        if dynamic_dependency_ids is not None:
-            task["dynamic_dependency_ids"] = dynamic_dependency_ids
-        self._write_manifest()
+        with self._lock:
+            self.ensure_task(node_id=node_id, task_name=task_name, env=env)
+            task = self._task(node_id)
+            if resolved_args is not None:
+                task["inputs"] = _render_value(resolved_args)
+            if input_hashes is not None:
+                task["input_hashes"] = _render_value(input_hashes)
+            if cache_key is not None:
+                task["cache_key"] = cache_key
+            if dependency_ids is not None:
+                task["dependency_ids"] = dependency_ids
+            if dynamic_dependency_ids is not None:
+                task["dynamic_dependency_ids"] = dynamic_dependency_ids
+            self._write_manifest()
 
     def mark_running(
         self,
@@ -148,17 +156,18 @@ class RunProvenanceRecorder:
         retries: int,
     ) -> None:
         """Mark a task as dispatched."""
-        self.ensure_task(node_id=node_id, task_name=task_name, env=env, retries=retries)
-        task = self._task(node_id)
-        task["attempt"] = attempt
-        task["attempts"] = max(int(task.get("attempts", 0)), attempt)
-        task["retries"] = retries
-        task["max_attempts"] = retries + 1
-        task["retries_remaining"] = max(0, retries - (attempt - 1))
-        task["status"] = "running"
-        task.setdefault("started_at", _timestamp())
-        task["last_started_at"] = _timestamp()
-        self._write_manifest()
+        with self._lock:
+            self.ensure_task(node_id=node_id, task_name=task_name, env=env, retries=retries)
+            task = self._task(node_id)
+            task["attempt"] = attempt
+            task["attempts"] = max(int(task.get("attempts", 0)), attempt)
+            task["retries"] = retries
+            task["max_attempts"] = retries + 1
+            task["retries_remaining"] = max(0, retries - (attempt - 1))
+            task["status"] = "running"
+            task.setdefault("started_at", _timestamp())
+            task["last_started_at"] = _timestamp()
+            self._write_manifest()
 
     def mark_retrying(
         self,
@@ -171,31 +180,33 @@ class RunProvenanceRecorder:
         retries_remaining: int,
     ) -> None:
         """Record a failed attempt that will be retried."""
-        self.ensure_task(node_id=node_id, task_name=task_name, env=env)
-        task = self._task(node_id)
-        task["cached"] = False
-        task["attempt"] = attempt
-        task["attempts"] = max(int(task.get("attempts", 0)), attempt)
-        task["last_error"] = str(exc)
-        task["last_exit_code"] = getattr(exc, "exit_code", 1)
-        task["retries_remaining"] = retries_remaining
-        task["status"] = "pending"
-        task.pop("finished_at", None)
-        self._write_manifest()
+        with self._lock:
+            self.ensure_task(node_id=node_id, task_name=task_name, env=env)
+            task = self._task(node_id)
+            task["cached"] = False
+            task["attempt"] = attempt
+            task["attempts"] = max(int(task.get("attempts", 0)), attempt)
+            task["last_error"] = str(exc)
+            task["last_exit_code"] = getattr(exc, "exit_code", 1)
+            task["retries_remaining"] = retries_remaining
+            task["status"] = "pending"
+            task.pop("finished_at", None)
+            self._write_manifest()
 
     def mark_cached(self, *, node_id: int, task_name: str, env: str | None, value: Any) -> None:
         """Mark a task as served from cache."""
-        self.ensure_task(node_id=node_id, task_name=task_name, env=env)
-        task = self._task(node_id)
-        task["cached"] = True
-        task["exit_code"] = 0
-        task["output"] = _render_value(value)
-        task["finished_at"] = _timestamp()
-        task["status"] = "cached"
-        task.pop("error", None)
-        task.pop("last_error", None)
-        task.pop("last_exit_code", None)
-        self._write_manifest()
+        with self._lock:
+            self.ensure_task(node_id=node_id, task_name=task_name, env=env)
+            task = self._task(node_id)
+            task["cached"] = True
+            task["exit_code"] = 0
+            task["output"] = _render_value(value)
+            task["finished_at"] = _timestamp()
+            task["status"] = "cached"
+            task.pop("error", None)
+            task.pop("last_error", None)
+            task.pop("last_exit_code", None)
+            self._write_manifest()
 
     def mark_succeeded(
         self,
@@ -206,17 +217,18 @@ class RunProvenanceRecorder:
         value: Any,
     ) -> None:
         """Mark a task as completed successfully."""
-        self.ensure_task(node_id=node_id, task_name=task_name, env=env)
-        task = self._task(node_id)
-        task["cached"] = False
-        task["exit_code"] = 0
-        task["output"] = _render_value(value)
-        task["finished_at"] = _timestamp()
-        task["status"] = "succeeded"
-        task.pop("error", None)
-        task.pop("last_error", None)
-        task.pop("last_exit_code", None)
-        self._write_manifest()
+        with self._lock:
+            self.ensure_task(node_id=node_id, task_name=task_name, env=env)
+            task = self._task(node_id)
+            task["cached"] = False
+            task["exit_code"] = 0
+            task["output"] = _render_value(value)
+            task["finished_at"] = _timestamp()
+            task["status"] = "succeeded"
+            task.pop("error", None)
+            task.pop("last_error", None)
+            task.pop("last_exit_code", None)
+            self._write_manifest()
 
     def mark_failed(
         self,
@@ -227,38 +239,56 @@ class RunProvenanceRecorder:
         exc: BaseException,
     ) -> None:
         """Mark a task as failed."""
-        self.ensure_task(node_id=node_id, task_name=task_name, env=env)
-        task = self._task(node_id)
-        task["cached"] = False
-        task["exit_code"] = getattr(exc, "exit_code", 1)
-        task["error"] = str(exc)
-        task["last_error"] = str(exc)
-        task["last_exit_code"] = getattr(exc, "exit_code", 1)
-        task["retries_remaining"] = 0
-        task["finished_at"] = _timestamp()
-        task["status"] = "failed"
-        self._write_manifest()
+        with self._lock:
+            self.ensure_task(node_id=node_id, task_name=task_name, env=env)
+            task = self._task(node_id)
+            task["cached"] = False
+            task["exit_code"] = getattr(exc, "exit_code", 1)
+            task["error"] = str(exc)
+            task["last_error"] = str(exc)
+            task["last_exit_code"] = getattr(exc, "exit_code", 1)
+            task["retries_remaining"] = 0
+            task["finished_at"] = _timestamp()
+            task["status"] = "failed"
+            self._write_manifest()
 
     def copy_env_lock(self, *, env_name: str, lock_path: Path) -> None:
         """Copy a Pixi lockfile into the run provenance directory once."""
-        if env_name in self._copied_envs or not lock_path.is_file():
-            return
-        destination = self.envs_dir / f"{_slugify(env_name)}.pixi.lock"
-        shutil.copy2(lock_path, destination)
-        self._copied_envs.add(env_name)
+        with self._lock:
+            if env_name in self._copied_envs or not lock_path.is_file():
+                return
+            destination = self.envs_dir / f"{_slugify(env_name)}.pixi.lock"
+            shutil.copy2(lock_path, destination)
+            self._copied_envs.add(env_name)
 
-    def finalize(self, *, status: str, error: str | None = None) -> None:
+    def update_resources(self, resources: dict[str, Any]) -> None:
+        """Persist the latest run-level resource summary."""
+        with self._lock:
+            self._manifest["resources"] = _render_value(resources)
+            self._write_manifest()
+
+    def finalize(
+        self,
+        *,
+        status: str,
+        error: str | None = None,
+        resources: dict[str, Any] | None = None,
+    ) -> None:
         """Write the final run status."""
-        self.status = status
-        self._manifest["status"] = status
-        self._manifest["finished_at"] = _timestamp()
-        if error is not None:
-            self._manifest["error"] = error
-        self._write_manifest()
+        with self._lock:
+            self.status = status
+            self._manifest["status"] = status
+            self._manifest["finished_at"] = _timestamp()
+            if resources is not None:
+                self._manifest["resources"] = _render_value(resources)
+            if error is not None:
+                self._manifest["error"] = error
+            self._write_manifest()
 
     def log_paths_for(self, node_id: int) -> tuple[Path, Path] | None:
         """Return the ``(stdout, stderr)`` log paths for a task node."""
-        return self._task_logs.get(node_id)
+        with self._lock:
+            return self._task_logs.get(node_id)
 
     def _task(self, node_id: int) -> dict[str, Any]:
         return self._manifest["tasks"][_task_key(node_id)]
@@ -324,3 +354,15 @@ def _render_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {str(_render_value(key)): _render_value(item) for key, item in value.items()}
     return summarise_value(value)
+
+
+def _empty_resources() -> dict[str, Any]:
+    return {
+        "status": "pending",
+        "scope": "process_tree",
+        "sample_count": 0,
+        "current": None,
+        "peak": None,
+        "average": None,
+        "updated_at": None,
+    }

--- a/src/ginkgo/runtime/resources.py
+++ b/src/ginkgo/runtime/resources.py
@@ -1,0 +1,270 @@
+"""Run resource monitoring for Ginkgo process trees."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from threading import Event, Lock, Thread
+from typing import Any, Callable
+
+
+@dataclass(frozen=True, kw_only=True)
+class _ProcessTreeUsage:
+    """A single process-tree usage sample.
+
+    Parameters
+    ----------
+    cpu_percent : float
+        Total CPU usage percentage across the tracked process tree.
+    rss_bytes : int
+        Total resident memory in bytes across the tracked process tree.
+    process_count : int
+        Number of processes included in the sample.
+    """
+
+    cpu_percent: float
+    rss_bytes: int
+    process_count: int
+
+
+class RunResourceMonitor:
+    """Capture CPU and memory usage for the current Ginkgo process tree.
+
+    Parameters
+    ----------
+    root_pid : int
+        Root process identifier to track recursively.
+    sample_interval_seconds : float
+        Interval between resource samples.
+    sink : Callable[[dict[str, Any]], None] | None
+        Optional callback invoked whenever the summary changes.
+    """
+
+    def __init__(
+        self,
+        *,
+        root_pid: int,
+        sample_interval_seconds: float = 1.0,
+        sink: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        self._root_pid = root_pid
+        self._sample_interval_seconds = sample_interval_seconds
+        self._sink = sink
+        self._stop_event = Event()
+        self._lock = Lock()
+        self._thread: Thread | None = None
+        self._status = "pending"
+        self._reason: str | None = None
+        self._updated_at: str | None = None
+        self._sample_count = 0
+        self._cpu_total = 0.0
+        self._rss_total = 0
+        self._process_total = 0
+        self._current: dict[str, Any] | None = None
+        self._peak: dict[str, Any] | None = None
+
+    def start(self) -> None:
+        """Start background resource sampling."""
+        if shutil.which("ps") is None:
+            self._mark_unavailable(reason="`ps` command not available")
+            return
+
+        if self._thread is not None:
+            return
+
+        self._status = "running"
+        self._thread = Thread(target=self._run, name="ginkgo-resource-monitor", daemon=True)
+        self._thread.start()
+
+    def stop(self, *, final_status: str = "completed") -> dict[str, Any]:
+        """Stop sampling and return the final resource summary.
+
+        Parameters
+        ----------
+        final_status : str
+            Final status label to persist in the summary.
+
+        Returns
+        -------
+        dict[str, Any]
+            A JSON/YAML-serializable resource summary.
+        """
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(1.0, self._sample_interval_seconds * 2))
+            self._thread = None
+
+        with self._lock:
+            if self._status != "unavailable":
+                self._status = final_status
+                self._updated_at = _timestamp()
+            snapshot = self._snapshot_locked()
+
+        self._emit(snapshot)
+        return snapshot
+
+    def current_summary(self) -> dict[str, Any]:
+        """Return the latest resource summary snapshot."""
+        with self._lock:
+            return self._snapshot_locked()
+
+    def _run(self) -> None:
+        """Sample process-tree usage until the monitor is stopped."""
+        while not self._stop_event.is_set():
+            try:
+                usage = _collect_process_tree_usage(root_pid=self._root_pid)
+            except Exception as exc:
+                self._mark_unavailable(reason=str(exc))
+                return
+
+            self._record_sample(usage=usage)
+            if self._stop_event.wait(self._sample_interval_seconds):
+                return
+
+    def _record_sample(self, *, usage: _ProcessTreeUsage) -> None:
+        """Update rolling aggregates from one process-tree sample."""
+        sampled_at = _timestamp()
+
+        with self._lock:
+            self._sample_count += 1
+            self._cpu_total += usage.cpu_percent
+            self._rss_total += usage.rss_bytes
+            self._process_total += usage.process_count
+            self._updated_at = sampled_at
+            self._current = {
+                "cpu_percent": round(usage.cpu_percent, 2),
+                "rss_bytes": usage.rss_bytes,
+                "process_count": usage.process_count,
+                "sampled_at": sampled_at,
+            }
+
+            if self._peak is None:
+                self._peak = dict(self._current)
+            else:
+                if usage.cpu_percent >= float(self._peak["cpu_percent"]):
+                    self._peak["cpu_percent"] = round(usage.cpu_percent, 2)
+                    self._peak["sampled_at"] = sampled_at
+                if usage.rss_bytes >= int(self._peak["rss_bytes"]):
+                    self._peak["rss_bytes"] = usage.rss_bytes
+                    self._peak["sampled_at"] = sampled_at
+                if usage.process_count >= int(self._peak["process_count"]):
+                    self._peak["process_count"] = usage.process_count
+                    self._peak["sampled_at"] = sampled_at
+
+            snapshot = self._snapshot_locked()
+
+        self._emit(snapshot)
+
+    def _mark_unavailable(self, *, reason: str) -> None:
+        """Freeze the monitor in an unavailable state."""
+        with self._lock:
+            self._status = "unavailable"
+            self._reason = reason
+            self._updated_at = _timestamp()
+            snapshot = self._snapshot_locked()
+
+        self._emit(snapshot)
+
+    def _snapshot_locked(self) -> dict[str, Any]:
+        """Build a serializable resource summary while holding the state lock."""
+        average: dict[str, Any] | None = None
+        if self._sample_count > 0:
+            average = {
+                "cpu_percent": round(self._cpu_total / self._sample_count, 2),
+                "rss_bytes": int(round(self._rss_total / self._sample_count)),
+                "process_count": round(self._process_total / self._sample_count, 2),
+            }
+
+        snapshot: dict[str, Any] = {
+            "status": self._status,
+            "scope": "process_tree",
+            "sample_interval_seconds": self._sample_interval_seconds,
+            "sample_count": self._sample_count,
+            "updated_at": self._updated_at,
+            "current": None if self._current is None else dict(self._current),
+            "peak": None if self._peak is None else dict(self._peak),
+            "average": average,
+        }
+        if self._reason is not None:
+            snapshot["reason"] = self._reason
+        return snapshot
+
+    def _emit(self, snapshot: dict[str, Any]) -> None:
+        """Send a snapshot to the configured sink if one exists."""
+        if self._sink is None:
+            return
+        self._sink(snapshot)
+
+
+def _collect_process_tree_usage(*, root_pid: int) -> _ProcessTreeUsage:
+    """Return a process-tree resource sample rooted at ``root_pid``."""
+    completed = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,%cpu=,rss="],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    rows = _parse_ps_rows(completed.stdout)
+    descendants = _descendant_process_ids(rows=rows, root_pid=root_pid)
+    if not descendants:
+        return _ProcessTreeUsage(cpu_percent=0.0, rss_bytes=0, process_count=0)
+
+    cpu_percent = 0.0
+    rss_bytes = 0
+    for pid in descendants:
+        row = rows[pid]
+        cpu_percent += row["cpu_percent"]
+        rss_bytes += row["rss_kb"] * 1024
+
+    return _ProcessTreeUsage(
+        cpu_percent=cpu_percent,
+        rss_bytes=rss_bytes,
+        process_count=len(descendants),
+    )
+
+
+def _parse_ps_rows(output: str) -> dict[int, dict[str, float | int]]:
+    """Parse ``ps`` output into a PID-indexed mapping."""
+    rows: dict[int, dict[str, float | int]] = {}
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 3)
+        if len(parts) != 4:
+            continue
+        pid_text, ppid_text, cpu_text, rss_text = parts
+        rows[int(pid_text)] = {
+            "ppid": int(ppid_text),
+            "cpu_percent": float(cpu_text),
+            "rss_kb": int(rss_text),
+        }
+    return rows
+
+
+def _descendant_process_ids(*, rows: dict[int, dict[str, float | int]], root_pid: int) -> set[int]:
+    """Return all tracked descendant PIDs rooted at ``root_pid``."""
+    if root_pid not in rows:
+        return set()
+
+    children_by_parent: dict[int, list[int]] = {}
+    for pid, row in rows.items():
+        ppid = int(row["ppid"])
+        children_by_parent.setdefault(ppid, []).append(pid)
+
+    descendants = {root_pid}
+    frontier = [root_pid]
+    while frontier:
+        parent = frontier.pop()
+        for child in children_by_parent.get(parent, []):
+            if child in descendants:
+                continue
+            descendants.add(child)
+            frontier.append(child)
+    return descendants
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat()

--- a/src/ginkgo/runtime/scheduler.py
+++ b/src/ginkgo/runtime/scheduler.py
@@ -18,10 +18,13 @@ class SchedulableTask:
         Internal task identifier.
     threads : int
         Core footprint for the task.
+    memory_gb : int
+        Declared memory footprint for the task in GiB.
     """
 
     task_id: int
     threads: int
+    memory_gb: int
 
 
 def select_dispatch_subset(
@@ -29,6 +32,7 @@ def select_dispatch_subset(
     ready_tasks: Iterable[SchedulableTask],
     jobs: int,
     cores: int,
+    memory: int | None = None,
 ) -> list[int]:
     """Select a feasible subset of ready tasks to dispatch.
 
@@ -40,6 +44,9 @@ def select_dispatch_subset(
         Maximum number of tasks to dispatch in this cycle.
     cores : int
         Available core budget for this cycle.
+    memory : int | None
+        Available memory budget in GiB for this cycle, or ``None`` when
+        memory-aware scheduling is disabled.
 
     Returns
     -------
@@ -47,10 +54,10 @@ def select_dispatch_subset(
         The selected task identifiers.
     """
     tasks = list(ready_tasks)
-    if jobs <= 0 or cores <= 0 or not tasks:
+    if jobs <= 0 or cores <= 0 or (memory is not None and memory < 0) or not tasks:
         return []
 
-    return _select_with_cp_sat(tasks=tasks, jobs=jobs, cores=cores)
+    return _select_with_cp_sat(tasks=tasks, jobs=jobs, cores=cores, memory=memory)
 
 
 def _select_with_cp_sat(
@@ -58,6 +65,7 @@ def _select_with_cp_sat(
     tasks: list[SchedulableTask],
     jobs: int,
     cores: int,
+    memory: int | None,
 ) -> list[int]:
     """Select tasks using OR-Tools CP-SAT when available."""
     model = cp_model.CpModel()
@@ -65,6 +73,8 @@ def _select_with_cp_sat(
 
     model.Add(sum(selected.values()) <= jobs)
     model.Add(sum(task.threads * selected[task.task_id] for task in tasks) <= cores)
+    if memory is not None:
+        model.Add(sum(task.memory_gb * selected[task.task_id] for task in tasks) <= memory)
 
     total_selected = sum(selected.values())
     total_cores = sum(task.threads * selected[task.task_id] for task in tasks)

--- a/src/ginkgo/ui/server.py
+++ b/src/ginkgo/ui/server.py
@@ -111,6 +111,7 @@ def create_ui_server(
 
                 jobs = payload.get("jobs")
                 cores = payload.get("cores")
+                memory = payload.get("memory")
                 if jobs is not None and not isinstance(jobs, int):
                     self._send_json(
                         {"error": "jobs must be an integer when provided."},
@@ -123,6 +124,12 @@ def create_ui_server(
                         status=HTTPStatus.BAD_REQUEST,
                     )
                     return
+                if memory is not None and not isinstance(memory, int):
+                    self._send_json(
+                        {"error": "memory must be an integer when provided."},
+                        status=HTTPStatus.BAD_REQUEST,
+                    )
+                    return
 
                 try:
                     launch = _launch_workflow_process(
@@ -131,6 +138,7 @@ def create_ui_server(
                         config_paths=config_paths,
                         jobs=jobs,
                         cores=cores,
+                        memory=memory,
                     )
                 except FileNotFoundError as exc:
                     self._send_json(
@@ -373,6 +381,7 @@ def _run_payload(run_dir: Path) -> dict[str, Any]:
     return {
         "run_id": run_dir.name,
         "run_dir": str(run_dir),
+        "resources": manifest.get("resources", {}),
         "manifest": manifest,
         "params": params,
         "tasks": tasks,
@@ -420,6 +429,7 @@ def _launch_workflow_process(
     config_paths: list[str],
     jobs: int | None,
     cores: int | None,
+    memory: int | None,
 ) -> dict[str, Any]:
     workflow_path = Path(workflow)
     if not workflow_path.is_absolute():
@@ -445,6 +455,8 @@ def _launch_workflow_process(
         command.extend(["--jobs", str(jobs)])
     if cores is not None:
         command.extend(["--cores", str(cores)])
+    if memory is not None:
+        command.extend(["--memory", str(memory)])
 
     process = subprocess.Popen(  # noqa: S603 - controlled local CLI invocation
         command,

--- a/src/ginkgo/ui/static/assets/resource-monitor.js
+++ b/src/ginkgo/ui/static/assets/resource-monitor.js
@@ -1,0 +1,179 @@
+(function () {
+  const PANEL_ID = "ginkgo-resource-monitor";
+  const REFRESH_MS = 2000;
+
+  function ensurePanel() {
+    let panel = document.getElementById(PANEL_ID);
+    if (panel) {
+      return panel;
+    }
+
+    panel = document.createElement("aside");
+    panel.id = PANEL_ID;
+    panel.setAttribute("aria-live", "polite");
+    panel.style.position = "fixed";
+    panel.style.right = "18px";
+    panel.style.bottom = "18px";
+    panel.style.zIndex = "9999";
+    panel.style.minWidth = "210px";
+    panel.style.padding = "12px 14px";
+    panel.style.borderRadius = "12px";
+    panel.style.background = "rgba(12, 18, 22, 0.9)";
+    panel.style.color = "#f8fafc";
+    panel.style.boxShadow = "0 18px 40px rgba(15, 23, 42, 0.24)";
+    panel.style.border = "1px solid rgba(148, 163, 184, 0.16)";
+    panel.style.backdropFilter = "blur(10px)";
+    panel.style.fontFamily = "Inter, sans-serif";
+    panel.style.display = "none";
+    document.body.appendChild(panel);
+    return panel;
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!response.ok) {
+      throw new Error("Failed to fetch " + url);
+    }
+    return response.json();
+  }
+
+  function currentRunIdFromPath() {
+    const parts = window.location.pathname.split("/").filter(Boolean);
+    if (parts[0] === "runs" && parts[1]) {
+      return parts[1];
+    }
+    return null;
+  }
+
+  async function resolveRunId() {
+    const fromPath = currentRunIdFromPath();
+    if (fromPath) {
+      return fromPath;
+    }
+
+    const meta = await fetchJson("/api/meta");
+    return meta.selected_run_id || meta.latest_run_id || null;
+  }
+
+  function formatCpu(value) {
+    if (typeof value !== "number") {
+      return "--";
+    }
+    return value >= 100 ? value.toFixed(0) + "%" : value.toFixed(1) + "%";
+  }
+
+  function formatBytes(value) {
+    if (typeof value !== "number") {
+      return "--";
+    }
+
+    const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let size = value;
+    let index = 0;
+    while (size >= 1024 && index < units.length - 1) {
+      size /= 1024;
+      index += 1;
+    }
+    return (size >= 10 || index === 0 ? size.toFixed(0) : size.toFixed(1)) + " " + units[index];
+  }
+
+  function setLine(node, label, value) {
+    const row = document.createElement("div");
+    row.style.display = "flex";
+    row.style.justifyContent = "space-between";
+    row.style.gap = "12px";
+    row.style.fontSize = "12px";
+    row.style.lineHeight = "1.5";
+
+    const left = document.createElement("span");
+    left.textContent = label;
+    left.style.opacity = "0.72";
+
+    const right = document.createElement("strong");
+    right.textContent = value;
+    right.style.fontWeight = "600";
+
+    row.appendChild(left);
+    row.appendChild(right);
+    node.appendChild(row);
+  }
+
+  function render(run) {
+    const panel = ensurePanel();
+    const resources = run.resources || (run.manifest && run.manifest.resources) || null;
+    if (!resources || resources.status === "pending") {
+      panel.style.display = "none";
+      return;
+    }
+
+    const current = resources.current || {};
+    const average = resources.average || {};
+    const peak = resources.peak || {};
+    const isLive = resources.status === "running";
+
+    panel.replaceChildren();
+    panel.style.display = "block";
+
+    const title = document.createElement("div");
+    title.style.display = "flex";
+    title.style.justifyContent = "space-between";
+    title.style.alignItems = "center";
+    title.style.marginBottom = "8px";
+
+    const heading = document.createElement("strong");
+    heading.textContent = "Run usage";
+    heading.style.fontSize = "12px";
+    heading.style.letterSpacing = "0.06em";
+    heading.style.textTransform = "uppercase";
+
+    const badge = document.createElement("span");
+    badge.textContent = isLive ? "Live" : "Summary";
+    badge.style.fontSize = "11px";
+    badge.style.padding = "2px 7px";
+    badge.style.borderRadius = "999px";
+    badge.style.background = isLive ? "rgba(20, 184, 166, 0.2)" : "rgba(148, 163, 184, 0.18)";
+    badge.style.color = isLive ? "#99f6e4" : "#cbd5e1";
+
+    title.appendChild(heading);
+    title.appendChild(badge);
+    panel.appendChild(title);
+
+    setLine(panel, isLive ? "CPU" : "CPU avg", formatCpu(isLive ? current.cpu_percent : average.cpu_percent));
+    setLine(panel, "CPU peak", formatCpu(peak.cpu_percent));
+    setLine(panel, isLive ? "RSS" : "RSS avg", formatBytes(isLive ? current.rss_bytes : average.rss_bytes));
+    setLine(panel, "RSS peak", formatBytes(peak.rss_bytes));
+  }
+
+  async function refresh() {
+    try {
+      const runId = await resolveRunId();
+      if (!runId) {
+        ensurePanel().style.display = "none";
+        return;
+      }
+      const run = await fetchJson("/api/runs/" + encodeURIComponent(runId));
+      render(run);
+    } catch (_error) {
+      ensurePanel().style.display = "none";
+    }
+  }
+
+  const originalPushState = history.pushState;
+  history.pushState = function () {
+    const result = originalPushState.apply(this, arguments);
+    window.dispatchEvent(new Event("ginkgo:navigate"));
+    return result;
+  };
+
+  const originalReplaceState = history.replaceState;
+  history.replaceState = function () {
+    const result = originalReplaceState.apply(this, arguments);
+    window.dispatchEvent(new Event("ginkgo:navigate"));
+    return result;
+  };
+
+  window.addEventListener("popstate", refresh);
+  window.addEventListener("ginkgo:navigate", refresh);
+  refresh();
+  window.setInterval(refresh, REFRESH_MS);
+})();

--- a/src/ginkgo/ui/static/index.html
+++ b/src/ginkgo/ui/static/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
     <script type="module" crossorigin src="/assets/index-ClQoeabx.js"></script>
+    <script defer src="/assets/resource-monitor.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DKvBbzP3.css">
   </head>
   <body>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,6 +562,37 @@ def main():
         assert result.returncode == 0, result.stderr
         assert "💻 Running locally on 1 core" in result.stdout
 
+    def test_run_surfaces_memory_budget_and_resource_summary(self) -> None:
+        Path("workflow.py").write_text(
+            """
+import time
+from ginkgo import flow, task
+
+@task()
+def produce() -> str:
+    time.sleep(1.2)
+    return "ok"
+
+@flow
+def main():
+    return produce()
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "workflow.py", "--memory", "32", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "🧠 Memory budget: 32 GiB" in result.stdout
+        assert "CPU avg " in result.stdout
+        assert "RSS avg " in result.stdout
+
+        run_dir = _extract_run_dir(result.stdout)
+        manifest = yaml.safe_load((run_dir / "manifest.yaml").read_text(encoding="utf-8"))
+        assert manifest["memory"] == 32
+        assert manifest["resources"]["status"] == "completed"
+        assert manifest["resources"]["sample_count"] >= 1
+
 
 class TestCliMappedLabels:
     def test_map_tasks_use_first_parameter_value_as_runtime_label(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,7 @@ def main():
         )
         assert "📦 Loading workflow...  done" in first.stdout
         assert "🌱 Building expression tree...  1 tasks" in first.stdout
-        assert re.search(r"💻 Running locally on \d+ Cores", first.stdout)
+        assert re.search(r"Running locally on \d+ Cores", first.stdout)
         assert "write_message" in first.stdout
         assert "Environment" in first.stdout
         assert "local" in first.stdout
@@ -534,7 +534,7 @@ def main():
             r"🌿 ginkgo run workflow\.py \([0-9]{8}_[0-9]{6}_[0-9a-f]{8}\)", result.stdout
         )
         assert "Run Summary" not in result.stdout
-        assert re.search(r"💻 Running locally on \d+ Cores", result.stdout)
+        assert re.search(r"Running locally on \d+ Cores", result.stdout)
         assert "🧭 Verbose mode:" in result.stdout
         assert "config overlays=0" in result.stdout
         assert "🗂 Run directory:" in result.stdout
@@ -560,7 +560,7 @@ def main():
 
         result = _run_cli("run", "workflow.py", "--cores", "1", cwd=Path.cwd())
         assert result.returncode == 0, result.stderr
-        assert "💻 Running locally on 1 core" in result.stdout
+        assert "Running locally on 1 core" in result.stdout
 
     def test_run_surfaces_memory_budget_and_resource_summary(self) -> None:
         Path("workflow.py").write_text(

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,5 +1,6 @@
 """Unit tests for the evaluator runtime."""
 
+import subprocess
 import shutil
 from pathlib import Path
 
@@ -8,7 +9,9 @@ import pandas as pd
 import pytest
 
 from ginkgo import evaluate, file, folder, shell_task, task, tmp_dir
+from ginkgo.pixi import PixiRegistry
 from ginkgo.runtime.evaluator import CycleError, _ConcurrentEvaluator
+from ginkgo.runtime.worker import run_task
 
 
 def _append_line(path: str, line: str) -> None:
@@ -141,6 +144,17 @@ def build_dynamic_cycle_task() -> object:
     second = passthrough_task(value=first)
     first.args["value"] = second
     return first
+
+
+_PIXI_TEST_ENV = "race_env"
+
+
+@task(env=_PIXI_TEST_ENV)
+def pixi_shell_output_task(output_path: str) -> file:
+    return shell_task(
+        cmd=f"printf 'payload' > {output_path}",
+        output=output_path,
+    )
 
 
 class TestEvaluate:
@@ -321,6 +335,61 @@ class TestShellTask:
         assert result == file(str(output))
         assert output.read_text(encoding="utf-8") == "payload"
         assert "transient shell failure" in log.read_text(encoding="utf-8")
+
+    def test_pixi_environment_is_prepared_once_before_shell_fan_out(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        env_dir = tmp_path / "envs" / _PIXI_TEST_ENV
+        env_dir.mkdir(parents=True)
+        manifest = env_dir / "pixi.toml"
+        manifest.write_text(
+            "[workspace]\nname = 'race-env'\nchannels = []\nplatforms = []\n",
+            encoding="utf-8",
+        )
+
+        install_calls: list[list[str]] = []
+        real_subprocess_run = subprocess.run
+
+        def fake_pixi_install(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            if argv[:2] != ["pixi", "install"]:
+                return real_subprocess_run(
+                    argv, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+            install_calls.append(argv)
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        def fake_run_pixi_python_task(
+            self,
+            *,
+            node,
+            payload: dict[str, object],
+        ) -> dict[str, object]:
+            return run_task(payload)
+
+        registry = PixiRegistry(project_root=tmp_path)
+        monkeypatch.setattr("ginkgo.envs.pixi._require_pixi", lambda: None)
+        monkeypatch.setattr("ginkgo.envs.pixi.subprocess.run", fake_pixi_install)
+        monkeypatch.setattr(
+            _ConcurrentEvaluator, "_run_pixi_python_task", fake_run_pixi_python_task
+        )
+        monkeypatch.setattr(
+            registry,
+            "shell_argv",
+            lambda *, env, cmd: ["bash", "-c", cmd],
+        )
+
+        outputs = [tmp_path / f"pixi-shell-{index}.txt" for index in range(3)]
+        result = evaluate(
+            [pixi_shell_output_task(output_path=str(path)) for path in outputs],
+            pixi_registry=registry,
+        )
+
+        assert result == [file(str(path)) for path in outputs]
+        assert install_calls == [["pixi", "install", "--manifest-path", str(manifest.resolve())]]
+        for path in outputs:
+            assert path.read_text(encoding="utf-8") == "payload"
 
 
 class TestValidation:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -26,6 +26,7 @@ class TestRunProvenanceRecorder:
             root_dir=tmp_path / ".ginkgo" / "runs",
             jobs=None,
             cores=None,
+            memory=None,
             params={},
         )
 
@@ -41,3 +42,34 @@ class TestRunProvenanceRecorder:
 
         manifest = yaml.safe_load((recorder.run_dir / "manifest.yaml").read_text(encoding="utf-8"))
         assert manifest["tasks"]["task_0000"]["output"] == "results/out.txt"
+
+    def test_resources_and_memory_budget_are_serialized(self, tmp_path: Path) -> None:
+        workflow_path = tmp_path / "workflow.py"
+        workflow_path.write_text("# placeholder\n", encoding="utf-8")
+        recorder = RunProvenanceRecorder(
+            run_id="20260312_000000_deadbeef",
+            workflow_path=workflow_path,
+            root_dir=tmp_path / ".ginkgo" / "runs",
+            jobs=4,
+            cores=2,
+            memory=32,
+            params={},
+        )
+
+        recorder.update_resources(
+            {
+                "status": "completed",
+                "scope": "process_tree",
+                "sample_count": 3,
+                "current": {"cpu_percent": 10.0, "rss_bytes": 1024, "process_count": 1},
+                "peak": {"cpu_percent": 120.0, "rss_bytes": 4096, "process_count": 2},
+                "average": {"cpu_percent": 55.0, "rss_bytes": 2048, "process_count": 1.5},
+                "updated_at": "2026-03-13T00:00:00+00:00",
+            }
+        )
+        recorder.finalize(status="succeeded")
+
+        manifest = yaml.safe_load((recorder.run_dir / "manifest.yaml").read_text(encoding="utf-8"))
+        assert manifest["memory"] == 32
+        assert manifest["resources"]["status"] == "completed"
+        assert manifest["resources"]["peak"]["rss_bytes"] == 4096

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -67,6 +67,17 @@ def _make_run(tmp_path: Path, *, run_id: str, status: str, fail: bool) -> Path:
         dependency_ids=[],
         dynamic_dependency_ids=[],
     )
+    recorder.update_resources(
+        {
+            "status": "completed",
+            "scope": "process_tree",
+            "sample_count": 2,
+            "current": {"cpu_percent": 12.5, "rss_bytes": 1024, "process_count": 1},
+            "peak": {"cpu_percent": 85.0, "rss_bytes": 4096, "process_count": 2},
+            "average": {"cpu_percent": 48.0, "rss_bytes": 2048, "process_count": 1.5},
+            "updated_at": "2026-03-13T00:00:00+00:00",
+        }
+    )
     if fail:
         recorder.mark_failed(
             node_id=0,
@@ -101,6 +112,7 @@ class TestUiServer:
         assert status == 200
         assert '<div id="root"></div>' in body
         assert "Ginkgo" in body
+        assert "resource-monitor.js" in body
 
     def test_api_lists_runs(self, tmp_path: Path) -> None:
         runs_root = tmp_path / ".ginkgo" / "runs"
@@ -136,6 +148,7 @@ class TestUiServer:
             server.server_close()
 
         assert run_payload["run_id"] == run_dir.name
+        assert run_payload["resources"]["peak"]["rss_bytes"] == 4096
         assert run_payload["tasks"][0]["task"] == "demo.write_output"
         assert run_payload["tasks"][0]["dependency_ids"] == []
         assert task_payload["task"]["error"] == "boom"
@@ -257,6 +270,7 @@ class TestUiServer:
                 "config_paths": ["ginkgo.toml"],
                 "jobs": 4,
                 "cores": 2,
+                "memory": 12,
             }
         ).encode("utf-8")
 
@@ -284,6 +298,7 @@ class TestUiServer:
                 "config_paths": ["ginkgo.toml"],
                 "jobs": 4,
                 "cores": 2,
+                "memory": 12,
             }
         ]
 

--- a/tests/test_vw8_memory.py
+++ b/tests/test_vw8_memory.py
@@ -1,0 +1,152 @@
+"""VW-8 — Memory contention tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from ginkgo import evaluate, flow, task
+
+
+def _write_interval(
+    events_dir: str,
+    name: str,
+    *,
+    started_at: float,
+    ended_at: float,
+    threads: int,
+    memory_gb: int,
+    high_memory: bool,
+) -> None:
+    Path(events_dir).mkdir(parents=True, exist_ok=True)
+    Path(events_dir, f"{name}.json").write_text(
+        json.dumps(
+            {
+                "end": ended_at,
+                "high_memory": high_memory,
+                "memory_gb": memory_gb,
+                "start": started_at,
+                "threads": threads,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _load_intervals(events_dir: str) -> list[dict[str, object]]:
+    return [
+        json.loads(path.read_text(encoding="utf-8")) for path in Path(events_dir).glob("*.json")
+    ]
+
+
+def _compute_peaks(intervals: list[dict[str, object]]) -> tuple[int, int, int, int]:
+    points: list[tuple[float, int, int, int, int]] = []
+    for interval in intervals:
+        threads = int(interval["threads"])
+        memory_gb = int(interval["memory_gb"])
+        high_memory = 1 if interval["high_memory"] else 0
+        points.append((float(interval["start"]), 1, threads, memory_gb, high_memory))
+        points.append((float(interval["end"]), -1, -threads, -memory_gb, -high_memory))
+
+    points.sort(key=lambda item: (item[0], item[1]))
+
+    active_tasks = 0
+    active_cores = 0
+    active_memory = 0
+    active_high_memory = 0
+    peak_tasks = 0
+    peak_cores = 0
+    peak_memory = 0
+    peak_high_memory = 0
+    for _, task_delta, core_delta, memory_delta, high_memory_delta in points:
+        active_tasks += task_delta
+        active_cores += core_delta
+        active_memory += memory_delta
+        active_high_memory += high_memory_delta
+        peak_tasks = max(peak_tasks, active_tasks)
+        peak_cores = max(peak_cores, active_cores)
+        peak_memory = max(peak_memory, active_memory)
+        peak_high_memory = max(peak_high_memory, active_high_memory)
+
+    return peak_tasks, peak_cores, peak_memory, peak_high_memory
+
+
+@task()
+def high_mem(item: str, events_dir: str, threads: int = 2, memory_gb: int = 16) -> str:
+    started_at = time.time()
+    time.sleep(0.15)
+    ended_at = time.time()
+    _write_interval(
+        events_dir,
+        f"high-{item}",
+        started_at=started_at,
+        ended_at=ended_at,
+        threads=threads,
+        memory_gb=memory_gb,
+        high_memory=True,
+    )
+    return f"high:{item}"
+
+
+@task()
+def low_mem(item: str, events_dir: str, threads: int = 1, memory_gb: int = 4) -> str:
+    started_at = time.time()
+    time.sleep(0.15)
+    ended_at = time.time()
+    _write_interval(
+        events_dir,
+        f"low-{item}",
+        started_at=started_at,
+        ended_at=ended_at,
+        threads=threads,
+        memory_gb=memory_gb,
+        high_memory=False,
+    )
+    return f"low:{item}"
+
+
+@task()
+def too_large(marker_path: str, memory_gb: int = 64) -> str:
+    Path(marker_path).write_text("ran", encoding="utf-8")
+    return "ran"
+
+
+@flow
+def memory_pipeline(items: list[str], events_dir: str):
+    high_results = high_mem(events_dir=events_dir).map(item=items[:3])
+    low_results = low_mem(events_dir=events_dir).map(item=items[3:])
+    return high_results, low_results
+
+
+class TestVW8MemoryContention:
+    def test_memory_limit_is_never_exceeded(self) -> None:
+        items = [f"item_{index}" for index in range(6)]
+        events_dir = "memory-events"
+
+        high_results, low_results = evaluate(
+            memory_pipeline(items=items, events_dir=events_dir),
+            jobs=6,
+            cores=8,
+            memory=32,
+        )
+
+        peak_tasks, peak_cores, peak_memory, peak_high_memory = _compute_peaks(
+            _load_intervals(events_dir)
+        )
+        assert high_results == [f"high:{item}" for item in items[:3]]
+        assert low_results == [f"low:{item}" for item in items[3:]]
+        assert peak_high_memory <= 2
+        assert peak_tasks <= 6
+        assert peak_cores <= 8
+        assert peak_memory <= 32
+
+    def test_task_larger_than_budget_fails_before_dispatch(self) -> None:
+        marker_path = "too-large.marker"
+
+        with pytest.raises(ValueError, match="requires 64 GiB but only 32 GiB are available"):
+            evaluate(too_large(marker_path=marker_path), jobs=1, cores=1, memory=32)
+
+        assert not Path(marker_path).exists()

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -22,7 +22,12 @@ from pathlib import Path
 import pytest
 
 from ginkgo import evaluate, flow, shell_task, task
-from ginkgo.pixi import PixiEnvImportError, PixiEnvNotFoundError, PixiRegistry
+from ginkgo.pixi import (
+    PixiEnvImportError,
+    PixiEnvNotFoundError,
+    PixiEnvPrepareError,
+    PixiRegistry,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +172,37 @@ class TestPixiRegistry:
         registry = PixiRegistry(project_root=_TESTS_DIR)
         with pytest.raises(PixiEnvNotFoundError, match="missing_env"):
             registry.validate_envs(env_names={"missing_env"})
+
+    def test_prepare_installs_manifest_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry = PixiRegistry(project_root=_TESTS_DIR)
+        manifest = registry.resolve(env=_TEST_ENV_NAME)
+        install_calls: list[list[str]] = []
+
+        def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            install_calls.append(argv)
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("ginkgo.envs.pixi._require_pixi", lambda: None)
+        monkeypatch.setattr("ginkgo.envs.pixi.subprocess.run", fake_run)
+
+        assert registry.prepare(env=_TEST_ENV_NAME) == manifest
+        assert registry.prepare(env=_TEST_ENV_NAME) == manifest
+        assert install_calls == [["pixi", "install", "--manifest-path", str(manifest)]]
+
+    def test_prepare_raises_clear_error_on_install_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        registry = PixiRegistry(project_root=_TESTS_DIR)
+
+        def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="install failed")
+
+        monkeypatch.setattr("ginkgo.envs.pixi._require_pixi", lambda: None)
+        monkeypatch.setattr("ginkgo.envs.pixi.subprocess.run", fake_run)
+
+        with pytest.raises(PixiEnvPrepareError, match="install failed"):
+            registry.prepare(env=_TEST_ENV_NAME)
 
     def test_shell_argv_structure(self) -> None:
         registry = PixiRegistry(project_root=_TESTS_DIR)


### PR DESCRIPTION
## Summary
- add memory-aware task dispatch with a global `--memory` budget and per-task `memory_gb` declarations
- record run-level CPU/RSS summaries, show a compact live CPU/RSS monitor in the CLI, and expose the same data to the local UI
- document the new resource model and add regression coverage for scheduling, provenance, CLI output, and UI APIs

## Testing
- .pixi/envs/default/bin/pytest tests/ -q
- pixi run lint