### PR TITLE
feat: phase 2 cache integrity

### DIFF
--- a/ginkgo/cli/commands/cache.py
+++ b/ginkgo/cli/commands/cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 import re
@@ -16,6 +17,7 @@ from rich.text import Text
 
 from ginkgo.cli.common import CACHE_ROOT, console
 from ginkgo.cli.renderers.common import _task_base_name
+from ginkgo.runtime.artifact_store import _make_writable_recursive
 
 
 def command_cache(args) -> int:
@@ -74,7 +76,10 @@ def command_cache(args) -> int:
             return 0
 
         for entry in entries:
-            shutil.rmtree(entry.path)
+            _safe_rmtree(entry.path)
+
+        # Clean up orphaned artifacts after pruning.
+        _gc_orphan_artifacts(CACHE_ROOT)
 
         rich_console.print(
             f"[green]✓[/] Removed [bold]{len(entries)}[/] cache "
@@ -86,7 +91,10 @@ def command_cache(args) -> int:
     cache_dir = CACHE_ROOT / args.cache_key
     if not cache_dir.is_dir():
         raise FileNotFoundError(f"Cache entry not found: {args.cache_key}")
-    shutil.rmtree(cache_dir)
+    _safe_rmtree(cache_dir)
+
+    # Clean up orphaned artifacts after clearing.
+    _gc_orphan_artifacts(CACHE_ROOT)
     rich_console.print("[bold green]🌿 ginkgo cache[/] [bold]clear[/]\n")
     message = Text()
     message.append("✓ ", style="green")
@@ -218,3 +226,47 @@ def _parse_duration_seconds(value: str):
     from datetime import timedelta
 
     return timedelta(seconds=count * multipliers[unit])
+
+
+def _safe_rmtree(path: Path) -> None:
+    """Remove a cache entry directory, handling read-only artifacts."""
+    try:
+        shutil.rmtree(path)
+    except PermissionError:
+        _make_writable_recursive(path)
+        shutil.rmtree(path)
+
+
+def _gc_orphan_artifacts(cache_root: Path) -> None:
+    """Remove artifacts not referenced by any remaining cache entry.
+
+    Scans all ``meta.json`` files under *cache_root* to collect referenced
+    artifact IDs, then deletes any artifacts in the sibling ``artifacts/``
+    directory that are not referenced.
+    """
+    artifacts_root = cache_root.parent / "artifacts"
+    if not artifacts_root.exists():
+        return
+
+    # Collect all referenced artifact IDs from surviving cache entries.
+    referenced: set[str] = set()
+    for entry_dir in cache_root.iterdir():
+        if not entry_dir.is_dir():
+            continue
+        meta_path = entry_dir / "meta.json"
+        if not meta_path.exists():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        for artifact_id in meta.get("artifact_ids", {}).values():
+            referenced.add(artifact_id)
+
+    # Remove orphaned artifacts.
+    from ginkgo.runtime.artifact_store import LocalArtifactStore
+
+    store = LocalArtifactStore(root=artifacts_root)
+    for child in list(artifacts_root.iterdir()):
+        if child.name not in referenced:
+            store.delete(artifact_id=child.name)

--- a/ginkgo/core/task.py
+++ b/ginkgo/core/task.py
@@ -44,6 +44,7 @@ class TaskDef:
     _signature: inspect.Signature = field(init=False, repr=False)
     _type_hints: dict[str, Any] = field(init=False, repr=False)
     _required_params: frozenset[str] = field(init=False, repr=False)
+    _source_hash: str = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.retries < 0:
@@ -63,6 +64,7 @@ class TaskDef:
         object.__setattr__(self, "_signature", sig)
         object.__setattr__(self, "_type_hints", hints)
         object.__setattr__(self, "_required_params", required)
+        object.__setattr__(self, "_source_hash", _compute_source_hash(self.fn))
 
     @property
     def name(self) -> str:
@@ -96,6 +98,11 @@ class TaskDef:
     def type_hints(self) -> dict[str, Any]:
         """Resolved runtime type hints for the wrapped function."""
         return dict(self._type_hints)
+
+    @property
+    def source_hash(self) -> str:
+        """SHA-256 digest of the task function's source code."""
+        return self._source_hash
 
     def __call__(self, **kwargs: Any) -> Expr | PartialCall:
         """Build an ``Expr`` (all required args supplied) or ``PartialCall``.
@@ -259,6 +266,36 @@ def task(
         return TaskDef(fn=fn, env=env, version=version, retries=retries, kind=kind)
 
     return decorator
+
+
+def _compute_source_hash(fn: Callable[..., Any]) -> str:
+    """Return the SHA-256 digest of a function's source code.
+
+    Parameters
+    ----------
+    fn : Callable
+        The function to hash.
+
+    Returns
+    -------
+    str
+        Hex-encoded SHA-256 digest.
+
+    Raises
+    ------
+    ValueError
+        If the source cannot be extracted (lambdas, dynamic functions).
+    """
+    from ginkgo.runtime.hashing import hash_str
+
+    try:
+        source = inspect.getsource(fn)
+    except OSError as exc:
+        raise ValueError(
+            f"Cannot extract source for task '{fn.__qualname__}'. "
+            "Tasks must be defined as named, top-level functions."
+        ) from exc
+    return hash_str(source)
 
 
 def _load_taskdef(module_name: str, task_name: str) -> TaskDef:

--- a/ginkgo/envs/container.py
+++ b/ginkgo/envs/container.py
@@ -213,11 +213,11 @@ class ContainerBackend:
             cmd,
         ]
 
-    def python_argv_c(
+    def python_argv_m(
         self,
         *,
         env: str,
-        code: str,
+        module: str,
         args: Sequence[str] = (),
     ) -> list[str]:
         """Container environments only support shell tasks.

--- a/ginkgo/envs/pixi.py
+++ b/ginkgo/envs/pixi.py
@@ -355,21 +355,17 @@ class PixiRegistry:
             cmd,
         ]
 
-    def python_argv_c(self, *, env: str, code: str, args: Sequence[str] = ()) -> list[str]:
-        """Build argv to run Python *code* with ``-c`` inside the Pixi environment.
-
-        Using ``-c`` instead of running a script file avoids adding the script's
-        directory to ``sys.path``, which would cause module-name collisions with
-        stdlib modules (e.g. ``ginkgo/types.py`` shadowing ``types``).
+    def python_argv_m(self, *, env: str, module: str, args: Sequence[str] = ()) -> list[str]:
+        """Build argv to run a Python *module* with ``-m`` inside the Pixi environment.
 
         Parameters
         ----------
         env : str
             Environment name or path.
-        code : str
-            Python source code to pass to ``python -c``.
+        module : str
+            Fully-qualified module name to pass to ``python -m``.
         args : Sequence[str]
-            Positional arguments available as ``sys.argv[1:]`` inside *code*.
+            Positional arguments available as ``sys.argv[1:]`` inside the module.
 
         Returns
         -------
@@ -384,8 +380,8 @@ class PixiRegistry:
             str(manifest),
             "--",
             "python",
-            "-c",
-            code,
+            "-m",
+            module,
             *args,
         ]
 

--- a/ginkgo/envs/pixi.py
+++ b/ginkgo/envs/pixi.py
@@ -9,7 +9,7 @@ the normal Pixi path.
 
 from __future__ import annotations
 
-import hashlib
+
 import subprocess
 import shutil
 from dataclasses import dataclass, field
@@ -396,12 +396,10 @@ class PixiRegistry:
 
 
 def _hash_file(path: Path) -> str:
-    """Return the SHA-256 hex digest of a file's contents."""
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(65536), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+    """Return the BLAKE3 hex digest of a file's contents."""
+    from ginkgo.runtime.hashing import hash_file
+
+    return hash_file(path)
 
 
 def _require_pixi() -> None:

--- a/ginkgo/envs/pixi_worker.py
+++ b/ginkgo/envs/pixi_worker.py
@@ -1,19 +1,23 @@
-"""Reference implementation of the Pixi Python task worker.
+"""Pixi Python task worker — runnable as ``python -m ginkgo.envs.pixi_worker``.
 
-The evaluator does NOT run this file directly as a script (doing so would add
-the worker package directory to ``sys.path[0]`` and make imports fragile).
+The evaluator dispatches pixi-environment Python tasks by running::
 
-Instead, the evaluator uses ``python -c`` with inline code equivalent to
-the body of :func:`run` below.  This file exists for human readability.
+    pixi run -- python -m ginkgo.envs.pixi_worker <input_path> <output_path>
 
-The actual inline code used by the evaluator is built in
-:meth:`_ConcurrentEvaluator._run_env_python_task`.
+This avoids the ``python -c`` inline-string approach and relies on ginkgo
+being a proper installed dependency inside every pixi environment.
+
+Dynamic results (ShellExpr, Expr, ExprList) are not JSON-serializable, so
+when ``run_task`` returns one the result is pickle+base64 encoded under the
+special encoding ``"pixi_direct_pickled"`` for the main process to decode.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 import pathlib
+import pickle
 import sys
 from typing import Any
 
