### PR TITLE
Add workflow authoring helpers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,8 @@ Ginkgo is a Python-based workflow orchestrator for scientific and data workflows
 The repository currently implements:
 
 - Declarative workflow construction with `@flow`, `@task()`, `Expr`, and `ExprList`
+- Workflow authoring helpers via `expand(...)`, `zip_expand(...)`, `flatten(...)`, and `slug(...)`
+  for concise deterministic workflow authoring
 - Dynamic DAG expansion when tasks return nested `Expr` or `ExprList` values
 - Explicit task kinds via `@task(kind="python" | "shell")`
 - Content-addressed caching for scalar values, files, folders, arrays, DataFrames, and other supported Python objects
@@ -58,6 +60,7 @@ The current source tree is organized around the user-facing DSL, the execution e
 src/ginkgo/
 ├── __init__.py
 ├── config.py
+├── helpers.py
 ├── core/
 │   ├── expr.py
 │   ├── flow.py
@@ -91,6 +94,13 @@ src/ginkgo/
 `@task()`-decorated functions do not execute when called. They return `Expr[T]` values that describe deferred computation. A `@flow` function is the entrypoint that builds the initial expression tree.
 
 `ExprList[T]` is produced by `.map()` on a partially applied task and represents fan-out across multiple independent task invocations.
+
+Ginkgo also exposes small workflow-authoring helpers:
+
+- `expand(template, **wildcards)` for Cartesian wildcard expansion in placeholder order
+- `zip_expand(template, **wildcards)` for positional wildcard expansion with equal-length iterables
+- `flatten(items)` for flattening nested list/tuple structures into a single list
+- `slug(value)` for deterministic file-safe artifact names
 
 ### Dynamic DAG Expansion
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -56,6 +56,7 @@ Each phase is independently testable and follows the same structure:
 - Cache explanation tooling that reports why a task was cached or rerun.
 - Machine-readable inspection output for workflows, tasks, dependencies, envs, resources, and cache metadata.
 - Extend `ginkgo init` so project scaffolding also creates or installs a standard set of agent skills alongside the project template.
+- Add agent-facing notebook prototyping support based on the [`datalayer/jupyter-mcp-server`](https://github.com/datalayer/jupyter-mcp-server), with project-local notebooks stored under `workflow/notebooks/`.
 - Ongoing improvements to scaffolding templates and installed skills for common Ginkgo project types.
 
 ### Key design points
@@ -64,6 +65,7 @@ Each phase is independently testable and follows the same structure:
 - The linter and doctor commands should share the same validation logic as the runtime.
 - Cache explanation should rely on real cache-key components, not heuristic guesses.
 - Agent-skill bootstrapping should be deterministic and idempotent so rerunning `ginkgo init` or upgrading templates does not leave projects in a half-installed state.
+- Agent-oriented prototyping should happen in Jupyter notebooks accessed through the Jupyter MCP server, with a standard on-disk location at `workflow/notebooks/` so both humans and agents can discover and reuse exploratory work consistently.
 
 ### Validation
 
@@ -72,6 +74,7 @@ Each phase is independently testable and follows the same structure:
 - Assert cache explain reports a version bump, env lock hash change, and changed input file contents as distinct rerun reasons.
 - Assert the inspect API returns dependency edges, task metadata, and resource declarations in deterministic JSON.
 - Assert `ginkgo init` creates or installs the expected agent-skill set and that the resulting project is immediately usable by the agent without manual skill setup.
+- Assert initialized projects expose the expected notebook prototyping path at `workflow/notebooks/` and can be connected to the configured Jupyter MCP workflow without ad hoc directory setup.
 
 ---
 

--- a/examples/news/newsroom/modules/packets.py
+++ b/examples/news/newsroom/modules/packets.py
@@ -7,12 +7,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from ginkgo import ExprList, file, task
-
-
-def _safe_slug(value: str) -> str:
-    """Return a file-safe slug for a desk or artifact name."""
-    return "".join(ch if ch.isalnum() else "_" for ch in value.lower()).strip("_")
+from ginkgo import ExprList, expand, file, slug, task
 
 
 @task()
@@ -31,7 +26,7 @@ def write_desk_packet(desk: str, stories: list[dict[str, object]]) -> file:
                 f"(priority={item['priority_score']}, band={item['publish_band']})"
             )
         )
