### PR TITLE
Add env cleanup and harden Pixi worker shutdown

### DIFF
--- a/src/ginkgo/__init__.py
+++ b/src/ginkgo/__init__.py
@@ -2,16 +2,27 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import sys
 from importlib import import_module
+from types import ModuleType
+from typing import Any
 
-from ginkgo.config import config
-from ginkgo.core.expr import Expr, ExprList
-from ginkgo.core.flow import FlowDef, flow
-from ginkgo.core.shell import ShellExpr, shell_task
-from ginkgo.core.task import PartialCall, TaskDef, task
-from ginkgo.core.types import file, folder, tmp_dir
-from ginkgo.runtime.evaluator import evaluate
+_EXPORTS = {
+    "Expr": ("ginkgo.core.expr", "Expr"),
+    "ExprList": ("ginkgo.core.expr", "ExprList"),
+    "FlowDef": ("ginkgo.core.flow", "FlowDef"),
+    "PartialCall": ("ginkgo.core.task", "PartialCall"),
+    "ShellExpr": ("ginkgo.core.shell", "ShellExpr"),
+    "TaskDef": ("ginkgo.core.task", "TaskDef"),
+    "evaluate": ("ginkgo.runtime.evaluator", "evaluate"),
+    "file": ("ginkgo.core.types", "file"),
+    "flow": ("ginkgo.core.flow", "flow"),
+    "folder": ("ginkgo.core.types", "folder"),
+    "shell_task": ("ginkgo.core.shell", "shell_task"),
+    "task": ("ginkgo.core.task", "task"),
+    "tmp_dir": ("ginkgo.core.types", "tmp_dir"),
+}
 
 _LEGACY_MODULE_ALIASES = {
     "ginkgo.cache": "ginkgo.runtime.cache",
@@ -28,22 +39,76 @@ _LEGACY_MODULE_ALIASES = {
     "ginkgo.worker": "ginkgo.runtime.worker",
 }
 
-for legacy_name, current_name in _LEGACY_MODULE_ALIASES.items():
-    sys.modules.setdefault(legacy_name, import_module(current_name))
 
-__all__ = [
-    "Expr",
-    "ExprList",
-    "FlowDef",
-    "PartialCall",
-    "ShellExpr",
-    "TaskDef",
-    "config",
-    "evaluate",
-    "file",
-    "flow",
-    "folder",
-    "shell_task",
-    "task",
-    "tmp_dir",
-]
+class _LazyAliasModule(ModuleType):
+    """Module proxy that loads a legacy alias target on first attribute access."""
+
+    def __init__(self, *, alias_name: str, target_name: str) -> None:
+        super().__init__(alias_name)
+        self._target_name = target_name
+
+    def _resolve(self) -> ModuleType:
+        module = import_module(self._target_name)
+        sys.modules[self.__name__] = module
+        return module
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    def __dir__(self) -> list[str]:
+        return sorted(dir(self._resolve()))
+
+
+class _GinkgoModule(ModuleType):
+    """Package module that preserves callable exports across submodule imports."""
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Keep ``ginkgo.config(...)`` callable even after ``ginkgo.config`` is imported.
+        if (
+            name == "config"
+            and isinstance(value, ModuleType)
+            and value.__name__ == "ginkgo.config"
+        ):
+            ModuleType.__setattr__(self, "_config_module", value)
+            return
+
+        super().__setattr__(name, value)
+
+
+def config(path: str | Path) -> dict[str, Any]:
+    """Load a project configuration file via the top-level package API."""
+    from ginkgo.config import config as load_config
+
+    return load_config(path)
+
+
+def __getattr__(name: str):
+    """Resolve top-level package exports lazily."""
+    try:
+        module_name, attribute_name = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    module = import_module(module_name)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return the names exposed by this package."""
+    return sorted(list(globals().keys()) + list(_EXPORTS.keys()))
+
+
+for legacy_name, current_name in _LEGACY_MODULE_ALIASES.items():
+    sys.modules.setdefault(
+        legacy_name,
+        _LazyAliasModule(alias_name=legacy_name, target_name=current_name),
+    )
+
+
+_package = sys.modules[__name__]
+_package.__class__ = _GinkgoModule
+
+
+__all__ = sorted(["config", *_EXPORTS.keys()])

--- a/src/ginkgo/cli/app.py
+++ b/src/ginkgo/cli/app.py
@@ -10,6 +10,7 @@ from rich.text import Text
 
 from ginkgo.cli.commands.cache import command_cache
 from ginkgo.cli.commands.debug import command_debug
+from ginkgo.cli.commands.env import command_env
 from ginkgo.cli.commands.init import command_init
 from ginkgo.cli.commands.run import command_run
 from ginkgo.cli.commands.test import command_test
@@ -27,6 +28,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return command_run(args, output_mode=_run_mode_from_args(args))
         if args.command == "cache":
             return command_cache(args)
+        if args.command == "env":
+            return command_env(args)
         if args.command == "debug":
             return command_debug(args)
         if args.command == "test":
@@ -65,6 +68,14 @@ def _build_parser() -> argparse.ArgumentParser:
     prune_parser = cache_subparsers.add_parser("prune")
     prune_parser.add_argument("--older-than", required=True)
     prune_parser.add_argument("--dry-run", action="store_true")
+
+    env_parser = subparsers.add_parser("env")
+    env_subparsers = env_parser.add_subparsers(dest="env_command", required=True)
+    env_subparsers.add_parser("ls")
+    env_clear_parser = env_subparsers.add_parser("clear")
+    env_clear_parser.add_argument("env", nargs="?")
+    env_clear_parser.add_argument("--all", action="store_true")
+    env_clear_parser.add_argument("--dry-run", action="store_true")
 
     debug_parser = subparsers.add_parser("debug")
     debug_parser.add_argument("run_id", nargs="?")

--- a/src/ginkgo/cli/commands/env.py
+++ b/src/ginkgo/cli/commands/env.py
@@ -1,0 +1,135 @@
+"""Environment command handlers."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from rich import box
+from rich.table import Table
+from rich.text import Text
+
+from ginkgo.cli.common import console
+from ginkgo.envs.pixi import PixiRegistry
+
+
+@dataclass(frozen=True)
+class EnvEntryRow:
+    """Display metadata for a project-local Pixi environment."""
+
+    env: str
+    manifest: Path
+    install_dir: Path
+    installed: bool
+
+
+def command_env(args) -> int:
+    """Handle ``ginkgo env`` subcommands."""
+    rich_console = console(sys.stdout)
+    registry = PixiRegistry(project_root=Path.cwd())
+
+    if args.env_command == "ls":
+        rich_console.print("[bold green]🌿 ginkgo env[/] [bold]ls[/]\n")
+        entries = list_project_envs(registry=registry)
+        if not entries:
+            rich_console.print("[dim]No Pixi environments found under envs/.[/]")
+            return 0
+
+        table = Table(
+            box=box.SQUARE,
+            border_style="#0f766e",
+            header_style="bold #134e4a",
+            expand=False,
+        )
+        table.add_column("Env", style="bold")
+        table.add_column("Installed", no_wrap=True)
+        table.add_column("Manifest")
+        table.add_column("Install Dir")
+        for entry in entries:
+            table.add_row(
+                entry.env,
+                "yes" if entry.installed else "no",
+                str(entry.manifest),
+                str(entry.install_dir),
+            )
+        rich_console.print(table)
+        return 0
+
+    rich_console.print("[bold green]🌿 ginkgo env[/] [bold]clear[/]\n")
+    targets = _clear_targets(registry=registry, env=args.env, clear_all=args.all)
+    installed_targets = [target for target in targets if target.install_dir.exists()]
+
+    if args.dry_run:
+        rich_console.print(
+            f"[cyan]Preview:[/] {len(installed_targets)} Pixi "
+            f"{'env' if len(installed_targets) == 1 else 'envs'} would be removed."
+        )
+        for entry in installed_targets:
+            rich_console.print(f"[dim]-[/] {entry.env}: {entry.install_dir}")
+        if not installed_targets:
+            rich_console.print("[dim]Nothing to remove.[/]")
+        return 0
+
+    for entry in installed_targets:
+        shutil.rmtree(entry.install_dir)
+
+    if not installed_targets:
+        rich_console.print("[dim]Nothing to remove.[/]")
+        return 0
+
+    message = Text()
+    message.append("✓ ", style="green")
+    message.append("Removed ")
+    message.append(str(len(installed_targets)), style="bold")
+    message.append(" Pixi ")
+    message.append("env" if len(installed_targets) == 1 else "envs")
+    rich_console.print(message)
+    return 0
+
+
+def list_project_envs(*, registry: PixiRegistry) -> list[EnvEntryRow]:
+    """Return discoverable project-local Pixi environments."""
+    envs_dir = registry.project_root / "envs"
+    if not envs_dir.is_dir():
+        return []
+
+    entries: list[EnvEntryRow] = []
+    for child in sorted(envs_dir.iterdir(), key=lambda path: path.name):
+        manifest = child / "pixi.toml"
+        if not child.is_dir() or not manifest.is_file():
+            continue
+        install_dir = manifest.parent / ".pixi"
+        entries.append(
+            EnvEntryRow(
+                env=child.name,
+                manifest=manifest.resolve(),
+                install_dir=install_dir.resolve(strict=False),
+                installed=install_dir.exists(),
+            )
+        )
+    return entries
+
+
+def _clear_targets(
+    *, registry: PixiRegistry, env: str | None, clear_all: bool
+) -> list[EnvEntryRow]:
+    """Resolve the env install directories targeted by ``ginkgo env clear``."""
+    if clear_all == (env is not None):
+        raise ValueError("Specify exactly one of <env> or --all.")
+
+    if clear_all:
+        return list_project_envs(registry=registry)
+
+    assert env is not None
+    manifest = registry.resolve(env=env)
+    install_dir = manifest.parent / ".pixi"
+    return [
+        EnvEntryRow(
+            env=env,
+            manifest=manifest,
+            install_dir=install_dir.resolve(strict=False),
+            installed=install_dir.exists(),
+        )
+    ]

--- a/src/ginkgo/envs/pixi_worker.py
+++ b/src/ginkgo/envs/pixi_worker.py
@@ -30,9 +30,8 @@ def run(input_path: pathlib.Path, output_path: pathlib.Path) -> None:
     """
     payload: dict[str, Any] = json.loads(input_path.read_bytes())
 
-    # Inject the host sys.path so ginkgo and the workflow module are importable
-    # inside the Pixi env even when ginkgo is not installed there.
-    for p in payload.get("sys_path", []):
+    # Inject only the Ginkgo package roots required to bootstrap the worker.
+    for p in payload.get("ginkgo_import_roots", []):
         if p not in sys.path:
             sys.path.insert(0, p)
 

--- a/src/ginkgo/runtime/__init__.py
+++ b/src/ginkgo/runtime/__init__.py
@@ -1,37 +1,47 @@
 """Execution engine internals for Ginkgo."""
 
-from ginkgo.runtime.cache import CacheStore, MISSING
-from ginkgo.runtime.evaluator import evaluate
-from ginkgo.runtime.module_loader import load_module, load_module_from_path, module_name_for_path
-from ginkgo.runtime.provenance import RunProvenanceRecorder, latest_run_dir, load_manifest
-from ginkgo.runtime.scheduler import SchedulableTask, select_dispatch_subset
-from ginkgo.runtime.value_codec import (
-    CodecError,
-    decode_value,
-    encode_value,
-    ensure_serializable,
-    hash_value_bytes,
-    summarise_value,
-)
-from ginkgo.runtime.worker import run_task
+from __future__ import annotations
 
-__all__ = [
-    "CacheStore",
-    "CodecError",
-    "MISSING",
-    "SchedulableTask",
-    "RunProvenanceRecorder",
-    "decode_value",
-    "encode_value",
-    "ensure_serializable",
-    "evaluate",
-    "hash_value_bytes",
-    "latest_run_dir",
-    "load_manifest",
-    "load_module",
-    "load_module_from_path",
-    "module_name_for_path",
-    "run_task",
-    "select_dispatch_subset",
-    "summarise_value",
-]
+from importlib import import_module
+
+_EXPORTS = {
+    "CacheStore": ("ginkgo.runtime.cache", "CacheStore"),
+    "CodecError": ("ginkgo.runtime.value_codec", "CodecError"),
+    "MISSING": ("ginkgo.runtime.cache", "MISSING"),
+    "RunProvenanceRecorder": ("ginkgo.runtime.provenance", "RunProvenanceRecorder"),
+    "SchedulableTask": ("ginkgo.runtime.scheduler", "SchedulableTask"),
+    "decode_value": ("ginkgo.runtime.value_codec", "decode_value"),
+    "encode_value": ("ginkgo.runtime.value_codec", "encode_value"),
+    "ensure_serializable": ("ginkgo.runtime.value_codec", "ensure_serializable"),
+    "evaluate": ("ginkgo.runtime.evaluator", "evaluate"),
+    "hash_value_bytes": ("ginkgo.runtime.value_codec", "hash_value_bytes"),
+    "latest_run_dir": ("ginkgo.runtime.provenance", "latest_run_dir"),
+    "load_manifest": ("ginkgo.runtime.provenance", "load_manifest"),
+    "load_module": ("ginkgo.runtime.module_loader", "load_module"),
+    "load_module_from_path": ("ginkgo.runtime.module_loader", "load_module_from_path"),
+    "module_name_for_path": ("ginkgo.runtime.module_loader", "module_name_for_path"),
+    "run_task": ("ginkgo.runtime.worker", "run_task"),
+    "select_dispatch_subset": ("ginkgo.runtime.scheduler", "select_dispatch_subset"),
+    "summarise_value": ("ginkgo.runtime.value_codec", "summarise_value"),
+}
+
+
+def __getattr__(name: str):
+    """Resolve runtime exports lazily to avoid importing optional deps eagerly."""
+    try:
+        module_name, attribute_name = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    module = import_module(module_name)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return the names exposed by this package."""
+    return sorted(list(globals().keys()) + list(_EXPORTS.keys()))
+
+
+__all__ = sorted(_EXPORTS.keys())

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 import builtins
-from contextlib import ExitStack
+from contextlib import ExitStack, suppress
 from concurrent.futures import (
     FIRST_COMPLETED,
     Future,
@@ -21,7 +21,7 @@ from concurrent.futures import (
 from dataclasses import dataclass, field
 from multiprocessing import get_context
 from pathlib import Path
-from threading import current_thread, main_thread
+from threading import Lock, current_thread, main_thread
 from types import FrameType
 from typing import Any, get_args, get_origin
 
@@ -31,7 +31,7 @@ from ginkgo.core.task import TaskDef
 from ginkgo.core.types import file, folder, tmp_dir
 from ginkgo.envs.pixi import PixiRegistry
 from ginkgo.runtime.cache import MISSING, CacheStore
-from ginkgo.runtime.module_loader import load_module, resolve_module_file
+from ginkgo.runtime.module_loader import import_roots_for_path, load_module, resolve_module_file
 from ginkgo.runtime.provenance import RunProvenanceRecorder
 from ginkgo.runtime.scheduler import SchedulableTask, select_dispatch_subset
 from ginkgo.runtime.value_codec import (
@@ -52,7 +52,7 @@ from ginkgo.runtime.worker import run_task
 _PIXI_WORKER_C = (
     "import sys,json,pathlib,base64,pickle;"
     "p=json.loads(pathlib.Path(sys.argv[1]).read_bytes());"
-    "[sys.path.insert(0,x) for x in p.get('sys_path',[]) if x not in sys.path];"
+    "[sys.path.insert(0,x) for x in p.get('ginkgo_import_roots',[]) if x not in sys.path];"
     "from ginkgo.runtime.worker import run_task;"
     "r=dict(run_task(p));"
     "enc=r.get('result_encoding');"
@@ -207,7 +207,18 @@ class _ConcurrentEvaluator:
     _root_template: Any = field(default=None, init=False, repr=False)
     _root_dependency_ids: set[int] = field(default_factory=set, init=False, repr=False)
     _failure: BaseException | None = field(default=None, init=False, repr=False)
+    _python_executor: ProcessPoolExecutor | ThreadPoolExecutor | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
     _shell_executor: ThreadPoolExecutor | None = field(default=None, init=False, repr=False)
+    _subprocess_lock: Lock = field(default_factory=Lock, init=False, repr=False)
+    _active_subprocesses: dict[int, subprocess.Popen[str]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         default_jobs = os.cpu_count() or 1
@@ -245,40 +256,45 @@ class _ConcurrentEvaluator:
                 python_executor = stack.enter_context(ThreadPoolExecutor(max_workers=self.jobs))
             shell_executor = stack.enter_context(ThreadPoolExecutor(max_workers=self.jobs))
             signals = stack.enter_context(_SignalMonitor())
+            self._python_executor = python_executor
             self._shell_executor = shell_executor
-            while True:
-                if signals.exception is not None and self._failure is None:
-                    self._failure = signals.exception
-                    self._cancel_pending_futures()
+            try:
+                while True:
+                    if signals.exception is not None and self._failure is None:
+                        self._failure = signals.exception
+                        self._interrupt_running_work()
 
-                if self._failure is None:
-                    self._prepare_pending_nodes()
-                    self._finalize_dynamic_nodes()
-                    self._dispatch_ready_nodes(
-                        python_executor=python_executor,
-                        shell_executor=shell_executor,
-                    )
+                    if self._failure is None:
+                        self._prepare_pending_nodes()
+                        self._finalize_dynamic_nodes()
+                        self._dispatch_ready_nodes(
+                            python_executor=python_executor,
+                            shell_executor=shell_executor,
+                        )
 
-                    if self._is_root_resolved() and not self._running_futures:
+                        if self._is_root_resolved() and not self._running_futures:
+                            return self._materialize(self._root_template)
+                    elif not self._running_futures:
+                        break
+
+                    if self._running_futures:
+                        done, _ = wait(
+                            tuple(self._running_futures.keys()),
+                            return_when=FIRST_COMPLETED,
+                        )
+                        self._consume_completed_futures(done)
+                        continue
+
+                    if self._failure is not None:
+                        break
+
+                    if self._is_root_resolved():
                         return self._materialize(self._root_template)
-                elif not self._running_futures:
-                    break
 
-                if self._running_futures:
-                    done, _ = wait(
-                        tuple(self._running_futures.keys()),
-                        return_when=FIRST_COMPLETED,
-                    )
-                    self._consume_completed_futures(done)
-                    continue
-
-                if self._failure is not None:
-                    break
-
-                if self._is_root_resolved():
-                    return self._materialize(self._root_template)
-
-                raise RuntimeError("Scheduler reached a deadlock with unresolved tasks")
+                    raise RuntimeError("Scheduler reached a deadlock with unresolved tasks")
+            finally:
+                self._python_executor = None
+                self._shell_executor = None
 
         assert self._failure is not None
         raise self._failure
@@ -638,7 +654,7 @@ class _ConcurrentEvaluator:
 
     def _handle_task_exception(self, *, node: _TaskNode, exc: BaseException) -> None:
         """Either retry a failed task attempt or fail the run."""
-        if self._should_retry(node=node):
+        if self._failure is None and self._should_retry(node=node):
             self._schedule_retry(node=node, exc=exc)
             return
 
@@ -812,6 +828,126 @@ class _ConcurrentEvaluator:
         for future in self._running_futures:
             future.cancel()
 
+    def _interrupt_running_work(self) -> None:
+        """Stop queued and active work after an external interrupt."""
+        self._cancel_pending_futures()
+        self._terminate_active_subprocesses()
+        self._shutdown_shell_executor()
+        self._shutdown_python_executor()
+
+    def _shutdown_shell_executor(self) -> None:
+        """Shut down the shell executor without waiting for new tasks."""
+        if self._shell_executor is None:
+            return
+        with suppress(Exception):
+            self._shell_executor.shutdown(wait=False, cancel_futures=True)
+
+    def _shutdown_python_executor(self) -> None:
+        """Shut down the Python executor and terminate worker processes."""
+        if self._python_executor is None:
+            return
+
+        executor = self._python_executor
+        with suppress(Exception):
+            executor.shutdown(wait=False, cancel_futures=True)
+
+        if isinstance(executor, ProcessPoolExecutor):
+            self._terminate_process_pool_workers(executor=executor)
+
+    def _terminate_process_pool_workers(self, *, executor: ProcessPoolExecutor) -> None:
+        """Terminate active process-pool workers using the executor's process table."""
+        processes = getattr(executor, "_processes", None)
+        if not isinstance(processes, dict):
+            return
+
+        for process in list(processes.values()):
+            with suppress(Exception):
+                if process.is_alive():
+                    process.terminate()
+
+        for process in list(processes.values()):
+            with suppress(Exception):
+                process.join(timeout=0.2)
+
+        for process in list(processes.values()):
+            with suppress(Exception):
+                if process.is_alive():
+                    process.kill()
+
+    def _register_subprocess(self, *, process: subprocess.Popen[str]) -> None:
+        """Track a subprocess so interrupts can terminate it."""
+        with self._subprocess_lock:
+            self._active_subprocesses[process.pid] = process
+
+    def _unregister_subprocess(self, *, process: subprocess.Popen[str]) -> None:
+        """Stop tracking a subprocess after it exits."""
+        with self._subprocess_lock:
+            self._active_subprocesses.pop(process.pid, None)
+
+    def _terminate_active_subprocesses(self) -> None:
+        """Terminate all active shell and Pixi subprocesses."""
+        with self._subprocess_lock:
+            processes = list(self._active_subprocesses.values())
+
+        for process in processes:
+            self._terminate_subprocess(process=process)
+
+    def _terminate_subprocess(self, *, process: subprocess.Popen[str]) -> None:
+        """Terminate one subprocess, escalating to kill if needed."""
+        if process.poll() is not None:
+            return
+
+        if os.name == "posix":
+            with suppress(ProcessLookupError, OSError):
+                os.killpg(process.pid, signal.SIGTERM)
+        else:
+            with suppress(Exception):
+                process.terminate()
+
+        with suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=0.2)
+            return
+
+        if os.name == "posix":
+            with suppress(ProcessLookupError, OSError):
+                os.killpg(process.pid, signal.SIGKILL)
+        else:
+            with suppress(Exception):
+                process.kill()
+
+        with suppress(Exception):
+            process.wait(timeout=0.2)
+
+    def _run_subprocess(
+        self,
+        *,
+        argv: str | list[str],
+        use_shell: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a subprocess while tracking it for interrupt-time termination."""
+        popen_kwargs: dict[str, Any] = {
+            "shell": use_shell,
+            "stderr": subprocess.PIPE,
+            "stdout": subprocess.PIPE,
+            "text": True,
+        }
+        if os.name == "posix":
+            popen_kwargs["start_new_session"] = True
+
+        process = subprocess.Popen(argv, **popen_kwargs)
+        self._register_subprocess(process=process)
+        try:
+            stdout_text, stderr_text = process.communicate()
+        finally:
+            self._unregister_subprocess(process=process)
+
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=process.returncode,
+            stdout=stdout_text,
+            stderr=stderr_text,
+        )
+
     def _running_cores(self) -> int:
         """Return the core footprint of currently running tasks."""
         return sum(self._nodes[node_id].threads for node_id, _ in self._running_futures.values())
@@ -850,16 +986,18 @@ class _ConcurrentEvaluator:
         """Encode task inputs into a transport payload for the process pool."""
         assert node.transport_path is not None
         assert node.resolved_args is not None
+        worker_module_file = resolve_module_file("ginkgo.runtime.worker")
+        assert worker_module_file is not None
         return {
             "args": {
                 name: encode_value(value, base_dir=node.transport_path)
                 for name, value in node.resolved_args.items()
             },
+            "ginkgo_import_roots": import_roots_for_path(worker_module_file),
             "stdout_path": str(node.stdout_path) if node.stdout_path is not None else None,
             "stderr_path": str(node.stderr_path) if node.stderr_path is not None else None,
             "module": node.task_def.fn.__module__,
             "module_file": resolve_module_file(node.task_def.fn.__module__),
-            "sys_path": list(sys.path),
             "task_name": node.task_def.fn.__name__,
             "transport_dir": str(node.transport_path),
         }
@@ -1002,14 +1140,7 @@ class _ConcurrentEvaluator:
             argv = shell_expr.cmd
             use_shell = True
 
-        completed = subprocess.run(
-            argv,
-            shell=use_shell,
-            check=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        completed = self._run_subprocess(argv=argv, use_shell=use_shell)
         stdout_text = completed.stdout or ""
         stderr_text = completed.stderr or ""
 
@@ -1077,7 +1208,7 @@ class _ConcurrentEvaluator:
             code=_PIXI_WORKER_C,
             args=(str(input_path), str(output_path)),
         )
-        completed = subprocess.run(argv, shell=False, check=False, text=True, capture_output=True)
+        completed = self._run_subprocess(argv=argv, use_shell=False)
         stdout_text = completed.stdout or ""
         stderr_text = completed.stderr or ""
         if node.stdout_path is not None and stdout_text:

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -56,9 +56,9 @@ _PIXI_WORKER_C = (
     "from ginkgo.runtime.worker import run_task;"
     "r=dict(run_task(p));"
     "enc=r.get('result_encoding');"
-    "r['result'],r['result_encoding']="
-    "(base64.b64encode(pickle.dumps(r['result'],5)).decode(),'pixi_direct_pickled')"
-    " if enc=='direct' else (r['result'],enc);"
+    "r['result'],r['result_encoding']=("
+    "base64.b64encode(pickle.dumps(r['result'],5)).decode(),'pixi_direct_pickled'"
+    ") if r.get('ok') and enc=='direct' else (r.get('result'),enc);"
     "pathlib.Path(sys.argv[2]).write_text(json.dumps(r))"
 )
 

--- a/src/ginkgo/runtime/module_loader.py
+++ b/src/ginkgo/runtime/module_loader.py
@@ -18,9 +18,9 @@ def module_name_for_path(path: str | Path) -> str:
     return f"ginkgo_user_{stem}_{digest}"
 
 
-def _import_roots_for_path(path: Path) -> list[str]:
-    """Return sys.path entries needed to import a workflow file and its package."""
-    source_dir = path.parent.resolve()
+def import_roots_for_path(path: str | Path) -> list[str]:
+    """Return import roots needed to load a source file and its package."""
+    source_dir = Path(path).resolve().parent
     roots = [str(source_dir)]
 
     current = source_dir
@@ -44,7 +44,7 @@ def load_module_from_path(path: str | Path, *, module_name: str | None = None) -
     if chosen_name in sys.modules:
         del sys.modules[chosen_name]
 
-    for import_root in reversed(_import_roots_for_path(source_path)):
+    for import_root in reversed(import_roots_for_path(source_path)):
         if import_root not in sys.path:
             sys.path.insert(0, import_root)
 

--- a/src/ginkgo/runtime/worker.py
+++ b/src/ginkgo/runtime/worker.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
-import sys
 import traceback
 from typing import Any
 
@@ -14,10 +13,6 @@ from ginkgo.runtime.value_codec import decode_value, encode_value
 
 def run_task(payload: dict[str, Any]) -> dict[str, Any]:
     """Execute a task payload inside a process-pool worker."""
-    for path in payload.get("sys_path", []):
-        if path not in sys.path:
-            sys.path.insert(0, path)
-
     base_dir = Path(payload["transport_dir"])
     decoded_args = {
         name: decode_value(value, base_dir=base_dir) for name, value in payload["args"].items()

--- a/tests/envs/test_env/pixi.lock
+++ b/tests/envs/test_env/pixi.lock
@@ -10,7 +10,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -24,17 +27,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hcab7f73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.4-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
@@ -48,16 +60,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.3-hb06a95a_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
@@ -66,10 +87,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
@@ -134,6 +161,24 @@ packages:
   license: ISC
   size: 147413
   timestamp: 1772006283803
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  size: 21333
+  timestamp: 1763918099466
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
   sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
   md5: 186a18e3ba246eccfc7cff00cd19a870
@@ -164,6 +209,15 @@ packages:
   license_family: MIT
   size: 12389400
   timestamp: 1772209104304
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
+  md5: 9614359868482abba1bd15ce465e3c42
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 13387
+  timestamp: 1760831448842
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
   sha256: 565941ac1f8b0d2f2e8f02827cbca648f4d18cd461afc31f15604cd291b5c5f3
   md5: 12bd9a3f089ee6c9266a37dab82afabd
@@ -512,6 +566,54 @@ packages:
   license_family: Apache
   size: 3104268
   timestamp: 1769556384749
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+  sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
+  md5: b76541e68fea4d511b1ac46a28dcd2c6
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72010
+  timestamp: 1769093650580
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
+  md5: d7585b6550ad04c8c5e21097ada2888e
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25877
+  timestamp: 1764896838868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+  sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+  md5: 6b6ece66ebcae2d5f326c77ef2c5a066
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889287
+  timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+  sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
+  md5: 2b694bad8a50dc2f712f5368de866480
+  depends:
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - colorama >=0.4
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  size: 299581
+  timestamp: 1765062031645
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
   build_number: 101
   sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd
@@ -665,6 +767,26 @@ packages:
   license_family: BSD
   size: 3127137
   timestamp: 1769460817696
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+  sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
+  md5: 72e780e9aa2d0a3295f59b1874e3768b
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 21453
+  timestamp: 1768146676791
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 51692
+  timestamp: 1756220668932
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610

--- a/tests/envs/test_env/pixi.toml
+++ b/tests/envs/test_env/pixi.toml
@@ -7,3 +7,4 @@ platforms = ["osx-arm64", "linux-64", "linux-aarch64"]
 
 [dependencies]
 python = ">=3.11"
+pytest = ">=8.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,6 +237,64 @@ def main():
         assert "Invalid duration for --older-than" in result.stderr
 
 
+class TestCliEnv:
+    def test_env_ls_empty_state_is_styled(self) -> None:
+        result = _run_cli("env", "ls", cwd=Path.cwd())
+        assert result.returncode == 0
+        assert "🌿 ginkgo env ls" in result.stdout
+        assert "No Pixi environments found under envs/." in result.stdout
+
+    def test_env_ls_and_clear_manage_project_local_pixi_installs(self) -> None:
+        analysis_dir = Path("envs") / "analysis_tools"
+        analysis_dir.mkdir(parents=True)
+        (analysis_dir / "pixi.toml").write_text(
+            "[workspace]\nname = 'analysis-tools'\nchannels = []\nplatforms = []\n",
+            encoding="utf-8",
+        )
+        analysis_install = analysis_dir / ".pixi" / "envs" / "default"
+        analysis_install.mkdir(parents=True)
+        (analysis_install / "marker.txt").write_text("installed", encoding="utf-8")
+
+        bioinfo_dir = Path("envs") / "bioinfo_tools"
+        bioinfo_dir.mkdir(parents=True)
+        (bioinfo_dir / "pixi.toml").write_text(
+            "[workspace]\nname = 'bioinfo-tools'\nchannels = []\nplatforms = []\n",
+            encoding="utf-8",
+        )
+        bioinfo_install = bioinfo_dir / ".pixi" / "envs" / "default"
+        bioinfo_install.mkdir(parents=True)
+        (bioinfo_install / "marker.txt").write_text("installed", encoding="utf-8")
+
+        listed = _run_cli("env", "ls", cwd=Path.cwd())
+        assert listed.returncode == 0, listed.stderr
+        assert "analysis_tools" in listed.stdout
+        assert "bioinfo_tools" in listed.stdout
+        assert "yes" in listed.stdout
+
+        preview = _run_cli("env", "clear", "--all", "--dry-run", cwd=Path.cwd())
+        assert preview.returncode == 0, preview.stderr
+        assert "would be removed" in preview.stdout
+        assert analysis_dir.joinpath(".pixi").exists()
+        assert bioinfo_dir.joinpath(".pixi").exists()
+
+        cleared_one = _run_cli("env", "clear", "analysis_tools", cwd=Path.cwd())
+        assert cleared_one.returncode == 0, cleared_one.stderr
+        assert "🌿 ginkgo env clear" in cleared_one.stdout
+        assert "✓ Removed 1 Pixi env" in cleared_one.stdout
+        assert not analysis_dir.joinpath(".pixi").exists()
+        assert bioinfo_dir.joinpath(".pixi").exists()
+
+        cleared_all = _run_cli("env", "clear", "--all", cwd=Path.cwd())
+        assert cleared_all.returncode == 0, cleared_all.stderr
+        assert "✓ Removed 1 Pixi env" in cleared_all.stdout
+        assert not bioinfo_dir.joinpath(".pixi").exists()
+
+    def test_env_clear_requires_exactly_one_target(self) -> None:
+        result = _run_cli("env", "clear", cwd=Path.cwd())
+        assert result.returncode == 1
+        assert "Specify exactly one of <env> or --all." in result.stderr
+
+
 class TestCliDebug:
     def test_debug_reports_failed_task_inputs_and_log_tail(self) -> None:
         Path("failing_workflow.py").write_text(

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,5 +1,6 @@
 """Unit tests for the evaluator runtime."""
 
+from concurrent.futures import Future, ProcessPoolExecutor
 import subprocess
 import shutil
 from pathlib import Path
@@ -11,6 +12,7 @@ import pytest
 from ginkgo import evaluate, file, folder, shell_task, task, tmp_dir
 from ginkgo.pixi import PixiRegistry
 from ginkgo.runtime.evaluator import CycleError, _ConcurrentEvaluator
+from ginkgo.runtime.module_loader import import_roots_for_path, resolve_module_file
 from ginkgo.runtime.worker import run_task
 
 
@@ -390,6 +392,129 @@ class TestShellTask:
         assert install_calls == [["pixi", "install", "--manifest-path", str(manifest.resolve())]]
         for path in outputs:
             assert path.read_text(encoding="utf-8") == "payload"
+
+
+class _FakeShellExecutor:
+    def __init__(self) -> None:
+        self.shutdown_calls: list[tuple[bool, bool]] = []
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        self.shutdown_calls.append((wait, cancel_futures))
+
+
+class _FakeProcessPoolExecutor(ProcessPoolExecutor):
+    def __init__(self) -> None:
+        self.shutdown_calls: list[tuple[bool, bool]] = []
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        self.shutdown_calls.append((wait, cancel_futures))
+
+
+class _FakeTrackedProcess:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+
+class TestInterruptHandling:
+    def test_interrupt_running_work_terminates_subprocesses_and_shuts_down_executors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        evaluator = _ConcurrentEvaluator()
+        future_one = Future()
+        future_two = Future()
+        tracked_one = _FakeTrackedProcess(pid=101)
+        tracked_two = _FakeTrackedProcess(pid=202)
+        shell_executor = _FakeShellExecutor()
+        python_executor = _FakeProcessPoolExecutor()
+        terminated: list[int] = []
+        pool_shutdowns: list[ProcessPoolExecutor] = []
+
+        evaluator._running_futures = {
+            future_one: (0, "shell"),
+            future_two: (1, "python"),
+        }
+        evaluator._active_subprocesses = {
+            tracked_one.pid: tracked_one,  # type: ignore[assignment]
+            tracked_two.pid: tracked_two,  # type: ignore[assignment]
+        }
+        evaluator._shell_executor = shell_executor
+        evaluator._python_executor = python_executor
+
+        monkeypatch.setattr(
+            evaluator,
+            "_terminate_subprocess",
+            lambda *, process: terminated.append(process.pid),
+        )
+        monkeypatch.setattr(
+            evaluator,
+            "_terminate_process_pool_workers",
+            lambda *, executor: pool_shutdowns.append(executor),
+        )
+
+        evaluator._interrupt_running_work()
+
+        assert future_one.cancelled()
+        assert future_two.cancelled()
+        assert terminated == [101, 202]
+        assert shell_executor.shutdown_calls == [(False, True)]
+        assert python_executor.shutdown_calls == [(False, True)]
+        assert pool_shutdowns == [python_executor]
+
+    def test_run_subprocess_unregisters_process_after_completion(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        evaluator = _ConcurrentEvaluator()
+        popen_calls: list[tuple[object, dict[str, object]]] = []
+
+        class FakePopen:
+            def __init__(self, argv: object, **kwargs: object) -> None:
+                popen_calls.append((argv, kwargs))
+                self.pid = 31337
+                self.returncode = 0
+
+            def communicate(self) -> tuple[str, str]:
+                assert 31337 in evaluator._active_subprocesses
+                return ("stdout", "stderr")
+
+        monkeypatch.setattr("ginkgo.runtime.evaluator.subprocess.Popen", FakePopen)
+
+        completed = evaluator._run_subprocess(argv=["echo", "hi"], use_shell=False)
+
+        assert completed.returncode == 0
+        assert completed.stdout == "stdout"
+        assert completed.stderr == "stderr"
+        assert evaluator._active_subprocesses == {}
+        assert popen_calls[0][0] == ["echo", "hi"]
+
+        if Path("/").anchor == "/":
+            assert popen_calls[0][1]["start_new_session"] is True
+
+
+class TestPixiWorkerPayload:
+    def test_build_worker_payload_uses_minimal_ginkgo_import_roots(self, tmp_path: Path) -> None:
+        evaluator = _ConcurrentEvaluator()
+        expr = add_one_task(x=1)
+        node_id = evaluator._register_expr(expr)
+        node = evaluator._nodes[node_id]
+        node.transport_path = tmp_path / "transport"
+        node.transport_path.mkdir()
+        node.resolved_args = {"x": 1}
+
+        payload = evaluator._build_worker_payload(node=node)
+
+        worker_module_file = resolve_module_file("ginkgo.runtime.worker")
+        assert worker_module_file is not None
+        assert payload["ginkgo_import_roots"] == import_roots_for_path(worker_module_file)
+        assert "sys_path" not in payload
+        assert "ginkgo_import_roots" in payload
+
+    def test_pixi_worker_bootstrap_uses_ginkgo_import_roots_not_host_sys_path(self) -> None:
+        from ginkgo.runtime.evaluator import _PIXI_WORKER_C
+
+        assert "ginkgo_import_roots" in _PIXI_WORKER_C
+        assert "sys_path" not in _PIXI_WORKER_C
 
 
 class TestValidation:

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 
+import ginkgo
 from ginkgo.runtime.module_loader import import_roots_for_path, load_module_from_path
 
 
 class TestLoadModuleFromPath:
+    def test_importing_ginkgo_does_not_eagerly_import_config_module(self) -> None:
+        sys.modules.pop("ginkgo.config", None)
+
+        importlib.reload(ginkgo)
+
+        assert "ginkgo.config" not in sys.modules
+
+    def test_importing_config_submodule_preserves_ginkgo_config_callable(self) -> None:
+        sys.modules.pop("ginkgo.config", None)
+
+        importlib.reload(ginkgo)
+
+        from ginkgo.config import _config_session
+
+        assert _config_session is not None
+        assert callable(ginkgo.config)
+        assert not isinstance(ginkgo.config, ModuleType)
+
     def test_import_roots_for_path_include_package_root_parent(self, tmp_path: Path) -> None:
         repo_root = tmp_path / "AmpSeeker"
         package_dir = repo_root / "ampseeker_ginkgo"

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -5,10 +5,23 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from ginkgo.runtime.module_loader import load_module_from_path
+from ginkgo.runtime.module_loader import import_roots_for_path, load_module_from_path
 
 
 class TestLoadModuleFromPath:
+    def test_import_roots_for_path_include_package_root_parent(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "AmpSeeker"
+        package_dir = repo_root / "ampseeker_ginkgo"
+        package_dir.mkdir(parents=True)
+
+        (package_dir / "__init__.py").write_text("", encoding="utf-8")
+        workflow_path = package_dir / "workflow.py"
+        workflow_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+        roots = import_roots_for_path(workflow_path)
+
+        assert roots == [str(package_dir.resolve()), str(repo_root.resolve())]
+
     def test_load_module_supports_importing_own_package(self, tmp_path: Path) -> None:
         repo_root = tmp_path / "AmpSeeker"
         package_dir = repo_root / "ampseeker_ginkgo"

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from ginkgo import evaluate, flow, shell_task, task
+from ginkgo import flow, shell_task, task
 from ginkgo.pixi import (
     PixiEnvImportError,
     PixiEnvNotFoundError,
@@ -41,6 +41,13 @@ _TEST_ENV_NAME = "test_env"
 def _make_registry(tmp_path: Path) -> PixiRegistry:
     """Return a PixiRegistry pointing at the real test envs directory."""
     return PixiRegistry(project_root=_TESTS_DIR)
+
+
+def _evaluate(expr, *, registry: PixiRegistry):
+    """Evaluate an expression without importing the evaluator at module import time."""
+    from ginkgo import evaluate
+
+    return evaluate(expr, pixi_registry=registry)
 
 
 def _pixi_available() -> bool:
@@ -239,7 +246,7 @@ class TestPixiRegistry:
 
         registry = PixiRegistry(project_root=_TESTS_DIR)
         with pytest.raises(PixiEnvNotFoundError):
-            evaluate(my_flow(), pixi_registry=registry)
+            _evaluate(my_flow(), registry=registry)
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +307,7 @@ class TestPixiShellTask:
     def test_shell_task_runs_in_pixi_env(self, tmp_path: Path) -> None:
         output = str(tmp_path / "sentinel.txt")
         registry = _make_registry(tmp_path)
-        result = evaluate(shell_touch(output_path=output), pixi_registry=registry)
+        result = _evaluate(shell_touch(output_path=output), registry=registry)
         assert result == output
         assert Path(output).read_text().strip() == "pixi_ran"
 
@@ -313,7 +320,7 @@ class TestPixiShellTask:
         registry = _make_registry(tmp_path)
 
         # Run 1 — shell command executes, result cached.
-        evaluate(shell_touch(output_path=output), pixi_registry=registry)
+        _evaluate(shell_touch(output_path=output), registry=registry)
         assert Path(output).exists()
 
         # Capture log output on run 2 to confirm the task was served from cache.
@@ -329,7 +336,7 @@ class TestPixiPythonTask:
     @pixi_required
     def test_python_task_runs_in_pixi_env(self, tmp_path: Path) -> None:
         registry = _make_registry(tmp_path)
-        result = evaluate(pixi_python_add(x=3, y=4), pixi_registry=registry)
+        result = _evaluate(pixi_python_add(x=3, y=4), registry=registry)
         assert result == 7
 
     @pixi_required
@@ -341,14 +348,14 @@ class TestPixiPythonTask:
             return pixi_double().map(x=items)
 
         registry = _make_registry(tmp_path)
-        result = evaluate(fan_flow(items=[1, 2, 3, 4, 5]), pixi_registry=registry)
+        result = _evaluate(fan_flow(items=[1, 2, 3, 4, 5]), registry=registry)
         assert result == [2, 4, 6, 8, 10]
 
     @pixi_required
     def test_mixed_pixi_and_plain_tasks(self, tmp_path: Path) -> None:
         """Pixi and non-pixi tasks coexist correctly in the same run."""
         registry = _make_registry(tmp_path)
-        pixi_result, plain_result = evaluate(mixed_flow(x=10, y=5), pixi_registry=registry)
+        pixi_result, plain_result = _evaluate(mixed_flow(x=10, y=5), registry=registry)
         assert pixi_result == 15
         assert plain_result == 15
 
@@ -359,8 +366,8 @@ class TestPixiCacheInvalidation:
         log_path = str(tmp_path / "log.txt")
         registry = _make_registry(tmp_path)
 
-        evaluate(logged_flow(x=2, y=3, log_path=log_path), pixi_registry=registry)
-        evaluate(logged_flow(x=2, y=3, log_path=log_path), pixi_registry=registry)
+        _evaluate(logged_flow(x=2, y=3, log_path=log_path), registry=registry)
+        _evaluate(logged_flow(x=2, y=3, log_path=log_path), registry=registry)
 
         # Task should have run exactly once despite two evaluate() calls.
         lines = Path(log_path).read_text().splitlines()
@@ -373,7 +380,7 @@ class TestPixiCacheInvalidation:
         registry = _make_registry(tmp_path)
         lock_path = _TESTS_DIR / "envs" / _TEST_ENV_NAME / "pixi.lock"
 
-        evaluate(logged_flow(x=2, y=3, log_path=log_path), pixi_registry=registry)
+        _evaluate(logged_flow(x=2, y=3, log_path=log_path), registry=registry)
 
         # Invalidate the lock hash by appending a harmless comment.
         original = lock_path.read_text(encoding="utf-8")
@@ -381,7 +388,7 @@ class TestPixiCacheInvalidation:
             lock_path.write_text(original + "\n# test-invalidation\n", encoding="utf-8")
             # Flush the registry's in-memory hash cache.
             registry2 = _make_registry(tmp_path)
-            evaluate(logged_flow(x=2, y=3, log_path=log_path), pixi_registry=registry2)
+            _evaluate(logged_flow(x=2, y=3, log_path=log_path), registry=registry2)
         finally:
             lock_path.write_text(original, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add a top-level `ginkgo env` command for listing and clearing project-local Pixi installs
- terminate active shell/Pixi subprocesses and shut down executors promptly on interrupt
- stop forwarding the host `sys.path` into Pixi workers and bootstrap them with minimal Ginkgo import roots only

## Testing
- pixi run pytest tests/test_cli.py tests/test_evaluator.py -q
- pixi run pytest tests/test_evaluator.py tests/test_module_loader.py tests/test_cli.py -q
- pixi run ruff check src/ginkgo/cli/app.py src/ginkgo/cli/commands/env.py src/ginkgo/runtime/evaluator.py tests/test_cli.py tests/test_evaluator.py
- pixi run ruff check src/ginkgo/runtime/module_loader.py src/ginkgo/runtime/evaluator.py src/ginkgo/runtime/worker.py src/ginkgo/envs/pixi_worker.py tests/test_module_loader.py tests/test_evaluator.py
- pixi run ruff format --check src/ginkgo/cli/app.py src/ginkgo/cli/commands/env.py src/ginkgo/runtime/evaluator.py tests/test_cli.py tests/test_evaluator.py
- pixi run ty check src/ginkgo/cli/app.py
