### PR TITLE
Support multi-output shell tasks

### DIFF
--- a/src/ginkgo/core/shell.py
+++ b/src/ginkgo/core/shell.py
@@ -8,6 +8,9 @@ to a shell runner.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeAlias
+
+ShellOutput: TypeAlias = str | list[str] | tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -18,19 +21,19 @@ class ShellExpr:
     ----------
     cmd : str
         The shell command (already interpolated with resolved values).
-    output : str
-        Expected output path.  Used for cache checking and post-execution
-        validation.
+    output : str | list[str] | tuple[str, ...]
+        Expected output path or paths. Used for cache checking and post-
+        execution validation.
     log : str | None
         Optional path to capture stdout/stderr.
     """
 
     cmd: str
-    output: str
+    output: ShellOutput
     log: str | None = None
 
 
-def shell_task(*, cmd: str, output: str, log: str | None = None) -> ShellExpr:
+def shell_task(*, cmd: str, output: ShellOutput, log: str | None = None) -> ShellExpr:
     """Create a shell command expression.
 
     Called from inside a ``@task()`` body with fully resolved argument values.
@@ -41,8 +44,8 @@ def shell_task(*, cmd: str, output: str, log: str | None = None) -> ShellExpr:
     ----------
     cmd : str
         The shell command to run.
-    output : str
-        The expected output path.
+    output : str | list[str] | tuple[str, ...]
+        The expected output path or paths.
     log : str | None
         Optional path to capture stdout/stderr.
 