-    output = Path(f"results/desk_packets/{_safe_slug(desk)}_packet.md")
+    output = Path(f"results/desk_packets/{slug(desk)}_packet.md")
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return file(str(output))
@@ -83,8 +78,7 @@ def compile_newsroom_digest(
         )
 
     lines.extend(["", "## Desk Packets"])
-    for packet_path in desk_packets:
-        lines.append(f"- {packet_path}")
+    lines.extend(expand("- {packet_path}", packet_path=desk_packets))
 
     output = Path("results/newsroom_digest.md")
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ginkgo/__init__.py
+++ b/src/ginkgo/__init__.py
@@ -16,12 +16,16 @@ _EXPORTS = {
     "ShellExpr": ("ginkgo.core.shell", "ShellExpr"),
     "TaskDef": ("ginkgo.core.task", "TaskDef"),
     "evaluate": ("ginkgo.runtime.evaluator", "evaluate"),
+    "expand": ("ginkgo.helpers", "expand"),
+    "flatten": ("ginkgo.helpers", "flatten"),
     "file": ("ginkgo.core.types", "file"),
     "flow": ("ginkgo.core.flow", "flow"),
     "folder": ("ginkgo.core.types", "folder"),
     "shell": ("ginkgo.core.shell", "shell"),
+    "slug": ("ginkgo.helpers", "slug"),
     "task": ("ginkgo.core.task", "task"),
     "tmp_dir": ("ginkgo.core.types", "tmp_dir"),
+    "zip_expand": ("ginkgo.helpers", "zip_expand"),
 }
 
 _LEGACY_MODULE_ALIASES = {

--- a/src/ginkgo/helpers.py
+++ b/src/ginkgo/helpers.py
@@ -1,0 +1,184 @@
+"""Workflow authoring helper utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from itertools import product
+from string import Formatter
+from typing import Any
+
+
+def _placeholder_names(*, template: str, function_name: str) -> list[str]:
+    """Return simple named placeholders in first-appearance order."""
+    formatter = Formatter()
+    names: list[str] = []
+    seen_names: set[str] = set()
+
+    for _, field_name, _, _ in formatter.parse(template):
+        if field_name is None:
+            continue
+        if not field_name.isidentifier():
+            raise ValueError(
+                f"{function_name}() only supports simple named placeholders like "
+                f"'{{sample}}'; got {field_name!r} in template {template!r}."
+            )
+        if field_name not in seen_names:
+            seen_names.add(field_name)
+            names.append(field_name)
+
+    return names
+
+
+def _normalize_wildcards(
+    *,
+    template: str,
+    function_name: str,
+    wildcards: dict[str, Iterable[Any]],
+) -> tuple[list[str], list[list[Any]]]:
+    """Validate wildcard names and normalize iterable values to lists."""
+    placeholder_names = _placeholder_names(template=template, function_name=function_name)
+
+    missing_names = [name for name in placeholder_names if name not in wildcards]
+    if missing_names:
+        raise ValueError(
+            f"{function_name}() template {template!r} references wildcard(s) "
+            f"{missing_names!r} without matching keyword arguments."
+        )
+
+    extra_names = sorted(name for name in wildcards if name not in placeholder_names)
+    if extra_names:
+        raise ValueError(
+            f"{function_name}() received wildcard argument(s) {extra_names!r} that do not appear "
+            f"in template {template!r}."
+        )
+
+    wildcard_values: list[list[Any]] = []
+    for name in placeholder_names:
+        values = wildcards[name]
+        if isinstance(values, str | bytes):
+            raise ValueError(
+                f"{function_name}() wildcard {name!r} must be an iterable of values, "
+                f"not {type(values).__name__}."
+            )
+        wildcard_values.append(list(values))
+
+    return placeholder_names, wildcard_values
+
+
+def expand(template: str, **wildcards: Iterable[Any]) -> list[str]:
+    """Expand a string template across wildcard combinations.
+
+    Parameters
+    ----------
+    template : str
+        Template containing named ``str.format`` placeholders.
+    **wildcards : collections.abc.Iterable[Any]
+        Iterable values for each placeholder in ``template``.
+
+    Returns
+    -------
+    list[str]
+        Expanded strings in deterministic Cartesian-product order.
+    """
+    placeholder_names, wildcard_values = _normalize_wildcards(
+        template=template,
+        function_name="expand",
+        wildcards=wildcards,
+    )
+    if not placeholder_names:
+        return [template]
+
+    return [
+        template.format_map(dict(zip(placeholder_names, combination, strict=True)))
+        for combination in product(*wildcard_values)
+    ]
+
+
+def zip_expand(template: str, **wildcards: Iterable[Any]) -> list[str]:
+    """Expand a string template by zipping wildcard values positionally.
+
+    Parameters
+    ----------
+    template : str
+        Template containing named ``str.format`` placeholders.
+    **wildcards : collections.abc.Iterable[Any]
+        Iterable values for each placeholder in ``template``.
+
+    Returns
+    -------
+    list[str]
+        Expanded strings in deterministic positional order.
+    """
+    placeholder_names, wildcard_values = _normalize_wildcards(
+        template=template,
+        function_name="zip_expand",
+        wildcards=wildcards,
+    )
+    if not placeholder_names:
+        return [template]
+
+    lengths = {len(values) for values in wildcard_values}
+    if len(lengths) > 1:
+        raise ValueError(
+            f"zip_expand() wildcard iterables must have equal lengths; got lengths "
+            f"{[len(values) for values in wildcard_values]!r} for template {template!r}."
+        )
+
+    return [
+        template.format_map(dict(zip(placeholder_names, combination, strict=True)))
+        for combination in zip(*wildcard_values, strict=True)
+    ]
+
+
+def slug(value: str) -> str:
+    """Return a deterministic file-safe slug.
+
+    Parameters
+    ----------
+    value : str
+        Input text to normalize.
+
+    Returns
+    -------
+    str
+        Lowercased slug with non-alphanumeric runs collapsed to underscores.
+    """
+    characters: list[str] = []
+    previous_was_separator = False
+
+    for character in value.lower():
+        if character.isalnum():
+            characters.append(character)
+            previous_was_separator = False
+            continue
+
+        if not previous_was_separator:
+            characters.append("_")
+            previous_was_separator = True
+
+    return "".join(characters).strip("_")
+
+
+def flatten(items: list[Any] | tuple[Any, ...]) -> list[Any]:
+    """Flatten nested lists and tuples into a single list.
+
+    Parameters
+    ----------
+    items : list[Any] | tuple[Any, ...]
+        Nested list or tuple structure.
+
+    Returns
+    -------
+    list[Any]
+        Flat list preserving left-to-right order.
+    """
+    flattened: list[Any] = []
+
+    # Flatten only explicit sequence containers to keep helper behavior predictable.
+    for item in items:
+        if isinstance(item, list | tuple):
+            flattened.extend(flatten(item))
+            continue
+        flattened.append(item)
+
+    return flattened

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,90 @@
+"""Unit tests for workflow authoring helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ginkgo import expand, flatten, slug, zip_expand
+
+
+class TestExpand:
+    def test_expands_single_wildcard(self) -> None:
+        assert expand("results/{sample}.txt", sample=["a", "b", "c"]) == [
+            "results/a.txt",
+            "results/b.txt",
+            "results/c.txt",
+        ]
+
+    def test_expands_cartesian_product_in_template_order(self) -> None:
+        assert expand("{a}_{b}", b=["x", "y"], a=[1, 2]) == [
+            "1_x",
+            "1_y",
+            "2_x",
+            "2_y",
+        ]
+
+    def test_reuses_repeated_placeholder(self) -> None:
+        assert expand("{sample}/{sample}.txt", sample=["alpha", "beta"]) == [
+            "alpha/alpha.txt",
+            "beta/beta.txt",
+        ]
+
+    def test_returns_template_when_no_placeholders_are_present(self) -> None:
+        assert expand("results/static.txt") == ["results/static.txt"]
+
+    def test_raises_for_missing_wildcard(self) -> None:
+        with pytest.raises(ValueError, match="references wildcard"):
+            expand("results/{sample}.txt", batch=["a"])
+
+    def test_raises_for_extra_wildcard(self) -> None:
+        with pytest.raises(ValueError, match="do not appear"):
+            expand("results/{sample}.txt", sample=["a"], batch=["b"])
+
+    def test_raises_for_non_simple_placeholder(self) -> None:
+        with pytest.raises(ValueError, match="simple named placeholders"):
+            expand("results/{sample.name}.txt", sample=[{"name": "a"}])
+
+    def test_raises_for_string_wildcard_value(self) -> None:
+        with pytest.raises(ValueError, match="must be an iterable of values"):
+            expand("results/{sample}.txt", sample="abc")
+
+
+class TestZipExpand:
+    def test_expands_positionally(self) -> None:
+        assert zip_expand("results/{sample}_{lane}.txt", sample=["a", "b"], lane=[1, 2]) == [
+            "results/a_1.txt",
+            "results/b_2.txt",
+        ]
+
+    def test_reuses_expand_validation_for_non_simple_placeholders(self) -> None:
+        with pytest.raises(ValueError, match="simple named placeholders"):
+            zip_expand("results/{sample.name}.txt", sample=["a"])
+
+    def test_raises_for_unequal_lengths(self) -> None:
+        with pytest.raises(ValueError, match="equal lengths"):
+            zip_expand("results/{sample}_{lane}.txt", sample=["a"], lane=[1, 2])
+
+    def test_returns_template_when_no_placeholders_are_present(self) -> None:
+        assert zip_expand("results/static.txt") == ["results/static.txt"]
+
+
+class TestSlug:
+    def test_normalizes_mixed_content(self) -> None:
+        assert slug("Business Desk / Q1!") == "business_desk_q1"
+
+    def test_collapses_repeated_separators(self) -> None:
+        assert slug("alpha---beta___gamma") == "alpha_beta_gamma"
+
+    def test_returns_empty_string_for_separator_only_input(self) -> None:
+        assert slug(" --- ") == ""
+
+
+class TestFlatten:
+    def test_flattens_nested_lists_and_tuples(self) -> None:
+        assert flatten([1, (2, 3), [4, [5, 6]]]) == [1, 2, 3, 4, 5, 6]
+
+    def test_preserves_strings_and_scalars(self) -> None:
+        assert flatten(["ab", ["cd"], 3]) == ["ab", "cd", 3]
+
+    def test_returns_empty_list_for_empty_input(self) -> None:
+        assert flatten([]) == []


### PR DESCRIPTION
## Summary
- add public workflow authoring helpers: `expand`, `zip_expand`, `slug`, and `flatten`
- add focused unit coverage for helper behavior and validation
- update the newsroom example and docs to reflect the new helper surface

## Testing
- pytest tests/test_helpers.py tests/test_examples.py -q
- pixi run ruff check src/ginkgo/helpers.py src/ginkgo/__init__.py tests/test_helpers.py examples/news/newsroom/modules/packets.py