@@ -30,12 +34,21 @@ def run(input_path: pathlib.Path, output_path: pathlib.Path) -> None:
     """
     payload: dict[str, Any] = json.loads(input_path.read_bytes())
 
-    # Inject only the Ginkgo package roots required to bootstrap the worker.
-    for p in payload.get("ginkgo_import_roots", []):
-        if p not in sys.path:
-            sys.path.insert(0, p)
-
     from ginkgo.runtime.worker import run_task  # noqa: PLC0415
 
-    result = run_task(payload)
+    result: dict[str, Any] = dict(run_task(payload))
+
+    # Dynamic results cross the JSON bridge as pickle+base64.
+    enc = result.get("result_encoding")
+    if result.get("ok") and enc == "direct":
+        result["result"] = base64.b64encode(pickle.dumps(result["result"], 5)).decode()
+        result["result_encoding"] = "pixi_direct_pickled"
+
     output_path.write_text(json.dumps(result), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    run(
+        input_path=pathlib.Path(sys.argv[1]),
+        output_path=pathlib.Path(sys.argv[2]),
+    )

--- a/ginkgo/runtime/artifact_store.py
+++ b/ginkgo/runtime/artifact_store.py
@@ -1,0 +1,339 @@
+"""Content-addressed artifact storage for Ginkgo.
+
+The ``ArtifactStore`` protocol defines the contract for storing and retrieving
+binary artifacts.  ``LocalArtifactStore`` is the default implementation that
+stores artifacts on the local filesystem under ``.ginkgo/artifacts/``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import stat
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from ginkgo.runtime.hashing import hash_bytes, hash_file, new_hasher
+
+
+@runtime_checkable
+class ArtifactStore(Protocol):
+    """Protocol for content-addressed artifact storage.
+
+    Artifact IDs use the format ``<sha256>.<ext>`` for files and ``<sha256>``
+    for directories.  This identity scheme is consumed directly by downstream
+    phases (remote artifact store, asset catalog, versioned assets).
+    """
+
+    def store(self, *, src_path: Path) -> str:
+        """Copy bytes into the store and return a content-addressed artifact ID.
+
+        Parameters
+        ----------
+        src_path : Path
+            Source file or directory to store.
+
+        Returns
+        -------
+        str
+            Artifact ID in the form ``<sha256>.<ext>`` (file) or ``<sha256>``
+            (directory).
+        """
+        ...
+
+    def retrieve(self, *, artifact_id: str, dest_path: Path) -> None:
+        """Materialise an artifact at *dest_path* as a symlink.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID returned by :meth:`store`.
+        dest_path : Path
+            Location where the symlink should be created.
+        """
+        ...
+
+    def exists(self, *, artifact_id: str) -> bool:
+        """Return whether an artifact exists in the store.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID to check.
+
+        Returns
+        -------
+        bool
+        """
+        ...
+
+    def delete(self, *, artifact_id: str) -> None:
+        """Remove an artifact from the store.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID to remove.
+        """
+        ...
+
+    def artifact_path(self, *, artifact_id: str) -> Path:
+        """Return the absolute filesystem path for an artifact.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID.
+
+        Returns
+        -------
+        Path
+        """
+        ...
+
+    def store_bytes(self, *, data: bytes, extension: str) -> str:
+        """Store raw bytes and return a content-addressed artifact ID.
+
+        Parameters
+        ----------
+        data : bytes
+            Raw bytes to store.
+        extension : str
+            File extension (without leading dot).
+
+        Returns
+        -------
+        str
+            Artifact ID.
+        """
+        ...
+
+    def read_bytes(self, *, artifact_id: str) -> bytes:
+        """Read raw bytes for an artifact.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID.
+
+        Returns
+        -------
+        bytes
+        """
+        ...
+
+
+class LocalArtifactStore:
+    """Local filesystem artifact store.
+
+    Parameters
+    ----------
+    root : Path
+        Root directory for artifact storage.  Defaults to
+        ``.ginkgo/artifacts`` under the current working directory.
+    """
+
+    def __init__(self, *, root: Path | None = None) -> None:
+        self._root = root if root is not None else Path.cwd() / ".ginkgo" / "artifacts"
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def store(self, *, src_path: Path) -> str:
+        """Copy a file or directory into the store.
+
+        Parameters
+        ----------
+        src_path : Path
+            Source file or directory to store.
+
+        Returns
+        -------
+        str
+            Content-addressed artifact ID.
+        """
+        if src_path.is_dir():
+            return self._store_directory(src_path)
+        return self._store_file(src_path)
+
+    def retrieve(self, *, artifact_id: str, dest_path: Path) -> None:
+        """Create a symlink at *dest_path* pointing to the stored artifact.
+
+        Parameters
+        ----------
+        artifact_id : str
+            Artifact ID returned by :meth:`store`.
+        dest_path : Path
+            Target symlink location.  Parent directories are created if needed.
+        """
+        target = self._root / artifact_id
+        if not target.exists():
+            raise FileNotFoundError(f"Artifact not found in store: {artifact_id}")
+
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        if dest_path.is_symlink() or dest_path.exists():
+            if dest_path.is_symlink():
+                dest_path.unlink()
+            elif dest_path.is_dir():
+                shutil.rmtree(dest_path)
+            else:
+                dest_path.unlink()
+        dest_path.symlink_to(target)
+
+    def exists(self, *, artifact_id: str) -> bool:
+        """Check whether an artifact exists in the store.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID to check.
+
+        Returns
+        -------
+        bool
+        """
+        return (self._root / artifact_id).exists()
+
+    def delete(self, *, artifact_id: str) -> None:
+        """Remove an artifact from the store.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID to remove.
+        """
+        target = self._root / artifact_id
+        if not target.exists():
+            return
+        if target.is_dir():
+            _make_writable_recursive(target)
+            shutil.rmtree(target)
+        else:
+            target.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            target.unlink()
+
+    def artifact_path(self, *, artifact_id: str) -> Path:
+        """Return the absolute path for an artifact.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID.
+
+        Returns
+        -------
+        Path
+        """
+        return self._root / artifact_id
+
+    def _store_file(self, src_path: Path) -> str:
+        """Store a single file, returning its artifact ID."""
+        digest = hash_file(src_path)
+        ext = src_path.suffix.lstrip(".")
+        artifact_id = f"{digest}.{ext}" if ext else digest
+        dest = self._root / artifact_id
+
+        # Content-addressed dedup: skip if already present.
+        if dest.exists():
+            return artifact_id
+
+        shutil.copy2(src_path, dest)
+        dest.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 0o444
+        return artifact_id
+
+    def _store_directory(self, src_path: Path) -> str:
+        """Store a directory tree, returning its artifact ID."""
+        digest = _hash_directory(src_path)
+        artifact_id = digest
+        dest = self._root / artifact_id
+
+        # Content-addressed dedup: skip if already present.
+        if dest.exists():
+            return artifact_id
+
+        shutil.copytree(src_path, dest)
+        _set_read_only_recursive(dest)
+        return artifact_id
+
+    def store_bytes(self, *, data: bytes, extension: str) -> str:
+        """Store raw bytes, returning a content-addressed artifact ID.
+
+        Parameters
+        ----------
+        data : bytes
+            Raw bytes to store.
+        extension : str
+            File extension (without leading dot).
+
+        Returns
+        -------
+        str
+            Artifact ID in the form ``<sha256>.<ext>``.
+        """
+        digest = hash_bytes(data)
+        artifact_id = f"{digest}.{extension}" if extension else digest
+        dest = self._root / artifact_id
+
+        if dest.exists():
+            return artifact_id
+
+        dest.write_bytes(data)
+        dest.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 0o444
+        return artifact_id
+
+    def read_bytes(self, *, artifact_id: str) -> bytes:
+        """Read raw bytes for an artifact.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID.
+
+        Returns
+        -------
+        bytes
+        """
+        target = self._root / artifact_id
+        if not target.exists():
+            raise FileNotFoundError(f"Artifact not found in store: {artifact_id}")
+        return target.read_bytes()
+
+
+def _hash_directory(path: Path) -> str:
+    """Return a BLAKE3 digest over a directory's recursive contents."""
+    hasher = new_hasher()
+    for child in sorted(path.rglob("*"), key=lambda p: str(p.relative_to(path))):
+        rel = str(child.relative_to(path))
+        if child.is_dir():
+            hasher.update(f"D:{rel}".encode("utf-8"))
+            continue
+        hasher.update(f"F:{rel}".encode("utf-8"))
+        hasher.update(hash_file(child).encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def _set_read_only_recursive(path: Path) -> None:
+    """Set a directory tree to read-only (files 0o444, dirs 0o555)."""
+    for child in path.rglob("*"):
+        if child.is_dir():
+            child.chmod(
+                stat.S_IRUSR
+                | stat.S_IXUSR
+                | stat.S_IRGRP
+                | stat.S_IXGRP
+                | stat.S_IROTH
+                | stat.S_IXOTH
+            )
+        else:
+            child.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    # Set the root directory itself.
+    path.chmod(
+        stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+    )
+
+
+def _make_writable_recursive(path: Path) -> None:
+    """Restore write permissions on a read-only directory tree before deletion."""
+    for child in path.rglob("*"):
+        if child.is_dir():
+            child.chmod(stat.S_IRWXU)
+        else:
+            child.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    path.chmod(stat.S_IRWXU)

--- a/ginkgo/runtime/backend.py
+++ b/ginkgo/runtime/backend.py
@@ -56,14 +56,14 @@ class TaskBackend(Protocol):
         """
         ...
 
-    def python_argv_c(
+    def python_argv_m(
         self,
         *,
         env: str,
-        code: str,
+        module: str,
         args: Sequence[str] = (),
     ) -> list[str]:
-        """Build an argument vector to run ``python -c`` inside the environment.
+        """Build an argument vector to run ``python -m`` inside the environment.
 
         Returns
         -------
@@ -113,15 +113,15 @@ class LocalBackend:
         """Build argv to run *cmd* through the Pixi environment."""
         return self.pixi_registry.shell_argv(env=env, cmd=cmd)
 
-    def python_argv_c(
+    def python_argv_m(
         self,
         *,
         env: str,
-        code: str,
+        module: str,
         args: Sequence[str] = (),
     ) -> list[str]:
-        """Build argv to run ``python -c`` through the Pixi environment."""
-        return self.pixi_registry.python_argv_c(env=env, code=code, args=args)
+        """Build argv to run ``python -m`` through the Pixi environment."""
+        return self.pixi_registry.python_argv_m(env=env, module=module, args=args)
 
     def env_lock_path(self, *, env: str) -> Path | None:
         """Return the path to the Pixi lock file for provenance capture."""
@@ -186,15 +186,15 @@ class CompositeBackend:
         """Delegate to the correct backend."""
         return self._route(env=env).shell_argv(env=env, cmd=cmd)
 
-    def python_argv_c(
+    def python_argv_m(
         self,
         *,
         env: str,
-        code: str,
+        module: str,
         args: Sequence[str] = (),
     ) -> list[str]:
         """Delegate to the correct backend."""
-        return self._route(env=env).python_argv_c(env=env, code=code, args=args)
+        return self._route(env=env).python_argv_m(env=env, module=module, args=args)
 
     def env_lock_path(self, *, env: str) -> Path | None:
         """Delegate to the correct backend."""

--- a/ginkgo/runtime/cache.py
+++ b/ginkgo/runtime/cache.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import shutil
@@ -14,6 +13,8 @@ from typing import Any, get_args, get_origin
 
 from ginkgo.core.task import TaskDef
 from ginkgo.core.types import file, folder, tmp_dir
+from ginkgo.runtime.artifact_store import LocalArtifactStore
+from ginkgo.runtime.hashing import hash_bytes, hash_file, hash_str, new_hasher
 from ginkgo.runtime.value_codec import (
     decode_value,
     encode_value,
@@ -37,16 +38,28 @@ class CacheStore:
         Execution backend used to resolve per-environment identity hashes.
         When ``None``, falls back to looking for a single ``pixi.lock`` in the
         current working directory (pre-Phase-5 behaviour).
+    artifact_store : LocalArtifactStore | None
+        Shared artifact store for content-addressed binary and file/folder
+        artifacts.  Created automatically when ``None``.
     """
 
     root: Path | None = None
     backend: Any | None = None  # TaskBackend; typed as Any to avoid circular import
+    artifact_store: LocalArtifactStore | None = None
     _root: Path = field(init=False, repr=False)
+    _artifact_store: LocalArtifactStore = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         root = self.root if self.root is not None else Path.cwd() / ".ginkgo" / "cache"
         object.__setattr__(self, "_root", Path(root))
         self._root.mkdir(parents=True, exist_ok=True)
+
+        if self.artifact_store is not None:
+            object.__setattr__(self, "_artifact_store", self.artifact_store)
+        else:
+            # Default: sibling directory to the cache root.
+            artifacts_root = self._root.parent / "artifacts"
+            object.__setattr__(self, "_artifact_store", LocalArtifactStore(root=artifacts_root))
 
     def build_cache_key(
         self,
@@ -67,11 +80,12 @@ class CacheStore:
             "env": task_def.env,
             "env_hash": env_hash,
             "inputs": input_hashes,
+            "source_hash": task_def.source_hash,
             "task": task_def.name,
             "version": task_def.version,
         }
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        return hashlib.sha256(encoded).hexdigest(), input_hashes
+        return hash_bytes(encoded), input_hashes
 
     def load(self, *, cache_key: str) -> Any:
         """Load a cached result if present."""
@@ -83,6 +97,7 @@ class CacheStore:
         return decode_value(
             json.loads(output_path.read_text(encoding="utf-8")),
             base_dir=entry_dir,
+            artifact_store=self._artifact_store,
         )
 
     def save(
@@ -94,40 +109,282 @@ class CacheStore:
         resolved_args: dict[str, Any],
         input_hashes: dict[str, Any],
     ) -> None:
-        """Atomically persist a task result and metadata."""
+        """Atomically persist a task result and metadata.
+
+        File and folder outputs are copied into the artifact store and replaced
+        with read-only symlinks at their original paths.
+        """
+        # Always store output artifacts and create symlinks, even if the cache
+        # entry already exists (handles re-execution after symlink replacement).
+        artifact_ids = self._store_output_artifacts(result=result, task_def=task_def)
+
         entry_dir = self._entry_dir(cache_key)
-        if entry_dir.exists():
+        if not entry_dir.exists():
+            temp_dir = Path(tempfile.mkdtemp(prefix=f"{cache_key}.tmp-", dir=self._root))
+            try:
+                output_path = temp_dir / "output.json"
+                output_path.write_text(
+                    json.dumps(
+                        encode_value(
+                            result, base_dir=temp_dir, artifact_store=self._artifact_store
+                        ),
+                        sort_keys=True,
+                    ),
+                    encoding="utf-8",
+                )
+
+                meta = {
+                    "artifact_ids": artifact_ids,
+                    "cache_key": cache_key,
+                    "env": task_def.env,
+                    "function": task_def.name,
+                    "inputs": self._serialise_inputs(
+                        task_def=task_def, resolved_args=resolved_args
+                    ),
+                    "input_hashes": input_hashes,
+                    "source_hash": task_def.source_hash,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "version": task_def.version,
+                }
+                (temp_dir / "meta.json").write_text(
+                    json.dumps(meta, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+
+                try:
+                    os.replace(temp_dir, entry_dir)
+                except FileExistsError:
+                    pass
+            finally:
+                if temp_dir.exists():
+                    shutil.rmtree(temp_dir)
+
+        # Replace original output paths with symlinks to the artifact store.
+        self._symlink_output_artifacts(result=result, task_def=task_def)
+
+    def validate_cached_outputs(self, *, task_def: TaskDef, value: Any) -> bool:
+        """Check whether cached file/folder outputs are valid symlinks.
+
+        Returns
+        -------
+        bool
+            ``True`` if all file/folder outputs are intact symlinks to the
+            artifact store, or if missing symlinks were successfully recreated.
+            ``False`` if any output has been replaced with a regular file
+            (indicating external modification — cache miss).
+        """
+        return_annotation = task_def.type_hints.get("return", task_def.signature.return_annotation)
+        return self._validate_output_value(annotation=return_annotation, value=value)
+
+    def _validate_output_value(self, *, annotation: Any, value: Any) -> bool:
+        """Recursively validate symlink integrity for file/folder outputs."""
+        origin = get_origin(annotation)
+        if origin in {list, tuple}:
+            inner_args = get_args(annotation)
+            inner_annotation = inner_args[0] if inner_args else Any
+            for item in value:
+                if not self._validate_output_value(annotation=inner_annotation, value=item):
+                    return False
+            return True
+
+        if annotation is file or isinstance(value, file):
+            return self._validate_file_symlink(Path(str(value)))
+
+        if annotation is folder or isinstance(value, folder):
+            return self._validate_folder_symlink(Path(str(value)))
+
+        # Non-path types: no symlink validation needed.
+        return True
+
+    def _validate_file_symlink(self, path: Path) -> bool:
+        """Validate a single file output symlink.
+
+        Returns ``True`` if the symlink is valid or was recreated.  Returns
+        ``False`` if the path is a regular file (external modification).
+        """
+        if path.is_symlink():
+            target = path.resolve()
+            # Symlink points into our artifact store — valid.
+            if str(target).startswith(str(self._artifact_store._root)):
+                return True
+            # Symlink to somewhere else — treat as modified.
+            return False
+
+        if path.exists():
+            # Regular file replaced the symlink — external modification.
+            return False
+
+        # Path is absent — try to recreate from the artifact store.
+        artifact_id = self._find_artifact_for_path(path, is_dir=False)
+        if artifact_id is not None and self._artifact_store.exists(artifact_id=artifact_id):
+            self._artifact_store.retrieve(artifact_id=artifact_id, dest_path=path)
+            return True
+        return False
+
+    def _validate_folder_symlink(self, path: Path) -> bool:
+        """Validate a single folder output symlink."""
+        if path.is_symlink():
+            target = path.resolve()
+            if str(target).startswith(str(self._artifact_store._root)):
+                return True
+            return False
+
+        if path.exists():
+            return False
+
+        artifact_id = self._find_artifact_for_path(path, is_dir=True)
+        if artifact_id is not None and self._artifact_store.exists(artifact_id=artifact_id):
+            self._artifact_store.retrieve(artifact_id=artifact_id, dest_path=path)
+            return True
+        return False
+
+    def _find_artifact_for_path(self, path: Path, *, is_dir: bool) -> str | None:
+        """Look up the artifact ID for an output path from cache metadata.
+
+        Scans all cache entries for one whose artifact_ids map contains the
+        given path.  This is O(entries) but only triggered on symlink
+        recreation (rare path).
+        """
+        path_str = str(path)
+        for entry_dir in self._root.iterdir():
+            if not entry_dir.is_dir():
+                continue
+            meta_path = entry_dir / "meta.json"
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            artifact_ids = meta.get("artifact_ids", {})
+            artifact_id = artifact_ids.get(path_str)
+            if artifact_id is not None:
+                return artifact_id
+        return None
+
+    def _store_output_artifacts(
+        self,
+        *,
+        result: Any,
+        task_def: TaskDef,
+    ) -> dict[str, str]:
+        """Store file/folder outputs in the artifact store.
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping from output path strings to artifact IDs.
+        """
+        artifact_ids: dict[str, str] = {}
+        return_annotation = task_def.type_hints.get("return", task_def.signature.return_annotation)
+        self._collect_output_artifacts(
+            annotation=return_annotation,
+            value=result,
+            artifact_ids=artifact_ids,
+        )
+        return artifact_ids
+
+    def _collect_output_artifacts(
+        self,
+        *,
+        annotation: Any,
+        value: Any,
+        artifact_ids: dict[str, str],
+    ) -> None:
+        """Recursively walk a result value and store file/folder outputs."""
+        origin = get_origin(annotation)
+        if origin in {list, tuple}:
+            inner_args = get_args(annotation)
+            inner_annotation = inner_args[0] if inner_args else Any
+            for item in value:
+                self._collect_output_artifacts(
+                    annotation=inner_annotation,
+                    value=item,
+                    artifact_ids=artifact_ids,
+                )
             return
 
-        temp_dir = Path(tempfile.mkdtemp(prefix=f"{cache_key}.tmp-", dir=self._root))
-        try:
-            output_path = temp_dir / "output.json"
-            output_path.write_text(
-                json.dumps(encode_value(result, base_dir=temp_dir), sort_keys=True),
-                encoding="utf-8",
-            )
+        if annotation is file or isinstance(value, file):
+            path = Path(str(value))
+            if path.is_symlink():
+                # Already a symlink (e.g. from a previous run) — skip.
+                return
+            if path.is_file():
+                artifact_id = self._artifact_store.store(src_path=path)
+                artifact_ids[str(path)] = artifact_id
+            return
 
-            meta = {
-                "cache_key": cache_key,
-                "env": task_def.env,
-                "function": task_def.name,
-                "inputs": self._serialise_inputs(task_def=task_def, resolved_args=resolved_args),
-                "input_hashes": input_hashes,
-                "timestamp": datetime.now(UTC).isoformat(),
-                "version": task_def.version,
-            }
-            (temp_dir / "meta.json").write_text(
-                json.dumps(meta, indent=2, sort_keys=True),
-                encoding="utf-8",
-            )
+        if annotation is folder or isinstance(value, folder):
+            path = Path(str(value))
+            if path.is_symlink():
+                return
+            if path.is_dir():
+                artifact_id = self._artifact_store.store(src_path=path)
+                artifact_ids[str(path)] = artifact_id
+            return
 
+    def _symlink_output_artifacts(self, *, result: Any, task_def: TaskDef) -> None:
+        """Replace original output paths with symlinks to the artifact store."""
+        return_annotation = task_def.type_hints.get("return", task_def.signature.return_annotation)
+        self._symlink_output_value(annotation=return_annotation, value=result)
+
+    def _symlink_output_value(self, *, annotation: Any, value: Any) -> None:
+        """Recursively replace file/folder outputs with symlinks."""
+        origin = get_origin(annotation)
+        if origin in {list, tuple}:
+            inner_args = get_args(annotation)
+            inner_annotation = inner_args[0] if inner_args else Any
+            for item in value:
+                self._symlink_output_value(annotation=inner_annotation, value=item)
+            return
+
+        if annotation is file or isinstance(value, file):
+            path = Path(str(value))
+            if path.is_symlink():
+                return
+            self._replace_with_symlink(path, is_dir=False)
+            return
+
+        if annotation is folder or isinstance(value, folder):
+            path = Path(str(value))
+            if path.is_symlink():
+                return
+            self._replace_with_symlink(path, is_dir=True)
+            return
+
+    def _replace_with_symlink(self, path: Path, *, is_dir: bool) -> None:
+        """Replace a file or directory with a symlink to its artifact."""
+        path_str = str(path)
+
+        # Find the artifact ID from the most recently saved entry.
+        artifact_id: str | None = None
+        for entry_dir in self._root.iterdir():
+            if not entry_dir.is_dir():
+                continue
+            meta_path = entry_dir / "meta.json"
+            if not meta_path.exists():
+                continue
             try:
-                os.replace(temp_dir, entry_dir)
-            except FileExistsError:
-                pass
-        finally:
-            if temp_dir.exists():
-                shutil.rmtree(temp_dir)
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            aids = meta.get("artifact_ids", {})
+            if path_str in aids:
+                artifact_id = aids[path_str]
+                break
+
+        if artifact_id is None:
+            return
+
+        # Remove the original and replace with a symlink.
+        if is_dir and path.is_dir():
+            shutil.rmtree(path)
+        elif path.is_file():
+            path.unlink()
+        else:
+            return
+
+        self._artifact_store.retrieve(artifact_id=artifact_id, dest_path=path)
 
     def _entry_dir(self, cache_key: str) -> Path:
         """Return the cache directory for a given key."""
@@ -212,7 +469,7 @@ class CacheStore:
 
         if value is None or isinstance(value, (bool, int, float, str)):
             return {
-                "sha256": hashlib.sha256(repr(value).encode("utf-8")).hexdigest(),
+                "sha256": hash_str(repr(value)),
                 "type": type(value).__name__,
             }
 
@@ -239,27 +496,30 @@ class CacheStore:
         return inputs
 
     def _hash_file_contents(self, path: Path) -> str:
-        """Return the SHA-256 digest of a file's contents."""
-        digest = hashlib.sha256()
-        with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(65536), b""):
-                digest.update(chunk)
-        return digest.hexdigest()
+        """Return the BLAKE3 digest of a file's contents.
+
+        Follows symlinks so that hashing a symlinked output reads the artifact
+        store content transparently.
+        """
+        return hash_file(path)
 
     def _hash_folder_contents(self, path: Path) -> str:
-        """Return the SHA-256 digest of a folder's recursive contents."""
-        digest = hashlib.sha256()
+        """Return the BLAKE3 digest of a folder's recursive contents."""
+        real_path = path.resolve()
+        hasher = new_hasher()
 
-        for child in sorted(path.rglob("*"), key=lambda item: str(item.relative_to(path))):
-            rel = str(child.relative_to(path))
+        for child in sorted(
+            real_path.rglob("*"), key=lambda item: str(item.relative_to(real_path))
+        ):
+            rel = str(child.relative_to(real_path))
             if child.is_dir():
-                digest.update(f"D:{rel}".encode("utf-8"))
+                hasher.update(f"D:{rel}".encode("utf-8"))
                 continue
 
-            digest.update(f"F:{rel}".encode("utf-8"))
-            digest.update(self._hash_file_contents(child).encode("utf-8"))
+            hasher.update(f"F:{rel}".encode("utf-8"))
+            hasher.update(self._hash_file_contents(child).encode("utf-8"))
 
-        return digest.hexdigest()
+        return hasher.hexdigest()
 
     def _dict_annotations(self, annotation: Any) -> tuple[Any, Any]:
         """Extract key and value annotations for a mapping annotation."""

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -1405,11 +1405,22 @@ class _ConcurrentEvaluator:
         return [Path(item) for item in output]
 
     def _is_valid_cached_result(self, *, task_def: TaskDef, value: Any) -> bool:
-        """Return whether a cached value still satisfies return validation."""
+        """Return whether a cached value still satisfies return validation.
+
+        For file/folder outputs, checks symlink integrity via the cache store.
+        Missing symlinks are silently recreated; replaced regular files trigger
+        a cache miss.  Symlink validation runs first so that missing symlinks
+        can be recreated before the standard file-existence check.
+        """
+        # Symlink-aware validation first: may recreate missing symlinks.
+        if not self._cache_store.validate_cached_outputs(task_def=task_def, value=value):
+            return False
+
         try:
             self._validate_return_value(task_def=task_def, value=value)
         except (FileNotFoundError, ValueError):
             return False
+
         return True
 
     def _record_task_metadata(self, node: _TaskNode) -> None:

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -33,7 +33,7 @@ from ginkgo.envs.container import is_container_env
 from ginkgo.envs.pixi import PixiRegistry
 from ginkgo.runtime.backend import LocalBackend, TaskBackend
 from ginkgo.runtime.cache import MISSING, CacheStore
-from ginkgo.runtime.module_loader import import_roots_for_path, load_module, resolve_module_file
+from ginkgo.runtime.module_loader import load_module, resolve_module_file
 from ginkgo.runtime.provenance import RunProvenanceRecorder
 from ginkgo.runtime.scheduler import SchedulableTask, select_dispatch_subset
 from ginkgo.runtime.value_codec import (
@@ -43,26 +43,6 @@ from ginkgo.runtime.value_codec import (
     ensure_serializable,
 )
 from ginkgo.runtime.worker import _task_log_context, run_task
-
-# Inline Python code executed via ``python -c`` inside a Pixi environment.
-# Using ``-c`` avoids adding the script directory to sys.path, which would
-# otherwise make the worker's package-local modules import precedence-sensitive.
-#
-# Dynamic results (ShellExpr, Expr, ExprList) are not JSON-serializable, so
-# when run_task returns one, we pickle+base64 encode it under the special
-# encoding "pixi_direct_pickled" for the main process to decode.
-_PIXI_WORKER_C = (
-    "import sys,json,pathlib,base64,pickle;"
-    "p=json.loads(pathlib.Path(sys.argv[1]).read_bytes());"
-    "[sys.path.insert(0,x) for x in p.get('ginkgo_import_roots',[]) if x not in sys.path];"
-    "from ginkgo.runtime.worker import run_task;"
-    "r=dict(run_task(p));"
-    "enc=r.get('result_encoding');"
-    "r['result'],r['result_encoding']=("
-    "base64.b64encode(pickle.dumps(r['result'],5)).decode(),'pixi_direct_pickled'"
-    ") if r.get('ok') and enc=='direct' else (r.get('result'),enc);"
-    "pathlib.Path(sys.argv[2]).write_text(json.dumps(r))"
-)
 
 
 class CycleError(RuntimeError):
@@ -979,14 +959,11 @@ class _ConcurrentEvaluator:
         """Encode task inputs into a transport payload for the process pool."""
         assert node.transport_path is not None
         assert node.resolved_args is not None
-        worker_module_file = resolve_module_file("ginkgo.runtime.worker")
-        assert worker_module_file is not None
         return {
             "args": {
                 name: encode_value(value, base_dir=node.transport_path)
                 for name, value in node.resolved_args.items()
             },
-            "ginkgo_import_roots": import_roots_for_path(worker_module_file),
             "stdout_path": str(node.stdout_path) if node.stdout_path is not None else None,
             "stderr_path": str(node.stderr_path) if node.stderr_path is not None else None,
             "env": node.task_def.env,
@@ -1206,9 +1183,9 @@ class _ConcurrentEvaluator:
         # Write the serialized payload for the worker script to consume.
         input_path.write_text(json.dumps(payload), encoding="utf-8")
 
-        argv = self.backend.python_argv_c(
+        argv = self.backend.python_argv_m(
             env=node.task_def.env,
-            code=_PIXI_WORKER_C,
+            module="ginkgo.envs.pixi_worker",
             args=(str(input_path), str(output_path)),
         )
         completed = self._run_subprocess(argv=argv, use_shell=False)

--- a/ginkgo/runtime/hashing.py
+++ b/ginkgo/runtime/hashing.py
@@ -1,0 +1,79 @@
+"""Centralised content hashing using BLAKE3.
+
+All content-addressed hashing in Ginkgo (cache keys, artifact IDs, input
+hashing, source hashing) flows through the helpers in this module.  Swapping
+the underlying algorithm requires changes only here.
+
+BLAKE3 is ~3-5x faster than SHA-256 on a single core and natively parallelises
+across cores via tree hashing, which matters for large artifact files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import blake3
+
+
+def hash_bytes(data: bytes) -> str:
+    """Return the hex digest of raw bytes.
+
+    Parameters
+    ----------
+    data : bytes
+        Bytes to hash.
+
+    Returns
+    -------
+    str
+        Hex-encoded BLAKE3 digest.
+    """
+    return blake3.blake3(data).hexdigest()
+
+
+def hash_str(value: str) -> str:
+    """Return the hex digest of a UTF-8 string.
+
+    Parameters
+    ----------
+    value : str
+        String to hash.
+
+    Returns
+    -------
+    str
+        Hex-encoded BLAKE3 digest.
+    """
+    return hash_bytes(value.encode("utf-8"))
+
+
+def hash_file(path: Path) -> str:
+    """Return the hex digest of a file's contents.
+
+    Parameters
+    ----------
+    path : Path
+        File to hash.  Symlinks are followed.
+
+    Returns
+    -------
+    str
+        Hex-encoded BLAKE3 digest.
+    """
+    real_path = path.resolve()
+    hasher = blake3.blake3()
+    with real_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def new_hasher() -> blake3.blake3:
+    """Return a fresh incremental BLAKE3 hasher.
+
+    Returns
+    -------
+    blake3.blake3
+        An incremental hasher supporting ``.update()`` and ``.hexdigest()``.
+    """
+    return blake3.blake3()

--- a/ginkgo/runtime/value_codec.py
+++ b/ginkgo/runtime/value_codec.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 import io
 import pickle
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ginkgo.core.types import file, folder, tmp_dir
+
+if TYPE_CHECKING:
+    from ginkgo.runtime.artifact_store import ArtifactStore
 
 INLINE_BYTES_LIMIT = 256 * 1024
 
@@ -22,9 +24,23 @@ def encode_value(
     value: Any,
     *,
     base_dir: Path,
+    artifact_store: ArtifactStore | None = None,
     inline_limit: int = INLINE_BYTES_LIMIT,
 ) -> Any:
-    """Encode a Python value into a JSON-safe payload with optional artifacts."""
+    """Encode a Python value into a JSON-safe payload with optional artifacts.
+
+    Parameters
+    ----------
+    value : Any
+        The value to encode.
+    base_dir : Path
+        Directory for ephemeral artifact storage (used by process transport).
+    artifact_store : ArtifactStore | None
+        When provided, large binary payloads are stored through the artifact
+        store instead of writing to *base_dir*.  Used by cache persistence.
+    inline_limit : int
+        Byte threshold below which binary payloads are base64-inlined.
+    """
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
 
@@ -41,7 +57,13 @@ def encode_value(
         return {
             "__ginkgo_type__": "list",
             "items": [
-                encode_value(item, base_dir=base_dir, inline_limit=inline_limit) for item in value
+                encode_value(
+                    item,
+                    base_dir=base_dir,
+                    artifact_store=artifact_store,
+                    inline_limit=inline_limit,
+                )
+                for item in value
             ],
         }
 
@@ -49,7 +71,13 @@ def encode_value(
         return {
             "__ginkgo_type__": "tuple",
             "items": [
-                encode_value(item, base_dir=base_dir, inline_limit=inline_limit) for item in value
+                encode_value(
+                    item,
+                    base_dir=base_dir,
+                    artifact_store=artifact_store,
+                    inline_limit=inline_limit,
+                )
+                for item in value
             ],
         }
 
@@ -58,8 +86,18 @@ def encode_value(
             "__ginkgo_type__": "dict",
             "items": [
                 {
-                    "key": encode_value(key, base_dir=base_dir, inline_limit=inline_limit),
-                    "value": encode_value(item, base_dir=base_dir, inline_limit=inline_limit),
+                    "key": encode_value(
+                        key,
+                        base_dir=base_dir,
+                        artifact_store=artifact_store,
+                        inline_limit=inline_limit,
+                    ),
+                    "value": encode_value(
+                        item,
+                        base_dir=base_dir,
+                        artifact_store=artifact_store,
+                        inline_limit=inline_limit,
+                    ),
                 }
                 for key, item in value.items()
             ],
@@ -71,12 +109,29 @@ def encode_value(
         data=data,
         extension=extension,
         base_dir=base_dir,
+        artifact_store=artifact_store,
         inline_limit=inline_limit,
     )
 
 
-def decode_value(payload: Any, *, base_dir: Path) -> Any:
-    """Restore a Python value from an encoded payload."""
+def decode_value(
+    payload: Any,
+    *,
+    base_dir: Path,
+    artifact_store: ArtifactStore | None = None,
+) -> Any:
+    """Restore a Python value from an encoded payload.
+
+    Parameters
+    ----------
+    payload : Any
+        Encoded payload from :func:`encode_value`.
+    base_dir : Path
+        Base directory for resolving ephemeral artifact paths.
+    artifact_store : ArtifactStore | None
+        When provided, artifact-backed binary payloads are read through the
+        store instead of from *base_dir*.
+    """
     if not isinstance(payload, dict):
         return payload
 
@@ -88,18 +143,30 @@ def decode_value(payload: Any, *, base_dir: Path) -> Any:
     if kind == "tmp_dir":
         return tmp_dir(payload["value"])
     if kind == "list":
-        return [decode_value(item, base_dir=base_dir) for item in payload["items"]]
+        return [
+            decode_value(item, base_dir=base_dir, artifact_store=artifact_store)
+            for item in payload["items"]
+        ]
     if kind == "tuple":
-        return tuple(decode_value(item, base_dir=base_dir) for item in payload["items"])
+        return tuple(
+            decode_value(item, base_dir=base_dir, artifact_store=artifact_store)
+            for item in payload["items"]
+        )
     if kind == "dict":
         return {
-            decode_value(item["key"], base_dir=base_dir): decode_value(
-                item["value"], base_dir=base_dir
+            decode_value(
+                item["key"], base_dir=base_dir, artifact_store=artifact_store
+            ): decode_value(
+                item["value"],
+                base_dir=base_dir,
+                artifact_store=artifact_store,
             )
             for item in payload["items"]
         }
     if kind == "binary":
-        return _decode_binary_payload(payload=payload, base_dir=base_dir)
+        return _decode_binary_payload(
+            payload=payload, base_dir=base_dir, artifact_store=artifact_store
+        )
     return payload
 
 
@@ -149,9 +216,11 @@ def summarise_value(value: Any) -> Any:
 
 
 def hash_value_bytes(value: Any) -> tuple[str, str]:
-    """Return the codec name and SHA-256 digest for a Python value."""
+    """Return the codec name and BLAKE3 digest for a Python value."""
+    from ginkgo.runtime.hashing import hash_bytes
+
     codec_name, data, _extension = _encode_bytes(value)
-    digest = hashlib.sha256(data).hexdigest()
+    digest = hash_bytes(data)
     return codec_name, digest
 
 
@@ -186,6 +255,7 @@ def _encode_binary_payload(
     data: bytes,
     extension: str,
     base_dir: Path,
+    artifact_store: ArtifactStore | None = None,
     inline_limit: int,
 ) -> dict[str, Any]:
     if len(data) <= inline_limit:
@@ -196,9 +266,22 @@ def _encode_binary_payload(
             "data": base64.b64encode(data).decode("ascii"),
         }
 
+    # Route through the artifact store when available (cache persistence).
+    if artifact_store is not None:
+        artifact_id = artifact_store.store_bytes(data=data, extension=extension)
+        return {
+            "__ginkgo_type__": "binary",
+            "artifact_id": artifact_id,
+            "codec": codec_name,
+            "storage": "artifact_store",
+        }
+
+    # Ephemeral transport fallback: write to base_dir/artifacts/.
+    from ginkgo.runtime.hashing import hash_bytes
+
     artifacts_dir = base_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-    digest = hashlib.sha256(data).hexdigest()
+    digest = hash_bytes(data)
     artifact_name = f"{digest}.{extension}"
     artifact_path = artifacts_dir / artifact_name
     if not artifact_path.exists():
@@ -213,11 +296,22 @@ def _encode_binary_payload(
     }
 
 
-def _decode_binary_payload(*, payload: dict[str, Any], base_dir: Path) -> Any:
-    if payload["storage"] == "inline":
+def _decode_binary_payload(
+    *,
+    payload: dict[str, Any],
+    base_dir: Path,
+    artifact_store: ArtifactStore | None = None,
+) -> Any:
+    storage = payload["storage"]
+
+    if storage == "inline":
         data = base64.b64decode(payload["data"])
+    elif storage == "artifact_store" and artifact_store is not None:
+        data = artifact_store.read_bytes(artifact_id=payload["artifact_id"])
     else:
+        # Ephemeral transport or legacy cache entries.
         data = (base_dir / payload["artifact"]).read_bytes()
+
     return _decode_bytes(codec_name=payload["codec"], data=data)
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -10,6 +10,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blake3-1.0.8-py314h2e6c369_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -58,16 +59,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/14/69a25a0cad493fb6a947302471b579a03516a3b00e7bece77fdc6b4afb9b/ty-0.0.23-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/f1/32c05a1c4c3c2a95c5b7361dee03a9bf1231d4ad096b161c838b45bce5a0/ty-0.0.24-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
       - pypi: ./
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blake3-1.0.8-py314haad56a0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -111,13 +113,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0f/01/3f25909b02fac29bb0a62b2251f8d62e65d697781ffa4cf6b47a4c075c85/ty-0.0.23-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/63/cfc805adeaa61d63ba3ea71127efa7d97c40ba36d97ee7bd957341d05107/ty-0.0.24-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
       - pypi: ./
 packages:
@@ -140,6 +142,38 @@ packages:
   version: 2.4.0
   sha256: 88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blake3-1.0.8-py314h2e6c369_1.conda
+  sha256: b5f1a9a90dd2a139c51da0c03f22f3caee4af4cf1c92d2ccdf1bc183983d0343
+  md5: b09502727d3117eaa284e937db60f55c
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/blake3?source=hash-mapping
+  size: 386856
+  timestamp: 1763135669021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blake3-1.0.8-py314haad56a0_1.conda
+  sha256: 51de043c0cc262784689341ea07015d60f4e989a81669102b4148e6116d52d78
+  md5: 20b4e9168a48f844232f0aa7078f31d7
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/blake3?source=hash-mapping
+  size: 334818
+  timestamp: 1763135726465
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -209,8 +243,9 @@ packages:
 - pypi: ./
   name: ginkgo
   version: 0.1.0
-  sha256: 4c65c172184ee6960694ba176d74216e5b42ea04a52ebb6ccf4868d5f0647a98
+  sha256: 5dc9d979f76fa2be704261fff34c2e5b5d11ec7674bc2ee1266ac4c2ba2772eb
   requires_dist:
+  - blake3>=1.0.0
   - numpy>=2.0
   - ortools>=9.11
   - pandas>=2.0
@@ -801,15 +836,15 @@ packages:
   - pyyaml>=5.1
   - virtualenv>=20.10.0
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
   name: protobuf
-  version: 6.33.5
-  sha256: cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0
+  version: 6.33.6
+  sha256: e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
   name: protobuf
-  version: 6.33.5
-  sha256: a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5
+  version: 6.33.6
+  sha256: 9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl
   name: pyarrow
@@ -913,10 +948,10 @@ packages:
   requires_dist:
   - six>=1.5
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl
   name: python-discovery
-  version: 1.1.3
-  sha256: 90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e
+  version: 1.2.0
+  sha256: 1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a
   requires_dist:
   - filelock>=3.15.4
   - platformdirs>=4.3.6,<5
@@ -1076,15 +1111,15 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 21453
   timestamp: 1768146676791
-- pypi: https://files.pythonhosted.org/packages/0f/01/3f25909b02fac29bb0a62b2251f8d62e65d697781ffa4cf6b47a4c075c85/ty-0.0.23-py3-none-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/ac/f1/32c05a1c4c3c2a95c5b7361dee03a9bf1231d4ad096b161c838b45bce5a0/ty-0.0.24-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ty
-  version: 0.0.23
-  sha256: bd6a340969577b4645f231572c4e46012acba2d10d4c0c6570fe1ab74e76ae00
+  version: 0.0.24
+  sha256: 7981df5c709c054da4ac5d7c93f8feb8f45e69e829e4461df4d5f0988fe67d04
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/18/14/69a25a0cad493fb6a947302471b579a03516a3b00e7bece77fdc6b4afb9b/ty-0.0.23-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/e4/63/cfc805adeaa61d63ba3ea71127efa7d97c40ba36d97ee7bd957341d05107/ty-0.0.24-py3-none-macosx_11_0_arm64.whl
   name: ty
-  version: 0.0.23
-  sha256: 559d9a299df793cb7a7902caed5eda8a720ff69164c31c979673e928f02251ee
+  version: 0.0.24
+  sha256: b6d2a3b6d4470c483552a31e9b368c86f154dcc964bccb5406159dc9cd362246
   requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A dynamic, reproducible workflow orchestrator for scientific and data workflows"
 requires-python = ">= 3.11"
 dependencies = [
+    "blake3>=1.0.0",
     "numpy>=2.0",
     "ortools>=9.11",
     "pandas>=2.0",
@@ -37,6 +38,7 @@ rich = ">=13.9"
 [tool.pixi.dependencies]
 python = ">=3.11"
 pyyaml = ">=6.0"
+blake3 = ">=1.0.8,<2"
 
 [tool.pixi.feature.dev.dependencies]
 pytest = ">=8.0"

--- a/tests/envs/test_env/pixi.lock
+++ b/tests/envs/test_env/pixi.lock
@@ -3,6 +3,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -39,6 +41,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/73/9058a1a457dd20491d1b37de53d6876eff125e1520d9b2dd7d0acbc88de2/blake3-1.0.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: ../../..
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
@@ -72,6 +89,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+      - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/b913eb9cc4af708c03e01e6b88a8bb3a74833ba4ae4b16b87e2829198e06/blake3-1.0.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/b8/612ce010c0728b1c363fa4ea3aa4c22fe1c5da1de008486f8c2f5cb92fae/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/e0/ac57dd43eaadd73748bb542b30912e16c7dbf3a75f393f69efb8a1a2f032/ortools-9.15.6755-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/4e/f7/b449ffb3f68c11da12fc06fbf6d2fa3a41c41e17d0284d23a79e1c13a7e4/pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: ../../..
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
@@ -99,6 +131,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/06/8e/8458c4285fbc5de76414f243e4e0fcab795d71a8b75324e14959aee699da/blake3-1.0.8-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: ../../..
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -111,6 +158,7 @@ packages:
   - openmp_impl <0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 28948
   timestamp: 1770939786096
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
@@ -123,8 +171,35 @@ packages:
   - openmp_impl <0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 28926
   timestamp: 1770939656741
+- pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+  name: absl-py
+  version: 2.4.0
+  sha256: 88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/06/8e/8458c4285fbc5de76414f243e4e0fcab795d71a8b75324e14959aee699da/blake3-1.0.8-cp314-cp314-macosx_11_0_arm64.whl
+  name: blake3
+  version: 1.0.8
+  sha256: c445eff665d21c3b3b44f864f849a2225b1164c08654beb23224a02f087b7ff1
+  requires_dist:
+  - typing-extensions>=4.6.0 ; python_full_version < '3.12'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/34/73/9058a1a457dd20491d1b37de53d6876eff125e1520d9b2dd7d0acbc88de2/blake3-1.0.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: blake3
+  version: 1.0.8
+  sha256: 2d78f06f3fb838b34c330e2987090376145cbe5944d8608a0c4779c779618f7b
+  requires_dist:
+  - typing-extensions>=4.6.0 ; python_full_version < '3.12'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/49/fa/b913eb9cc4af708c03e01e6b88a8bb3a74833ba4ae4b16b87e2829198e06/blake3-1.0.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  name: blake3
+  version: 1.0.8
+  sha256: a47939f04b89c5c6ff1e51e883e5efab1ea1bf01a02f4d208d216dddd63d0dd8
+  requires_dist:
+  - typing-extensions>=4.6.0 ; python_full_version < '3.12'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -133,6 +208,7 @@ packages:
   - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 260182
   timestamp: 1771350215188
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
@@ -142,6 +218,7 @@ packages:
   - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 192412
   timestamp: 1771350241232
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
@@ -151,6 +228,7 @@ packages:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 124834
   timestamp: 1771350416561
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
@@ -159,6 +237,7 @@ packages:
   depends:
   - __unix
   license: ISC
+  purls: []
   size: 147413
   timestamp: 1772006283803
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -168,6 +247,8 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -177,8 +258,23 @@ packages:
   - python >=3.10
   - typing_extensions >=4.6.0
   license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21333
   timestamp: 1763918099466
+- pypi: ../../..
+  name: ginkgo
+  version: 0.1.0
+  sha256: 5dc9d979f76fa2be704261fff34c2e5b5d11ec7674bc2ee1266ac4c2ba2772eb
+  requires_dist:
+  - blake3>=1.0.0
+  - numpy>=2.0
+  - ortools>=9.11
+  - pandas>=2.0
+  - pyarrow>=23.0.1,<24
+  - pyyaml>=6.0
+  - rich>=13.9
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
   sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
   md5: 186a18e3ba246eccfc7cff00cd19a870
@@ -188,6 +284,7 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  purls: []
   size: 12728445
   timestamp: 1767969922681
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hcab7f73_0.conda
@@ -198,6 +295,7 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  purls: []
   size: 12851689
   timestamp: 1772208964788
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
@@ -207,8 +305,14 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 12389400
   timestamp: 1772209104304
+- pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
+  name: immutabledict
+  version: 4.3.1
+  sha256: c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf
+  requires_python: '>=3.8,<4.0'
 - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
   md5: 9614359868482abba1bd15ce465e3c42
@@ -216,6 +320,8 @@ packages:
   - python >=3.10
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/iniconfig?source=compressed-mapping
   size: 13387
   timestamp: 1760831448842
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
@@ -228,6 +334,7 @@ packages:
   - binutils_impl_linux-64 2.45.1
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 725507
   timestamp: 1770267139900
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
@@ -239,6 +346,7 @@ packages:
   - binutils_impl_linux-aarch64 2.45.1
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 875924
   timestamp: 1770267209884
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -251,6 +359,7 @@ packages:
   - expat 2.7.4.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 76798
   timestamp: 1771259418166
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.4-hfae3067_0.conda
@@ -262,6 +371,7 @@ packages:
   - expat 2.7.4.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 76564
   timestamp: 1771259530958
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
@@ -273,6 +383,7 @@ packages:
   - expat 2.7.4.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 68199
   timestamp: 1771260020767
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -283,6 +394,7 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  purls: []
   size: 58592
   timestamp: 1769456073053
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
@@ -292,6 +404,7 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  purls: []
   size: 55952
   timestamp: 1769456078358
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
@@ -301,6 +414,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 40979
   timestamp: 1769456747661
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
@@ -314,6 +428,7 @@ packages:
   - libgomp 15.2.0 he0feb66_18
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 1041788
   timestamp: 1771378212382
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_18.conda
@@ -326,6 +441,7 @@ packages:
   - libgomp 15.2.0 h8acb6b2_18
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 622900
   timestamp: 1771378128706
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
@@ -335,6 +451,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 603262
   timestamp: 1771378117851
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_18.conda
@@ -342,6 +459,7 @@ packages:
   md5: 4faa39bf919939602e594253bd673958
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 588060
   timestamp: 1771378040807
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
@@ -353,6 +471,7 @@ packages:
   constrains:
   - xz 5.8.2.*
   license: 0BSD
+  purls: []
   size: 113207
   timestamp: 1768752626120
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.2-he30d5cf_0.conda
@@ -363,6 +482,7 @@ packages:
   constrains:
   - xz 5.8.2.*
   license: 0BSD
+  purls: []
   size: 125916
   timestamp: 1768754941722
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
@@ -373,6 +493,7 @@ packages:
   constrains:
   - xz 5.8.2.*
   license: 0BSD
+  purls: []
   size: 92242
   timestamp: 1768752982486
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
@@ -383,6 +504,7 @@ packages:
   - libgcc >=14
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 92400
   timestamp: 1769482286018
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
@@ -392,6 +514,7 @@ packages:
   - libgcc >=14
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 114056
   timestamp: 1769482343003
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
@@ -401,6 +524,7 @@ packages:
   - __osx >=11.0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 73690
   timestamp: 1769482560514
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
@@ -412,6 +536,7 @@ packages:
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: blessing
+  purls: []
   size: 951405
   timestamp: 1772818874251
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.52.0-h10b116e_0.conda
@@ -422,6 +547,7 @@ packages:
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: blessing
+  purls: []
   size: 952296
   timestamp: 1772818881550
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
@@ -432,6 +558,7 @@ packages:
   - icu >=78.2,<79.0a0
   - libzlib >=1.3.1,<2.0a0
   license: blessing
+  purls: []
   size: 918420
   timestamp: 1772819478684
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
@@ -444,6 +571,7 @@ packages:
   - libstdcxx-ng ==15.2.0=*_18
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 5852330
   timestamp: 1771378262446
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_18.conda
@@ -455,6 +583,7 @@ packages:
   - libstdcxx-ng ==15.2.0=*_18
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 5541411
   timestamp: 1771378162499
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
@@ -465,6 +594,7 @@ packages:
   - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 40311
   timestamp: 1766271528534
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.3-h1022ec0_0.conda
@@ -474,6 +604,7 @@ packages:
   - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 43453
   timestamp: 1766271546875
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -486,6 +617,7 @@ packages:
   - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 60963
   timestamp: 1727963148474
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
@@ -497,6 +629,7 @@ packages:
   - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 66657
   timestamp: 1727963199518
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
@@ -508,8 +641,47 @@ packages:
   - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 46438
   timestamp: 1727963202283
+- pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+  name: markdown-it-py
+  version: 4.0.0
+  sha256: 87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147
+  requires_dist:
+  - mdurl~=0.1
+  - psutil ; extra == 'benchmarking'
+  - pytest ; extra == 'benchmarking'
+  - pytest-benchmark ; extra == 'benchmarking'
+  - commonmark~=0.9 ; extra == 'compare'
+  - markdown~=3.4 ; extra == 'compare'
+  - mistletoe~=1.0 ; extra == 'compare'
+  - mistune~=3.0 ; extra == 'compare'
+  - panflute~=2.3 ; extra == 'compare'
+  - markdown-it-pyrs ; extra == 'compare'
+  - linkify-it-py>=1,<3 ; extra == 'linkify'
+  - mdit-py-plugins>=0.5.0 ; extra == 'plugins'
+  - gprof2dot ; extra == 'profiling'
+  - mdit-py-plugins>=0.5.0 ; extra == 'rtd'
+  - myst-parser ; extra == 'rtd'
+  - pyyaml ; extra == 'rtd'
+  - sphinx ; extra == 'rtd'
+  - sphinx-copybutton ; extra == 'rtd'
+  - sphinx-design ; extra == 'rtd'
+  - sphinx-book-theme~=1.0 ; extra == 'rtd'
+  - jupyter-sphinx ; extra == 'rtd'
+  - ipykernel ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  - requests ; extra == 'testing'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  name: mdurl
+  version: 0.1.2
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   md5: 47e340acb35de30501a76c7c799c41d7
@@ -517,6 +689,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 891641
   timestamp: 1738195959188
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
@@ -525,6 +698,7 @@ packages:
   depends:
   - libgcc >=13
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 926034
   timestamp: 1738196018799
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
@@ -533,8 +707,24 @@ packages:
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 797030
   timestamp: 1738196177597
+- pypi: https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl
+  name: numpy
+  version: 2.4.3
+  sha256: 297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: numpy
+  version: 2.4.3
+  sha256: 679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/aa/b8/612ce010c0728b1c363fa4ea3aa4c22fe1c5da1de008486f8c2f5cb92fae/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  name: numpy
+  version: 2.4.3
+  sha256: 54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
   sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
   md5: f61eb8cd60ff9057122a3d338b99c00f
@@ -544,6 +734,7 @@ packages:
   - libgcc >=14
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 3164551
   timestamp: 1769555830639
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
@@ -554,6 +745,7 @@ packages:
   - libgcc >=14
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 3692030
   timestamp: 1769557678657
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
@@ -564,8 +756,45 @@ packages:
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 3104268
   timestamp: 1769556384749
+- pypi: https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl
+  name: ortools
+  version: 9.15.6755
+  sha256: 1a0677270b0cd317a6b8dae42514264eaf5da5756c5bc7215eeea409424577df
+  requires_dist:
+  - absl-py>=2.0.0
+  - numpy>=2.0.2
+  - pandas>=2.0.0
+  - protobuf>=6.33.1,<6.34
+  - typing-extensions>=4.12
+  - immutabledict>=3.0.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/1c/e0/ac57dd43eaadd73748bb542b30912e16c7dbf3a75f393f69efb8a1a2f032/ortools-9.15.6755-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+  name: ortools
+  version: 9.15.6755
+  sha256: 899b92afe3f775ab5867b9a8aa2850f81f2d95232db9b4ceec3456d69e6b8528
+  requires_dist:
+  - absl-py>=2.0.0
+  - numpy>=2.0.2
+  - pandas>=2.0.0
+  - protobuf>=6.33.1,<6.34
+  - typing-extensions>=4.12
+  - immutabledict>=3.0.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: ortools
+  version: 9.15.6755
+  sha256: 7181183cdcafe2b0d83ca5505b65048c7953dc7b5ad479361dded607964cc1b3
+  requires_dist:
+  - absl-py>=2.0.0
+  - numpy>=2.0.2
+  - pandas>=2.0.0
+  - protobuf>=6.33.1,<6.34
+  - typing-extensions>=4.12
+  - immutabledict>=3.0.0
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
   sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
   md5: b76541e68fea4d511b1ac46a28dcd2c6
@@ -574,8 +803,280 @@ packages:
   - python
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
+- pypi: https://files.pythonhosted.org/packages/4e/f7/b449ffb3f68c11da12fc06fbf6d2fa3a41c41e17d0284d23a79e1c13a7e4/pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
+  name: pandas
+  version: 3.0.1
+  sha256: 56cf59638bf24dc9bdf2154c81e248b3289f9a09a6d04e63608c159022352749
+  requires_dist:
+  - numpy>=1.26.0 ; python_full_version < '3.14'
+  - numpy>=2.3.3 ; python_full_version >= '3.14'
+  - python-dateutil>=2.8.2
+  - tzdata ; sys_platform == 'win32'
+  - tzdata ; sys_platform == 'emscripten'
+  - hypothesis>=6.116.0 ; extra == 'test'
+  - pytest>=8.3.4 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - bottleneck>=1.4.2 ; extra == 'performance'
+  - numba>=0.60.0 ; extra == 'performance'
+  - numexpr>=2.10.2 ; extra == 'performance'
+  - scipy>=1.14.1 ; extra == 'computation'
+  - xarray>=2024.10.0 ; extra == 'computation'
+  - fsspec>=2024.10.0 ; extra == 'fss'
+  - s3fs>=2024.10.0 ; extra == 'aws'
+  - gcsfs>=2024.10.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.5 ; extra == 'excel'
+  - python-calamine>=0.3.0 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.2.0 ; extra == 'excel'
+  - pyarrow>=13.0.0 ; extra == 'parquet'
+  - pyarrow>=13.0.0 ; extra == 'feather'
+  - pyiceberg>=0.8.1 ; extra == 'iceberg'
+  - tables>=3.10.1 ; extra == 'hdf5'
+  - pyreadstat>=1.2.8 ; extra == 'spss'
+  - sqlalchemy>=2.0.36 ; extra == 'postgresql'
+  - psycopg2>=2.9.10 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.36 ; extra == 'mysql'
+  - pymysql>=1.1.1 ; extra == 'mysql'
+  - sqlalchemy>=2.0.36 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.12.3 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'xml'
+  - matplotlib>=3.9.3 ; extra == 'plot'
+  - jinja2>=3.1.5 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.4.2 ; extra == 'clipboard'
+  - zstandard>=0.23.0 ; extra == 'compression'
+  - pytz>=2024.2 ; extra == 'timezone'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+  - beautifulsoup4>=4.12.3 ; extra == 'all'
+  - bottleneck>=1.4.2 ; extra == 'all'
+  - fastparquet>=2024.11.0 ; extra == 'all'
+  - fsspec>=2024.10.0 ; extra == 'all'
+  - gcsfs>=2024.10.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.116.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - lxml>=5.3.0 ; extra == 'all'
+  - matplotlib>=3.9.3 ; extra == 'all'
+  - numba>=0.60.0 ; extra == 'all'
+  - numexpr>=2.10.2 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.5 ; extra == 'all'
+  - psycopg2>=2.9.10 ; extra == 'all'
+  - pyarrow>=13.0.0 ; extra == 'all'
+  - pyiceberg>=0.8.1 ; extra == 'all'
+  - pymysql>=1.1.1 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.8 ; extra == 'all'
+  - pytest>=8.3.4 ; extra == 'all'
+  - pytest-xdist>=3.6.1 ; extra == 'all'
+  - python-calamine>=0.3.0 ; extra == 'all'
+  - pytz>=2024.2 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.4.2 ; extra == 'all'
+  - scipy>=1.14.1 ; extra == 'all'
+  - s3fs>=2024.10.0 ; extra == 'all'
+  - sqlalchemy>=2.0.36 ; extra == 'all'
+  - tables>=3.10.1 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2024.10.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.2.0 ; extra == 'all'
+  - zstandard>=0.23.0 ; extra == 'all'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: pandas
+  version: 3.0.1
+  sha256: c1a9f55e0f46951874b863d1f3906dcb57df2d9be5c5847ba4dfb55b2c815249
+  requires_dist:
+  - numpy>=1.26.0 ; python_full_version < '3.14'
+  - numpy>=2.3.3 ; python_full_version >= '3.14'
+  - python-dateutil>=2.8.2
+  - tzdata ; sys_platform == 'win32'
+  - tzdata ; sys_platform == 'emscripten'
+  - hypothesis>=6.116.0 ; extra == 'test'
+  - pytest>=8.3.4 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - bottleneck>=1.4.2 ; extra == 'performance'
+  - numba>=0.60.0 ; extra == 'performance'
+  - numexpr>=2.10.2 ; extra == 'performance'
+  - scipy>=1.14.1 ; extra == 'computation'
+  - xarray>=2024.10.0 ; extra == 'computation'
+  - fsspec>=2024.10.0 ; extra == 'fss'
+  - s3fs>=2024.10.0 ; extra == 'aws'
+  - gcsfs>=2024.10.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.5 ; extra == 'excel'
+  - python-calamine>=0.3.0 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.2.0 ; extra == 'excel'
+  - pyarrow>=13.0.0 ; extra == 'parquet'
+  - pyarrow>=13.0.0 ; extra == 'feather'
+  - pyiceberg>=0.8.1 ; extra == 'iceberg'
+  - tables>=3.10.1 ; extra == 'hdf5'
+  - pyreadstat>=1.2.8 ; extra == 'spss'
+  - sqlalchemy>=2.0.36 ; extra == 'postgresql'
+  - psycopg2>=2.9.10 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.36 ; extra == 'mysql'
+  - pymysql>=1.1.1 ; extra == 'mysql'
+  - sqlalchemy>=2.0.36 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.12.3 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'xml'
+  - matplotlib>=3.9.3 ; extra == 'plot'
+  - jinja2>=3.1.5 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.4.2 ; extra == 'clipboard'
+  - zstandard>=0.23.0 ; extra == 'compression'
+  - pytz>=2024.2 ; extra == 'timezone'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+  - beautifulsoup4>=4.12.3 ; extra == 'all'
+  - bottleneck>=1.4.2 ; extra == 'all'
+  - fastparquet>=2024.11.0 ; extra == 'all'
+  - fsspec>=2024.10.0 ; extra == 'all'
+  - gcsfs>=2024.10.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.116.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - lxml>=5.3.0 ; extra == 'all'
+  - matplotlib>=3.9.3 ; extra == 'all'
+  - numba>=0.60.0 ; extra == 'all'
+  - numexpr>=2.10.2 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.5 ; extra == 'all'
+  - psycopg2>=2.9.10 ; extra == 'all'
+  - pyarrow>=13.0.0 ; extra == 'all'
+  - pyiceberg>=0.8.1 ; extra == 'all'
+  - pymysql>=1.1.1 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.8 ; extra == 'all'
+  - pytest>=8.3.4 ; extra == 'all'
+  - pytest-xdist>=3.6.1 ; extra == 'all'
+  - python-calamine>=0.3.0 ; extra == 'all'
+  - pytz>=2024.2 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.4.2 ; extra == 'all'
+  - scipy>=1.14.1 ; extra == 'all'
+  - s3fs>=2024.10.0 ; extra == 'all'
+  - sqlalchemy>=2.0.36 ; extra == 'all'
+  - tables>=3.10.1 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2024.10.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.2.0 ; extra == 'all'
+  - zstandard>=0.23.0 ; extra == 'all'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl
+  name: pandas
+  version: 3.0.1
+  sha256: 3b66857e983208654294bb6477b8a63dee26b37bdd0eb34d010556e91261784f
+  requires_dist:
+  - numpy>=1.26.0 ; python_full_version < '3.14'
+  - numpy>=2.3.3 ; python_full_version >= '3.14'
+  - python-dateutil>=2.8.2
+  - tzdata ; sys_platform == 'win32'
+  - tzdata ; sys_platform == 'emscripten'
+  - hypothesis>=6.116.0 ; extra == 'test'
+  - pytest>=8.3.4 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - bottleneck>=1.4.2 ; extra == 'performance'
+  - numba>=0.60.0 ; extra == 'performance'
+  - numexpr>=2.10.2 ; extra == 'performance'
+  - scipy>=1.14.1 ; extra == 'computation'
+  - xarray>=2024.10.0 ; extra == 'computation'
+  - fsspec>=2024.10.0 ; extra == 'fss'
+  - s3fs>=2024.10.0 ; extra == 'aws'
+  - gcsfs>=2024.10.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.5 ; extra == 'excel'
+  - python-calamine>=0.3.0 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.2.0 ; extra == 'excel'
+  - pyarrow>=13.0.0 ; extra == 'parquet'
+  - pyarrow>=13.0.0 ; extra == 'feather'
+  - pyiceberg>=0.8.1 ; extra == 'iceberg'
+  - tables>=3.10.1 ; extra == 'hdf5'
+  - pyreadstat>=1.2.8 ; extra == 'spss'
+  - sqlalchemy>=2.0.36 ; extra == 'postgresql'
+  - psycopg2>=2.9.10 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.36 ; extra == 'mysql'
+  - pymysql>=1.1.1 ; extra == 'mysql'
+  - sqlalchemy>=2.0.36 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.12.3 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'xml'
+  - matplotlib>=3.9.3 ; extra == 'plot'
+  - jinja2>=3.1.5 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.4.2 ; extra == 'clipboard'
+  - zstandard>=0.23.0 ; extra == 'compression'
+  - pytz>=2024.2 ; extra == 'timezone'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+  - beautifulsoup4>=4.12.3 ; extra == 'all'
+  - bottleneck>=1.4.2 ; extra == 'all'
+  - fastparquet>=2024.11.0 ; extra == 'all'
+  - fsspec>=2024.10.0 ; extra == 'all'
+  - gcsfs>=2024.10.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.116.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - lxml>=5.3.0 ; extra == 'all'
+  - matplotlib>=3.9.3 ; extra == 'all'
+  - numba>=0.60.0 ; extra == 'all'
+  - numexpr>=2.10.2 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.5 ; extra == 'all'
+  - psycopg2>=2.9.10 ; extra == 'all'
+  - pyarrow>=13.0.0 ; extra == 'all'
+  - pyiceberg>=0.8.1 ; extra == 'all'
+  - pymysql>=1.1.1 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.8 ; extra == 'all'
+  - pytest>=8.3.4 ; extra == 'all'
+  - pytest-xdist>=3.6.1 ; extra == 'all'
+  - python-calamine>=0.3.0 ; extra == 'all'
+  - pytz>=2024.2 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.4.2 ; extra == 'all'
+  - scipy>=1.14.1 ; extra == 'all'
+  - s3fs>=2024.10.0 ; extra == 'all'
+  - sqlalchemy>=2.0.36 ; extra == 'all'
+  - tables>=3.10.1 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2024.10.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.2.0 ; extra == 'all'
+  - zstandard>=0.23.0 ; extra == 'all'
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
   sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
   md5: d7585b6550ad04c8c5e21097ada2888e
@@ -584,8 +1085,40 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=compressed-mapping
   size: 25877
   timestamp: 1764896838868
+- pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
+  name: protobuf
+  version: 6.33.6
+  sha256: e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
+  name: protobuf
+  version: 6.33.6
+  sha256: 9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl
+  name: protobuf
+  version: 6.33.6
+  sha256: e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl
+  name: pyarrow
+  version: 23.0.1
+  sha256: 4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl
+  name: pyarrow
+  version: 23.0.1
+  sha256: 0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl
+  name: pyarrow
+  version: 23.0.1
+  sha256: 5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -593,6 +1126,8 @@ packages:
   - python >=3.9
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=hash-mapping
   size: 889287
   timestamp: 1750615908735
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
@@ -612,6 +1147,8 @@ packages:
   - pytest-faulthandler >=2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pytest?source=hash-mapping
   size: 299581
   timestamp: 1765062031645
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
@@ -638,6 +1175,7 @@ packages:
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
+  purls: []
   size: 36702440
   timestamp: 1770675584356
   python_site_packages_path: lib/python3.14/site-packages
@@ -664,6 +1202,7 @@ packages:
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
+  purls: []
   size: 37305578
   timestamp: 1770674395875
   python_site_packages_path: lib/python3.14/site-packages
@@ -688,9 +1227,17 @@ packages:
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
+  purls: []
   size: 13522698
   timestamp: 1770675365241
   python_site_packages_path: lib/python3.14/site-packages
+- pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+  name: python-dateutil
+  version: 2.9.0.post0
+  sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+  requires_dist:
+  - six>=1.5
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   build_number: 8
   sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
@@ -699,8 +1246,24 @@ packages:
   - python 3.14.* *_cp314
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6989
   timestamp: 1752805904792
+- pypi: https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: pyyaml
+  version: 6.0.3
+  sha256: c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: pyyaml
+  version: 6.0.3
+  sha256: 501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl
+  name: pyyaml
+  version: 6.0.3
+  sha256: 34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -710,6 +1273,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 345073
   timestamp: 1765813471974
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
@@ -720,6 +1284,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 357597
   timestamp: 1765815673644
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
@@ -730,8 +1295,23 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 313930
   timestamp: 1765813902568
+- pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+  name: rich
+  version: 14.3.3
+  sha256: 793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d
+  requires_dist:
+  - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+  - markdown-it-py>=2.2.0
+  - pygments>=2.13.0,<3.0.0
+  requires_python: '>=3.8.0'
+- pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+  name: six
+  version: 1.17.0
+  sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -743,6 +1323,7 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3301196
   timestamp: 1769460227866
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
@@ -755,6 +1336,7 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3368666
   timestamp: 1769464148928
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
@@ -765,6 +1347,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3127137
   timestamp: 1769460817696
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
@@ -775,6 +1358,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=compressed-mapping
   size: 21453
   timestamp: 1768146676791
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -785,12 +1370,15 @@ packages:
   - python
   license: PSF-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
   size: 51692
   timestamp: 1756220668932
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610
   license: LicenseRef-Public-Domain
+  purls: []
   size: 119135
   timestamp: 1767016325805
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
@@ -801,6 +1389,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 601375
   timestamp: 1764777111296
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
@@ -810,6 +1399,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 614429
   timestamp: 1764777145593
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
@@ -820,5 +1410,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 433413
   timestamp: 1764777166076

--- a/tests/envs/test_env/pixi.toml
+++ b/tests/envs/test_env/pixi.toml
@@ -8,3 +8,6 @@ platforms = ["osx-arm64", "linux-64", "linux-aarch64"]
 [dependencies]
 python = ">=3.11"
 pytest = ">=8.0"
+
+[pypi-dependencies]
+ginkgo = { path = "../../..", editable = true }

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -1,0 +1,169 @@
+"""Unit tests for LocalArtifactStore."""
+
+import stat
+
+import pytest
+
+from ginkgo.runtime.artifact_store import LocalArtifactStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """Return a LocalArtifactStore rooted in a temporary directory."""
+    return LocalArtifactStore(root=tmp_path / "artifacts")
+
+
+class TestStoreFile:
+    def test_round_trip(self, store, tmp_path):
+        src = tmp_path / "hello.txt"
+        src.write_text("hello world")
+
+        artifact_id = store.store(src_path=src)
+        assert artifact_id.endswith(".txt")
+        assert store.exists(artifact_id=artifact_id)
+
+        dest = tmp_path / "restored.txt"
+        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+        assert dest.is_symlink()
+        assert dest.read_text() == "hello world"
+
+    def test_idempotent(self, store, tmp_path):
+        src = tmp_path / "data.csv"
+        src.write_text("a,b,c")
+
+        id1 = store.store(src_path=src)
+        id2 = store.store(src_path=src)
+        assert id1 == id2
+
+    def test_read_only(self, store, tmp_path):
+        src = tmp_path / "readonly.txt"
+        src.write_text("locked")
+
+        artifact_id = store.store(src_path=src)
+        artifact_path = store.artifact_path(artifact_id=artifact_id)
+        mode = artifact_path.stat().st_mode
+        assert not (mode & stat.S_IWUSR)
+        assert not (mode & stat.S_IWGRP)
+        assert not (mode & stat.S_IWOTH)
+
+    def test_no_extension(self, store, tmp_path):
+        src = tmp_path / "noext"
+        src.write_text("content")
+
+        artifact_id = store.store(src_path=src)
+        assert "." not in artifact_id
+
+
+class TestStoreDirectory:
+    def test_round_trip(self, store, tmp_path):
+        src_dir = tmp_path / "mydir"
+        src_dir.mkdir()
+        (src_dir / "a.txt").write_text("aaa")
+        (src_dir / "sub").mkdir()
+        (src_dir / "sub" / "b.txt").write_text("bbb")
+
+        artifact_id = store.store(src_path=src_dir)
+        assert store.exists(artifact_id=artifact_id)
+
+        dest = tmp_path / "restored_dir"
+        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+        assert dest.is_symlink()
+        assert (dest / "a.txt").read_text() == "aaa"
+        assert (dest / "sub" / "b.txt").read_text() == "bbb"
+
+    def test_idempotent(self, store, tmp_path):
+        src_dir = tmp_path / "mydir"
+        src_dir.mkdir()
+        (src_dir / "x.txt").write_text("xxx")
+
+        id1 = store.store(src_path=src_dir)
+        id2 = store.store(src_path=src_dir)
+        assert id1 == id2
+
+    def test_contents_read_only(self, store, tmp_path):
+        src_dir = tmp_path / "mydir"
+        src_dir.mkdir()
+        (src_dir / "f.txt").write_text("data")
+
+        artifact_id = store.store(src_path=src_dir)
+        stored_file = store.artifact_path(artifact_id=artifact_id) / "f.txt"
+        mode = stored_file.stat().st_mode
+        assert not (mode & stat.S_IWUSR)
+
+
+class TestStoreBytes:
+    def test_round_trip(self, store):
+        data = b"binary payload"
+        artifact_id = store.store_bytes(data=data, extension="bin")
+        assert store.exists(artifact_id=artifact_id)
+        assert store.read_bytes(artifact_id=artifact_id) == data
+
+    def test_idempotent(self, store):
+        data = b"same content"
+        id1 = store.store_bytes(data=data, extension="pkl")
+        id2 = store.store_bytes(data=data, extension="pkl")
+        assert id1 == id2
+
+
+class TestRetrieve:
+    def test_creates_symlink(self, store, tmp_path):
+        src = tmp_path / "file.dat"
+        src.write_bytes(b"\x00\x01\x02")
+
+        artifact_id = store.store(src_path=src)
+        dest = tmp_path / "link.dat"
+        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+
+        assert dest.is_symlink()
+        target = dest.resolve()
+        assert target == store.artifact_path(artifact_id=artifact_id).resolve()
+
+    def test_missing_artifact_raises(self, store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            store.retrieve(artifact_id="nonexistent.txt", dest_path=tmp_path / "out")
+
+    def test_creates_parent_dirs(self, store, tmp_path):
+        src = tmp_path / "file.txt"
+        src.write_text("content")
+        artifact_id = store.store(src_path=src)
+
+        dest = tmp_path / "deep" / "nested" / "link.txt"
+        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+        assert dest.is_symlink()
+
+
+class TestDelete:
+    def test_delete_file(self, store, tmp_path):
+        src = tmp_path / "to_delete.txt"
+        src.write_text("bye")
+
+        artifact_id = store.store(src_path=src)
+        assert store.exists(artifact_id=artifact_id)
+
+        store.delete(artifact_id=artifact_id)
+        assert not store.exists(artifact_id=artifact_id)
+
+    def test_delete_directory(self, store, tmp_path):
+        src_dir = tmp_path / "dir_del"
+        src_dir.mkdir()
+        (src_dir / "f.txt").write_text("data")
+
+        artifact_id = store.store(src_path=src_dir)
+        assert store.exists(artifact_id=artifact_id)
+
+        store.delete(artifact_id=artifact_id)
+        assert not store.exists(artifact_id=artifact_id)
+
+    def test_delete_nonexistent_is_noop(self, store):
+        store.delete(artifact_id="does_not_exist.txt")
+
+
+class TestExists:
+    def test_true_for_stored(self, store, tmp_path):
+        src = tmp_path / "f.txt"
+        src.write_text("content")
+        artifact_id = store.store(src_path=src)
+        assert store.exists(artifact_id=artifact_id) is True
+
+    def test_false_for_missing(self, store):
+        assert store.exists(artifact_id="missing.txt") is False

--- a/tests/test_cache_integrity.py
+++ b/tests/test_cache_integrity.py
@@ -1,0 +1,223 @@
+"""Integration tests for Phase 2 cache integrity: source hashing and symlink outputs."""
+
+import stat
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ginkgo import evaluate, file, folder, shell, task
+from ginkgo.core.task import TaskDef
+
+
+# ---------------------------------------------------------------------------
+# Source hashing
+# ---------------------------------------------------------------------------
+
+
+class TestSourceHash:
+    def test_source_hash_is_stable(self):
+        @task()
+        def stable_fn(x: int) -> int:
+            return x + 1
+
+        assert stable_fn.source_hash == stable_fn.source_hash
+
+    def test_different_bodies_produce_different_hashes(self):
+        @task()
+        def fn_a(x: int) -> int:
+            return x + 1
+
+        @task()
+        def fn_b(x: int) -> int:
+            return x + 2
+
+        assert fn_a.source_hash != fn_b.source_hash
+
+    def test_unsourceable_function_raises_at_registration(self):
+        # Functions created via exec() have no inspectable source.
+        ns: dict = {}
+        exec("def dynamic_fn(x): return x", ns)
+        with pytest.raises(ValueError, match="Cannot extract source"):
+            TaskDef(fn=ns["dynamic_fn"])
+
+
+class TestSourceHashCacheInvalidation:
+    """Verify that modifying a task function body causes a cache miss."""
+
+    def test_modified_source_causes_cache_miss(self, tmp_path, capsys):
+        """Write two versions of a task module and verify cache miss on change."""
+        module_dir = tmp_path / "pkg"
+        module_dir.mkdir()
+        (module_dir / "__init__.py").write_text("")
+
+        # Version 1 of the task.
+        v1_source = textwrap.dedent("""\
+            from ginkgo import task
+
+            @task()
+            def compute(x: int) -> int:
+                return x + 1
+        """)
+        (module_dir / "tasks.py").write_text(v1_source)
+
+        import importlib
+        import sys
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            mod = importlib.import_module("pkg.tasks")
+            result1 = evaluate(mod.compute(x=5))
+            assert result1 == 6
+            capsys.readouterr()
+
+            # Version 2: change the function body.
+            v2_source = textwrap.dedent("""\
+                from ginkgo import task
+
+                @task()
+                def compute(x: int) -> int:
+                    return x + 10
+            """)
+            (module_dir / "tasks.py").write_text(v2_source)
+
+            # Reload the module to pick up the new source.
+            importlib.reload(mod)
+            result2 = evaluate(mod.compute(x=5))
+            assert result2 == 15
+            captured = capsys.readouterr()
+
+            # Should have re-executed, not served from cache.
+            assert '"status": "running"' in captured.err
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("pkg.tasks", None)
+            sys.modules.pop("pkg", None)
+
+
+# ---------------------------------------------------------------------------
+# File output symlinks
+# ---------------------------------------------------------------------------
+
+
+@task(kind="shell")
+def write_file_task(output_path: str) -> file:
+    return shell(cmd=f"echo 'hello' > {output_path}", output=output_path)
+
+
+@task(kind="shell")
+def write_folder_task(output_dir: str) -> folder:
+    return shell(
+        cmd=f"mkdir -p {output_dir} && echo 'a' > {output_dir}/a.txt && echo 'b' > {output_dir}/b.txt",
+        output=output_dir,
+    )
+
+
+class TestFileOutputSymlinks:
+    def test_output_is_symlinked_after_execution(self, tmp_path):
+        output = tmp_path / "result.txt"
+        result = evaluate(write_file_task(output_path=str(output)))
+        assert Path(str(result)).is_symlink()
+        assert Path(str(result)).read_text().strip() == "hello"
+
+    def test_symlink_target_is_read_only(self, tmp_path):
+        output = tmp_path / "readonly.txt"
+        result = evaluate(write_file_task(output_path=str(output)))
+        target = Path(str(result)).resolve()
+        mode = target.stat().st_mode
+        assert not (mode & stat.S_IWUSR)
+
+    def test_writing_through_symlink_raises_permission_error(self, tmp_path):
+        output = tmp_path / "locked.txt"
+        result = evaluate(write_file_task(output_path=str(output)))
+        with pytest.raises(PermissionError):
+            Path(str(result)).write_text("modified")
+
+    def test_deleted_symlink_is_recreated_on_cache_hit(self, tmp_path, capsys):
+        output = tmp_path / "recreate.txt"
+        evaluate(write_file_task(output_path=str(output)))
+        capsys.readouterr()
+
+        # Delete the symlink.
+        output.unlink()
+        assert not output.exists()
+
+        # Re-evaluate: should be a cache hit that recreates the symlink.
+        result = evaluate(write_file_task(output_path=str(output)))
+        captured = capsys.readouterr()
+        assert '"status": "cached"' in captured.err
+        assert Path(str(result)).is_symlink()
+        assert Path(str(result)).read_text().strip() == "hello"
+
+    def test_replaced_file_causes_cache_miss(self, tmp_path, capsys):
+        output = tmp_path / "replaced.txt"
+        evaluate(write_file_task(output_path=str(output)))
+        capsys.readouterr()
+
+        # Replace the symlink with a regular file.
+        output.unlink()
+        output.write_text("tampered")
+
+        # Re-evaluate: should be a cache miss (regular file, not symlink).
+        result = evaluate(write_file_task(output_path=str(output)))
+        captured = capsys.readouterr()
+        assert '"status": "running"' in captured.err
+        # After re-execution, should be symlinked again.
+        assert Path(str(result)).is_symlink()
+
+
+class TestFolderOutputSymlinks:
+    def test_output_is_symlinked_after_execution(self, tmp_path):
+        output = tmp_path / "outdir"
+        result = evaluate(write_folder_task(output_dir=str(output)))
+        assert Path(str(result)).is_symlink()
+        assert (Path(str(result)) / "a.txt").read_text().strip() == "a"
+        assert (Path(str(result)) / "b.txt").read_text().strip() == "b"
+
+    def test_folder_contents_are_read_only(self, tmp_path):
+        output = tmp_path / "ro_dir"
+        result = evaluate(write_folder_task(output_dir=str(output)))
+        target = Path(str(result)).resolve()
+        file_mode = (target / "a.txt").stat().st_mode
+        assert not (file_mode & stat.S_IWUSR)
+
+    def test_deleted_symlink_is_recreated(self, tmp_path, capsys):
+        output = tmp_path / "dir_recreate"
+        evaluate(write_folder_task(output_dir=str(output)))
+        capsys.readouterr()
+
+        # Remove the symlink.
+        output.unlink()
+        assert not output.exists()
+
+        result = evaluate(write_folder_task(output_dir=str(output)))
+        captured = capsys.readouterr()
+        assert '"status": "cached"' in captured.err
+        assert Path(str(result)).is_symlink()
+
+
+# ---------------------------------------------------------------------------
+# Cache prune with read-only artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestCachePruneReadOnly:
+    def test_prune_handles_read_only_artifacts(self, tmp_path):
+        """Pruning cache entries with read-only artifacts should not raise."""
+        output = tmp_path / "prunable.txt"
+        evaluate(write_file_task(output_path=str(output)))
+
+        cache_root = Path(".ginkgo") / "cache"
+        assert cache_root.exists()
+
+        # Prune everything by removing all entries directly.
+        import shutil
+        from ginkgo.runtime.artifact_store import _make_writable_recursive
+
+        for entry in cache_root.iterdir():
+            if entry.is_dir():
+                try:
+                    shutil.rmtree(entry)
+                except PermissionError:
+                    _make_writable_recursive(entry)
+                    shutil.rmtree(entry)

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -244,7 +244,7 @@ class TestContainerBackendPythonArgv:
     def test_raises_not_implemented(self, tmp_path: Path):
         backend = ContainerBackend(project_root=tmp_path)
         with pytest.raises(NotImplementedError, match="only support shell tasks"):
-            backend.python_argv_c(env="docker://img:1", code="print(1)")
+            backend.python_argv_m(env="docker://img:1", module="ginkgo.envs.pixi_worker")
 
 
 class TestContainerBackendEnvLockPath:

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -12,7 +12,6 @@ import pytest
 from ginkgo import evaluate, file, folder, shell, task, tmp_dir
 from ginkgo.pixi import PixiRegistry
 from ginkgo.runtime.evaluator import CycleError, _ConcurrentEvaluator
-from ginkgo.runtime.module_loader import import_roots_for_path, resolve_module_file
 from ginkgo.runtime.worker import run_task
 
 
@@ -610,7 +609,7 @@ class TestInterruptHandling:
 
 
 class TestPixiWorkerPayload:
-    def test_build_worker_payload_uses_minimal_ginkgo_import_roots(self, tmp_path: Path) -> None:
+    def test_build_worker_payload_does_not_contain_import_roots(self, tmp_path: Path) -> None:
         evaluator = _ConcurrentEvaluator()
         expr = add_one_task(x=1)
         node_id = evaluator._register_expr(expr)
@@ -621,17 +620,8 @@ class TestPixiWorkerPayload:
 
         payload = evaluator._build_worker_payload(node=node)
 
-        worker_module_file = resolve_module_file("ginkgo.runtime.worker")
-        assert worker_module_file is not None
-        assert payload["ginkgo_import_roots"] == import_roots_for_path(worker_module_file)
+        assert "ginkgo_import_roots" not in payload
         assert "sys_path" not in payload
-        assert "ginkgo_import_roots" in payload
-
-    def test_pixi_worker_bootstrap_uses_ginkgo_import_roots_not_host_sys_path(self) -> None:
-        from ginkgo.runtime.evaluator import _PIXI_WORKER_C
-
-        assert "ginkgo_import_roots" in _PIXI_WORKER_C
-        assert "sys_path" not in _PIXI_WORKER_C
 
 
 class TestValidation:

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -412,8 +412,6 @@ class TestPixiPythonTask:
         workflow_path = tmp_path / "workflow.py"
         workflow_path.write_text(
             """
-import pandas as pd
-
 from ginkgo import task
 
 
@@ -426,6 +424,8 @@ def needs_worker_import(x: int) -> int:
         )
 
         module = load_module_from_path(workflow_path)
+        # Delete the file so the pixi worker subprocess cannot load it by path.
+        workflow_path.unlink()
         registry = _make_registry(tmp_path)
 
         with pytest.raises(RuntimeError, match="Foreign Python task .*kind='shell'"):

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -235,15 +235,17 @@ class TestPixiRegistry:
         assert "-c" in argv
         assert "echo hello" in argv
 
-    def test_python_argv_c_structure(self) -> None:
+    def test_python_argv_m_structure(self) -> None:
         registry = PixiRegistry(project_root=_TESTS_DIR)
-        argv = registry.python_argv_c(env=_TEST_ENV_NAME, code="print('hi')", args=("a", "b"))
+        argv = registry.python_argv_m(
+            env=_TEST_ENV_NAME, module="ginkgo.envs.pixi_worker", args=("a", "b")
+        )
         assert argv[0] == "pixi"
         assert argv[1] == "run"
         assert "--manifest-path" in argv
         assert "python" in argv
-        assert "-c" in argv
-        assert "print('hi')" in argv
+        assert "-m" in argv
+        assert "ginkgo.envs.pixi_worker" in argv
         assert "a" in argv
         assert "b" in argv
 


### PR DESCRIPTION
## Summary

- **Source code hashing**: `TaskDef` computes a BLAKE3 hash of the task function source at registration time. Any body change invalidates the cache without a manual `version=` bump. Unsourceable functions raise a clear error at decoration time.
- **ArtifactStore abstraction**: New `LocalArtifactStore` stores all content-addressed artifacts under `.ginkgo/artifacts/` with read-only permissions. Subsumes the existing per-cache-entry binary artifact storage in `value_codec`. `artifact_ids` recorded in `meta.json` as the stable identity reference for downstream phases (6, 7, 8, 9).
- **Symlink + read-only file/folder outputs**: After task execution, file/folder outputs are copied into the artifact store and replaced with read-only symlinks. On cache hit: valid symlink → hit; missing symlink → silently recreated; regular file replacing symlink → cache miss and re-execution.
- **BLAKE3 hashing**: New `ginkgo/runtime/hashing.py` centralises all content-addressed hashing. `blake3` added as a hard project dependency. The test pixi env now installs ginkgo as a proper editable package (previously relied on sys.path injection which broke when compiled dependencies were added).
- **Cache prune/clear**: Both commands handle read-only artifacts gracefully and run orphan artifact GC after removal.

## Test plan

- [ ] `tests/test_artifact_store.py` — 17 unit tests: store/retrieve/delete for files, directories, raw bytes; idempotency; read-only enforcement; symlink creation
- [ ] `tests/test_cache_integrity.py` — 13 integration tests: source hash invalidation, file/folder symlink creation, read-only enforcement, symlink recreation on cache hit, cache miss on external file replacement, prune handling
- [ ] Full existing test suite (246 tests) passes with no regressions