@@ -50,4 +53,7 @@ def shell_task(*, cmd: str, output: str, log: str | None = None) -> ShellExpr:
     -------
     ShellExpr
     """
+    if isinstance(output, list | tuple) and not output:
+        raise ValueError("shell_task output must contain at least one declared path")
+
     return ShellExpr(cmd=cmd, output=output, log=log)

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -1123,7 +1123,7 @@ class _ConcurrentEvaluator:
         return coerced
 
     def _run_shell(self, *, node: _TaskNode, shell_expr: ShellExpr) -> Any:
-        """Execute a shell command and return its declared output path."""
+        """Execute a shell command and return its declared output path or paths."""
         task_def = node.task_def
         user_log_path = Path(shell_expr.log) if shell_expr.log is not None else None
 
@@ -1131,6 +1131,10 @@ class _ConcurrentEvaluator:
         for path in (node.stdout_path, node.stderr_path, user_log_path):
             if path is not None:
                 path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Ensure declared output parents exist before running the command.
+        for output_path in self._iter_shell_output_paths(shell_expr.output):
+            output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Build the argv: wrap through pixi when the task declares an env.
         if task_def.env is not None and self.pixi_registry is not None:
@@ -1167,11 +1171,15 @@ class _ConcurrentEvaluator:
                 log=shell_expr.log,
             )
 
-        output_path = Path(shell_expr.output)
-        if not output_path.exists():
+        missing_outputs = [
+            str(output_path)
+            for output_path in self._iter_shell_output_paths(shell_expr.output)
+            if not output_path.exists()
+        ]
+        if missing_outputs:
+            missing_label = missing_outputs[0] if len(missing_outputs) == 1 else missing_outputs
             raise FileNotFoundError(
-                f"Shell task {task_def.name} completed but did not create output "
-                f"{shell_expr.output!r}"
+                f"Shell task {task_def.name} completed but did not create output {missing_label!r}"
             )
 
         return self._coerce_return_value(task_def=task_def, value=shell_expr.output)
@@ -1339,9 +1347,54 @@ class _ConcurrentEvaluator:
     def _coerce_return_value(self, *, task_def: TaskDef, value: Any) -> Any:
         """Coerce string returns into the declared Ginkgo path marker type."""
         annotation = task_def.type_hints.get("return", task_def.signature.return_annotation)
+        return self._coerce_annotated_value(annotation=annotation, value=value)
+
+    def _coerce_annotated_value(self, *, annotation: Any, value: Any) -> Any:
+        """Coerce values recursively for direct and container-wrapped path types."""
+        if annotation in {None, Any}:
+            return value
+
+        origin = get_origin(annotation)
+        if origin is list and isinstance(value, list):
+            inner_annotations = get_args(annotation)
+            inner_annotation = inner_annotations[0] if inner_annotations else Any
+            return [
+                self._coerce_annotated_value(annotation=inner_annotation, value=item)
+                for item in value
+            ]
+
+        if origin is tuple and isinstance(value, tuple):
+            inner_annotations = get_args(annotation)
+            if len(inner_annotations) == 2 and inner_annotations[1] is Ellipsis:
+                inner_annotation = inner_annotations[0]
+                return tuple(
+                    self._coerce_annotated_value(annotation=inner_annotation, value=item)
+                    for item in value
+                )
+
+            if inner_annotations and len(inner_annotations) == len(value):
+                return tuple(
+                    self._coerce_annotated_value(annotation=item_annotation, value=item)
+                    for item_annotation, item in zip(inner_annotations, value, strict=True)
+                )
+
+            inner_annotation = inner_annotations[0] if inner_annotations else Any
+            return tuple(
+                self._coerce_annotated_value(annotation=inner_annotation, value=item)
+                for item in value
+            )
+
         if annotation in {file, folder, tmp_dir} and isinstance(value, str):
             return annotation(value)
+
         return value
+
+    def _iter_shell_output_paths(self, output: str | list[str] | tuple[str, ...]) -> list[Path]:
+        """Return concrete output paths for a shell task declaration."""
+        if isinstance(output, str):
+            return [Path(output)]
+
+        return [Path(item) for item in output]
 
     def _is_valid_cached_result(self, *, task_def: TaskDef, value: Any) -> bool:
         """Return whether a cached value still satisfies return validation."""

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -73,6 +73,38 @@ def shell_missing_output_task(output_path: str) -> file:
     return shell_task(cmd="true", output=output_path)
 
 
+@task()
+def shell_write_multiple_outputs_task(
+    output_one: str,
+    output_two: str,
+    marker_path: str,
+) -> tuple[file, file]:
+    return shell_task(
+        cmd=(
+            f"printf 'left' > {output_one}; "
+            f"printf 'right' > {output_two}; "
+            f"printf 'run\\n' >> {marker_path}"
+        ),
+        output=(output_one, output_two),
+    )
+
+
+@task()
+def shell_write_list_outputs_task(output_one: str, output_two: str) -> list[file]:
+    return shell_task(
+        cmd=f"printf 'left' > {output_one}; printf 'right' > {output_two}",
+        output=[output_one, output_two],
+    )
+
+
+@task()
+def shell_missing_multiple_outputs_task(output_one: str, output_two: str) -> tuple[file, file]:
+    return shell_task(
+        cmd=f"printf 'left' > {output_one}",
+        output=(output_one, output_two),
+    )
+
+
 @task(retries=2)
 def flaky_shell_task(marker_path: str, output_path: str, log_path: str) -> file:
     return shell_task(
@@ -321,6 +353,49 @@ class TestShellTask:
         with pytest.raises(FileNotFoundError, match="did not create output"):
             evaluate(shell_missing_output_task(output_path=str(output)))
 
+    def test_shell_task_supports_multiple_outputs_and_creates_parent_dirs(self, tmp_path: Path):
+        output_one = tmp_path / "results" / "reads" / "sample_1.fastq.gz"
+        output_two = tmp_path / "results" / "reads" / "sample_2.fastq.gz"
+        marker = tmp_path / "command.log"
+
+        result = evaluate(
+            shell_write_multiple_outputs_task(
+                output_one=str(output_one),
+                output_two=str(output_two),
+                marker_path=str(marker),
+            )
+        )
+
+        assert result == (file(str(output_one)), file(str(output_two)))
+        assert output_one.read_text(encoding="utf-8") == "left"
+        assert output_two.read_text(encoding="utf-8") == "right"
+        assert marker.read_text(encoding="utf-8").splitlines() == ["run"]
+
+    def test_shell_task_supports_list_outputs(self, tmp_path: Path):
+        output_one = tmp_path / "list" / "sample_1.fastq.gz"
+        output_two = tmp_path / "list" / "sample_2.fastq.gz"
+
+        result = evaluate(
+            shell_write_list_outputs_task(
+                output_one=str(output_one),
+                output_two=str(output_two),
+            )
+        )
+
+        assert result == [file(str(output_one)), file(str(output_two))]
+
+    def test_shell_task_requires_all_declared_outputs_to_exist(self, tmp_path: Path):
+        output_one = tmp_path / "results" / "sample_1.fastq.gz"
+        output_two = tmp_path / "results" / "sample_2.fastq.gz"
+
+        with pytest.raises(FileNotFoundError, match=str(output_two)):
+            evaluate(
+                shell_missing_multiple_outputs_task(
+                    output_one=str(output_one),
+                    output_two=str(output_two),
+                )
+            )
+
     def test_shell_task_retries_allow_transient_failures(self, tmp_path: Path):
         marker = tmp_path / "flaky-shell.marker"
         output = tmp_path / "flaky-shell.txt"
@@ -337,6 +412,30 @@ class TestShellTask:
         assert result == file(str(output))
         assert output.read_text(encoding="utf-8") == "payload"
         assert "transient shell failure" in log.read_text(encoding="utf-8")
+
+    def test_multi_output_shell_task_is_restored_from_cache(self, tmp_path: Path):
+        output_one = tmp_path / "cached" / "sample_1.fastq.gz"
+        output_two = tmp_path / "cached" / "sample_2.fastq.gz"
+        marker = tmp_path / "cached-runs.log"
+
+        first = evaluate(
+            shell_write_multiple_outputs_task(
+                output_one=str(output_one),
+                output_two=str(output_two),
+                marker_path=str(marker),
+            )
+        )
+        second = evaluate(
+            shell_write_multiple_outputs_task(
+                output_one=str(output_one),
+                output_two=str(output_two),
+                marker_path=str(marker),
+            )
+        )
+
+        assert first == (file(str(output_one)), file(str(output_two)))
+        assert second == first
+        assert marker.read_text(encoding="utf-8").splitlines() == ["run"]
 
     def test_pixi_environment_is_prepared_once_before_shell_fan_out(
         self,


### PR DESCRIPTION
## Summary
- allow `shell_task(output=...)` to accept flat lists and tuples of declared outputs
- create parent directories for declared shell outputs before execution and validate every output exists
- return and cache the full multi-output value with regression coverage for success, failure, and cache reuse

## Testing
- pixi run pytest tests/test_evaluator.py -q
- pixi run pytest tests/test_vw_pixi.py -q
- pixi run ruff check src/ginkgo/core/shell.py src/ginkgo/runtime/evaluator.py tests/test_evaluator.py
- pixi run ruff format --check src/ginkgo/core/shell.py src/ginkgo/runtime/evaluator.py tests/test_evaluator.py
- pixi run ty check src/ginkgo/core/shell.py