### PR TITLE
Implement staged remote artifact access

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -13,42 +13,34 @@ Each phase is independently testable and follows the same structure:
 
 ## Tier 2 — Build on Foundations
 
-### Phase 6 — Remote Artifact Store
+### Phase 6 — Remote References and Staged Access
 
-**Goal:** Add a remote-capable artifact access layer that lets Ginkgo tasks read
-object storage inputs through normal filesystem paths, while remaining
-compatible with future remote execution.
+**Goal:** Add first-class remote object references and worker-local staged
+access so Ginkgo tasks can read object storage inputs through normal local
+filesystem paths, while remaining compatible with future remote execution.
 
 **Detailed design:** [`docs/phase6-remote-artifact-store-plan.md`](phase6-remote-artifact-store-plan.md)
 
 **Depends on:** Phase 2 (`ArtifactStore`, immutable artifact IDs, cache
 metadata). Hard prerequisite for Phase 14 (remote execution). Improves Phase 7,
-Phase 8, and Phase 9 by allowing artifacts to be stored and rehydrated outside
-the local machine.
+Phase 8, and Phase 9 by allowing remote inputs to be resolved consistently on
+workers outside the local machine.
 
 #### Deliverables
 
-- Refactor the artifact model from "local file or copied directory" into a
-  unified content-addressed store supporting:
-  - immutable file blobs
-  - immutable tree manifests for directory artifacts
-  - artifact metadata records that separate identity from local access paths
 - Distinguish between:
-  - managed artifacts published by Ginkgo
+  - managed local artifacts produced by Ginkgo
   - external remote object references such as `s3://...` and `oci://...`
 - Add canonical remote input constructors such as `remote_file(...)` and
   `remote_folder(...)`.
 - Add annotation-aware coercion so URI strings passed to parameters annotated as
   `file` or `folder` can be upgraded automatically to remote references.
-- Replace the current local-path-centric retrieval contract with a task-facing
-  resolution layer that can provide a local readable path by:
-  - local symlink
-  - staged local hydration
-  - mounted virtual filesystem access
-- Add a worker-local cache for remote reads and writes, with content-addressed
-  reuse across tasks on the same machine.
-- Publish task outputs into a remote-capable managed artifact store rather than
-  assuming the producer's local path is durable.
+- Materialize remote refs through a worker-local staging cache before task
+  execution.
+- Add a worker-local cache for remote reads, with content-addressed reuse
+  across tasks on the same machine.
+- Keep the remote backend abstraction compatible with `fsspec`-style adapters
+  such as `s3fs` and `ocifs`.
 - Record remote identity metadata in cache and provenance so reproducibility is
   preserved across machines.
 
@@ -59,17 +51,16 @@ the local machine.
 - `file` and `folder` should remain type-level input and output contracts.
   Remote values should be represented by explicit reference objects, with URI
   string auto-coercion limited to `file` and `folder` parameters only.
-- FUSE or Fusion-like mounted access is an optimization and UX layer, not the
-  correctness contract. A staging fallback must remain first-class.
+- Staging is the correctness path for remote inputs.
+- FUSE or Fusion-like mounted access remains a possible later optimization, but
+  is not part of the active Phase 6 scope.
 - Remote URIs are not stable cache identity by themselves. Cache keys must use
   version IDs, checksums, or materialized content hashes.
-- Directory artifacts must become tree manifests rather than opaque copied
-  folders if Ginkgo wants lazy mounted access and sparse hydration.
-- Object storage remains the durable source of truth. Local disk is a
-  transparent cache and writeback layer.
+- Worker-local staging must remain compatible with Kubernetes and other cloud
+  execution environments where workers do not share the scheduler filesystem.
 - Ginkgo should exploit workflow semantics such as known task inputs,
-  deterministic workdirs, and explicit artifact identity to enable prefetch and
-  deduplication.
+  deterministic workdirs, and explicit artifact identity to enable reuse and
+  later optimizations.
 
 #### Validation
 
@@ -83,10 +74,10 @@ the local machine.
 - Changing a remote object version invalidates the cache deterministically.
 - Two tasks on the same worker reuse the same local cached artifact instead of
   downloading it twice.
-- A produced output can be published to remote storage and consumed from a
-  different machine.
-- Environments that cannot use a mounted filesystem fall back to staging
-  without workflow changes.
+- The staging root can be configured for worker-local storage in future cloud
+  deployments.
+- The Phase 6 design remains compatible with a future FUSE-like optimization
+  without requiring mounted access today.
 
 ---
 

--- a/docs/phase6-remote-artifact-store-plan.md
+++ b/docs/phase6-remote-artifact-store-plan.md
@@ -1,0 +1,386 @@
+# Phase 6 Plan: Remote References and Staged Access
+
+## Problem Definition
+
+Ginkgo's current runtime is path-oriented. Tasks consume `file` and `folder`
+values as ordinary local filesystem paths, cached outputs are restored from the
+local artifact store, and shell and notebook execution assume those paths are
+usable without provider-specific I/O code.
+
+Phase 6A and Phase 6B established two important foundations:
+
+- the local artifact store now uses explicit blob/tree records
+- workflows can declare `s3://...` and `oci://...` inputs through first-class
+  remote references and have them staged locally before execution
+
+Those changes were originally framed as the first half of a larger plan that
+would later add FUSE-like mounted access and a remote-capable managed artifact
+store. That framing is too broad for the current needs of the project.
+
+The immediate problem to solve is narrower:
+
+- users need to pass object storage inputs into tasks without writing manual
+  download code
+- tasks must continue to receive ordinary local paths
+- the design must remain compatible with future Kubernetes and cloud execution,
+  where workers should stage inputs into worker-local storage rather than rely
+  on a shared scheduler filesystem
+
+## Proposed Scope
+
+Phase 6 should now focus on one correctness path only:
+
+- external remote references are resolved by staging them into worker-local
+  storage before task execution
+
+Phase 6 should not currently include:
+
+- FUSE-like mounted access as an active implementation target
+- publication of all managed artifacts into a remote store
+- a general multi-driver access engine where mount and stage are treated as
+  interchangeable runtime modes
+
+Those may still happen later, but they should be treated as follow-on work
+built on top of the staged-access model rather than part of the active Phase 6
+deliverable.
+
+## Goals
+
+- Allow workflow authors to pass remote object storage URIs into `file(...)`
+  and `folder(...)` inputs without explicit staging code.
+- Preserve local-path task semantics for Python, shell, notebook, and future
+  remote-worker execution.
+- Make staging the single correctness path for remote inputs.
+- Keep remote input identity, cache keys, and provenance explicit and
+  reproducible.
+- Use a storage adapter layer that can support `fsspec`-style backends such as
+  `s3fs` and `ocifs`.
+- Keep the design compatible with future worker execution on Kubernetes or
+  other cloud platforms.
+- Preserve extension points for a future FUSE-like optimization without
+  forcing mount-specific complexity into the current runtime.
+
+## Non-Goals
+
+- Implementing a mounted virtual filesystem in this phase.
+- Requiring Linux FUSE, macFUSE, or any other platform-specific mount support.
+- Turning object storage into a distributed POSIX filesystem.
+- Publishing every task output to object storage as part of the active Phase 6
+  scope.
+- Solving high-performance streaming, byte-range reads, or lazy hydration in
+  this phase.
+
+## Summary of the Proposed Solution
+
+Phase 6 should define a simple, stable contract:
+
+- workflows may declare external remote references
+- the evaluator resolves those references before task launch
+- remote files and folders are staged into worker-local storage
+- tasks receive normal local paths
+- cache identity is based on immutable remote metadata where possible and on
+  content digests after staging
+
+The runtime should be built around a small backend abstraction for object
+storage operations. That abstraction may be implemented with `fsspec`,
+`s3fs`, and `ocifs`, but the task-facing contract remains local-path-based.
+
+## Design Principles
+
+- Preserve the current task contract: tasks open local paths, not remote
+  streams.
+- Treat staging as the correctness layer, not as a fallback beneath a future
+  mount.
+- Keep remote input handling separate from the managed local artifact store.
+- Prefer worker-local caches and explicit transfer steps over shared mutable
+  filesystems.
+- Preserve explicit remote reference objects so future access modes can be
+  added without changing workflow code.
+- Keep scheduler and worker responsibilities compatible with Kubernetes-style
+  deployment, where workers may run in isolated pods with ephemeral local disk.
+
+## User-Facing Model
+
+```python
+from ginkgo import flow, task, file, remote_file
+
+
+@task
+def count_lines(path: file) -> int:
+    with open(path) as handle:
+        return sum(1 for _ in handle)
+
+
+@flow
+def main() -> int:
+    return count_lines(remote_file("s3://my-bucket/data/sample.txt"))
+```
+
+The task still receives a normal local path. Internally, Ginkgo stages the
+remote file into worker-local storage before the task starts.
+
+`remote_file()` remains the canonical constructor for file-shaped remote
+inputs, and `remote_folder()` remains the canonical constructor for
+folder-shaped remote inputs.
+
+Annotation-aware coercion remains useful, but it should stay narrow:
+
+- if a parameter is annotated as `file` or `folder`
+- and the caller passes a supported remote URI string such as `s3://...` or
+  `oci://...`
+- the evaluator may coerce that string into a remote reference and stage it
+
+Plain `str` parameters must remain plain strings.
+
+## Architecture
+
+### 1. Two Distinct Domains
+
+Phase 6 should keep a clear separation between:
+
+- managed local artifacts produced by Ginkgo
+- external remote references declared by the user
+
+Managed local artifacts continue to use the local blob/tree CAS introduced in
+Phase 6A. External remote references are staged into a separate local cache.
+
+This separation matters because the current requirement is remote input
+consumption, not a full remote artifact lifecycle for all outputs.
+
+### 2. Remote Reference Model
+
+Remote references remain explicit immutable values:
+
+- `RemoteFileRef`
+- `RemoteFolderRef`
+
+They represent provider URI, remote object identity hints, and enough metadata
+for the runtime to select the right backend and reproducibility policy.
+
+This explicit model should stay even though mounting is deferred. It is the
+main compatibility point for future enhancements such as:
+
+- FUSE-like path exposure
+- task-aware prefetch
+- remote worker transfer planning
+- stricter pinning and provenance policies
+
+### 3. Worker-Local Staging Contract
+
+The evaluator should resolve each remote input into a local staged path before
+task dispatch.
+
+For files:
+
+- download into a local staging cache
+- compute or confirm content identity
+- hand the staged local path to the task
+
+For folders:
+
+- enumerate the remote prefix
+- materialize the directory tree into worker-local storage
+- hand the local directory path to the task
+
+This contract works locally today and maps directly to cloud execution later:
+
+- on a local machine, the worker-local cache may live under `.ginkgo/staging/`
+- on Kubernetes, the same cache contract can point at pod-local ephemeral
+  storage or another node-local writable volume
+
+### 4. Backend Abstraction
+
+The runtime should keep a small backend protocol for object storage operations:
+
+- inspect object metadata
+- download one object
+- list a prefix
+- optionally upload in later phases
+
+The current implementation may use provider-specific clients, but the target
+direction for this phase is to support an adapter implementation based on
+`fsspec`, including:
+
+- `s3fs` for S3-compatible object storage
+- `ocifs` for OCI Object Storage
+
+Using a backend abstraction keeps evaluator logic independent from transport
+details and avoids coupling the task model to Python-only file interfaces.
+
+### 5. Identity and Reproducibility
+
+Remote URIs are mutable and must not be treated as stable cache identity.
+
+The staging cache should prefer the following identity policy:
+
+1. use an explicit version ID when present
+2. otherwise use provider metadata such as ETag when trustworthy
+3. materialize and hash the content when immutable metadata is insufficient
+
+For folders, Phase 6 should be explicit that folder identity is harder than
+file identity. A folder/prefix should eventually resolve to a manifest-like
+identity derived from the listed objects and their metadata, not just the URI
+string.
+
+### 6. Cloud and Kubernetes Compatibility
+
+The staged-access design should assume the long-term deployment model may
+include isolated workers running on Kubernetes or similar systems.
+
+That implies:
+
+- no assumption that workers can see the scheduler's local artifact root
+- no dependence on privileged FUSE support in containers
+- credentials should come from environment, mounted secrets, or provider-native
+  identity, not from hard-coded local machine assumptions
+- staging paths should be configurable so workers can use pod-local writable
+  volumes
+
+This is a better fit for cloud execution than treating mounted access as the
+primary path.
+
+## Why This Still Leaves Room for Future FUSE-Like Access
+
+Deferring mounted access does not invalidate the work already done.
+
+Phase 6A remains useful because blob/tree CAS and explicit artifact metadata
+are still the right internal representation for managed artifacts.
+
+Phase 6B remains useful because explicit remote references and staging are the
+correct baseline for any future optimization.
+
+If Ginkgo later adds a FUSE-like system, it should build on top of the same
+reference and staging model:
+
+- remote refs stay the user-facing abstraction
+- staging remains the correctness baseline and fallback path
+- any mount implementation becomes a worker-local optimization layer
+
+That future system should be justified by a specific execution environment and
+performance need, not treated as a prerequisite for remote input support.
+
+## Implemented Work and Required Adjustments
+
+The repository already contains meaningful Phase 6 work. Most of it still fits
+the revised plan, but some parts should be adjusted or re-scoped.
+
+### Work That Still Fits the Revised Plan
+
+- `ginkgo/core/remote.py`
+  Explicit `RemoteFileRef` and `RemoteFolderRef` types still match the desired
+  architecture.
+- `ginkgo/runtime/evaluator.py`
+  Remote ref staging and annotation-aware coercion still fit the active Phase 6
+  design.
+- `ginkgo/remote/staging.py`
+  A dedicated staging cache remains central to the revised plan.
+- Phase 6A blob/tree CAS
+  The local managed artifact model remains valid even without mount support.
+
+### Implemented Areas That Need Adjustment
+
+- `ginkgo/remote/publisher.py` and evaluator-driven remote publisher loading
+  should no longer be treated as part of active Phase 6 scope.
+  This work should move into a later phase focused on remote publication of
+  managed artifacts.
+
+- `ginkgo/remote/s3_compat.py` and `ginkgo/remote/resolve.py` currently encode
+  a boto3-based S3-compatible path for both S3 and OCI.
+  That is workable in the short term, but it does not yet reflect the desired
+  backend direction of `fsspec` plus provider-specific adapters such as
+  `s3fs` and `ocifs`.
+  The Phase 6 plan should therefore treat the backend implementation as
+  replaceable behind the protocol.
+
+- `ginkgo/remote/staging.py` currently stages folders under a URI-hash-based
+  directory.
+  That is adequate as a first implementation, but it is weaker than the file
+  identity model.
+  The revised plan should call for stronger folder identity based on a listed
+  object manifest rather than URI alone.
+
+- OCI backend configuration currently depends on environment-specific endpoint
+  construction.
+  That should be tightened so cloud and Kubernetes deployments can resolve
+  credentials and endpoints cleanly through runtime configuration and
+  provider-native mechanisms.
+
+## Implementation Stages
+
+### Stage 1: Consolidate the staged-access contract
+
+- Keep `remote_file()` and `remote_folder()` as the canonical remote input
+  constructors.
+- Keep annotation-aware coercion limited to `file` and `folder` parameters.
+- Remove Phase 6 references to mount-mode selection and remote output
+  publication as active deliverables.
+- Document staging as the sole correctness path for remote inputs.
+
+### Stage 2: Stabilize the worker-local staging cache
+
+- Keep a dedicated staging cache separate from the managed artifact store.
+- Ensure staged files are content-addressed and reusable across tasks on the
+  same worker.
+- Make the staging root configurable for cloud and Kubernetes workers.
+- Tighten folder staging semantics so folder identity can later be derived from
+  a manifest-like listing rather than only a URI hash.
+
+### Stage 3: Standardize backend integration
+
+- Keep the backend protocol narrow and evaluator-facing.
+- Support S3 and OCI through replaceable backends.
+- Prefer an implementation direction compatible with `fsspec`, `s3fs`, and
+  `ocifs`.
+- Keep provider-specific credential handling outside core task logic.
+
+### Stage 4: Strengthen reproducibility and provenance
+
+- Record remote identity hints such as URI, version ID, ETag, and resolved
+  digest in staging metadata.
+- Ensure cache keys for remote file inputs use stable content identity.
+- Define the provenance contract for folder refs clearly enough to support
+  future remote-worker execution.
+
+### Stage 5: Prepare for cloud worker execution
+
+- Ensure remote input resolution does not assume shared local scheduler state.
+- Treat worker-local staging as the execution boundary for future Kubernetes
+  workers.
+- Keep extension points for later optimizations such as prefetch, sparse
+  hydration, or FUSE-like mounted access, but do not implement them in this
+  phase.
+
+## Risks and Tradeoffs
+
+- Staging large inputs has latency and local disk costs.
+  That is an accepted tradeoff for a simpler and more portable correctness
+  model.
+
+- Deferring mounted access means some large-file workloads may be less
+  efficient than a mature Fusion-like system.
+  That is acceptable until there is a concrete performance problem in a target
+  deployment environment.
+
+- Folder identity remains more subtle than file identity.
+  This needs explicit follow-up so remote folder caching does not become too
+  URI-dependent.
+
+- Backend standardization around `fsspec` may still require provider-specific
+  exceptions.
+  The protocol boundary should absorb those differences.
+
+## Success Criteria
+
+- A Python task can consume `remote_file("s3://...")` through a normal local
+  path without explicit download code.
+- A shell or notebook task can consume the same staged path without any
+  provider-specific logic.
+- A `file` or `folder` parameter can accept a supported remote URI string
+  through annotation-aware coercion.
+- Re-running against the same pinned remote object reuses staged content on the
+  same worker.
+- Changing remote object identity invalidates the cache deterministically.
+- The staging root can be configured for worker-local storage in future cloud
+  deployments.
+- The Phase 6 design remains compatible with a future FUSE-like optimization,
+  but does not require it.

--- a/docs/phase6a-blob-tree-cas-plan.md
+++ b/docs/phase6a-blob-tree-cas-plan.md
@@ -1,0 +1,178 @@
+# Phase 6A Plan: Refactor Local Artifact Store onto Unified Blob/Tree CAS
+
+## Problem Definition
+
+The current `LocalArtifactStore` uses a flat content-addressed layout:
+
+- Files: `.ginkgo/artifacts/<blake3>.<ext>`
+- Directories: `.ginkgo/artifacts/<blake3>/` (full recursive copy)
+
+This works for local execution but has three limitations that block later
+Phase 6 work:
+
+1. **No artifact metadata**: artifact IDs are bare filesystem names with no
+   associated metadata (digest algorithm, kind, size, provenance origin).
+   Remote backends need richer identity records.
+
+2. **Opaque directory storage**: directories are stored as monolithic copies.
+   There is no manifest describing their internal structure, which prevents
+   lazy access, sparse hydration, and deduplication of shared files across
+   directories.
+
+3. **Extension-in-ID coupling**: the `<hash>.<ext>` naming convention bakes
+   the file extension into the artifact identity. A storage-layout-neutral
+   model should separate content identity from presentation metadata.
+
+Phase 6A refactors the local store onto a unified blob/tree CAS model that
+resolves these issues. Breaking changes to internal APIs and storage layout
+are acceptable.
+
+## Proposed Solution
+
+### New Storage Layout
+
+```text
+.ginkgo/artifacts/
+  blobs/
+    <digest>                # raw file bytes, read-only
+  trees/
+    <tree_digest>.json      # directory manifest
+  refs/
+    <artifact_id>.json      # artifact metadata record
+```
+
+- **Blobs** are raw content bytes, named by digest alone (no extension).
+- **Tree manifests** map `{relative_path: blob_digest, size, mode}` entries.
+- **Artifact refs** are metadata records that tie together identity, kind,
+  digest, original extension, size, and storage backend.
+
+### New Data Model
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class BlobRef:
+    """Reference to a single content-addressed blob."""
+    digest_algorithm: str   # "blake3"
+    digest_hex: str         # hex digest
+    size: int               # byte count
+    extension: str          # original file extension (e.g. ".csv")
+
+@dataclass(frozen=True, kw_only=True)
+class TreeEntry:
+    """One entry in a tree manifest."""
+    relative_path: str
+    blob_digest: str
+    size: int
+    mode: int               # original file mode (e.g. 0o644)
+
+@dataclass(frozen=True, kw_only=True)
+class TreeRef:
+    """Reference to a directory manifest."""
+    digest_algorithm: str
+    digest_hex: str         # digest of the manifest content
+    entries: tuple[TreeEntry, ...]
+
+@dataclass(frozen=True, kw_only=True)
+class ArtifactRecord:
+    """Metadata record persisted alongside stored content."""
+    artifact_id: str        # unique ID (= content digest for managed artifacts)
+    kind: str               # "blob" | "tree"
+    digest_algorithm: str
+    digest_hex: str
+    extension: str           # original extension for blobs, empty for trees
+    size: int                # total bytes
+    created_at: str          # ISO timestamp
+    storage_backend: str     # "local" for now, "s3" / "oci" later
+```
+
+### Refactored ArtifactStore Contract
+
+The `ArtifactStore` protocol changes to return richer types. All callers
+are updated directly -- no backward-compat shims.
+
+| Current method              | New method                          | Change summary                           |
+|-----------------------------|-------------------------------------|------------------------------------------|
+| `store(src_path) -> str`    | `store(src_path) -> ArtifactRecord` | Returns record instead of bare ID string |
+| `retrieve(id, dest_path)`   | `retrieve(id, dest_path)`           | Unchanged caller contract                |
+| `exists(id) -> bool`        | `exists(id) -> bool`                | Unchanged                                |
+| `delete(id)`                | `delete(id)`                        | Cleans up blobs + tree + ref             |
+| `artifact_path(id) -> Path` | `artifact_path(id) -> Path`         | Returns blob path or reconstructed dir   |
+| `store_bytes(data, ext)`    | `store_bytes(data, ext)`            | Returns `ArtifactRecord`                 |
+| `read_bytes(id) -> bytes`   | `read_bytes(id) -> bytes`           | Unchanged                                |
+
+### Directory Storage Change
+
+Currently directories are copied wholesale. Under the new model:
+
+1. Walk the directory tree.
+2. Store each file as an individual blob.
+3. Build a `TreeRef` manifest from the entries.
+4. Serialize and store the manifest as `trees/<tree_digest>.json`.
+5. Write an `ArtifactRecord` with `kind="tree"`.
+
+On retrieval:
+
+1. Load the tree manifest.
+2. Reconstruct the directory by creating symlinks (or copies) from blobs.
+
+This decomposition enables later phases to do sparse hydration, lazy reads,
+and cross-directory blob deduplication.
+
+## Implementation Stages
+
+### Stage 1: Introduce data model types (pure addition)
+
+- Add `ginkgo/runtime/artifact_model.py` with `BlobRef`, `TreeEntry`,
+  `TreeRef`, `ArtifactRecord`.
+- Unit tests for serialization/deserialization of these types.
+- No behavioral changes to existing code.
+
+### Stage 2: Refactor LocalArtifactStore for blob storage
+
+- Change file storage from `<hash>.<ext>` to `blobs/<digest>`.
+- Add `refs/<artifact_id>.json` metadata writing.
+- Change `store()` return type to `ArtifactRecord`.
+- Update all callers directly.
+- Update `retrieve()`, `exists()`, `delete()`, `artifact_path()`.
+- Update `store_bytes()` and `read_bytes()`.
+
+### Stage 3: Add tree manifest support for directories
+
+- Decompose directory storage into per-file blobs + tree manifest.
+- Store manifests under `trees/<tree_digest>.json`.
+- Update `retrieve()` to reconstruct directories from tree manifests.
+- Ensure symlink-based retrieval still works for directory outputs.
+
+### Stage 4: Update cache and evaluator integration
+
+- Update `CacheStore` to work with `ArtifactRecord` instead of bare string
+  IDs in `meta.json`.
+- Update `_store_output_artifacts()` and `_symlink_output_artifacts()`.
+- Update `validate_cached_outputs()` for new blob paths.
+- No backward compatibility with old cache entries -- users run
+  `ginkgo cache clear` after upgrading.
+
+### Stage 5: Update tests
+
+- Update `test_artifact_store.py` for new layout and return types.
+- Update `test_cache_integrity.py` for new symlink targets.
+- Run full integration suite (`test_examples.py`) to confirm no regressions.
+
+## Risks and Tradeoffs
+
+- **Directory decomposition increases I/O**: storing N individual blobs
+  instead of one `shutil.copytree` is more filesystem operations. For the
+  local case this is acceptable; it becomes an advantage for remote backends.
+- **Breaking change**: existing `.ginkgo/artifacts/` and `.ginkgo/cache/`
+  directories become invalid after the refactor. A `ginkgo cache clear`
+  is required after upgrading.
+
+## Success Criteria
+
+- All existing tests pass with the new storage layout.
+- `LocalArtifactStore` uses `blobs/<digest>` for file storage.
+- Directory artifacts are decomposed into individual blobs plus a tree
+  manifest.
+- Artifact metadata records are persisted as JSON alongside stored content.
+- Cache hit/miss behavior is correct on fresh runs.
+- Integration examples run and cache correctly.

--- a/docs/phase6b-remote-refs-staging-plan.md
+++ b/docs/phase6b-remote-refs-staging-plan.md
@@ -1,0 +1,319 @@
+# Phase 6B Plan: External Remote References and Staging-Based Access
+
+## Problem Definition
+
+After Phase 6A, the local artifact store uses a blob/tree CAS model with
+metadata records. But workflows can only consume local filesystem paths.
+A bioinformatics user who wants to run a task against
+`s3://my-bucket/samples/reads.fastq.gz` or
+`oci://namespace/bucket/object` must write their own download logic before
+passing the path to a Ginkgo task.
+
+Phase 6B adds first-class remote file references so that workflows can
+declare remote URIs and have Ginkgo stage them transparently before task
+execution.
+
+## Goals
+
+- `remote_file("s3://...")` / `remote_file("oci://...")` and
+  `remote_folder(...)` as value constructors that workflows can pass
+  directly to `file` and `folder` task parameters.
+- Transparent staging: remote refs are downloaded to a local staging cache
+  before the task runs. The task receives a normal local path.
+- Cache identity: remote input identity participates correctly in cache
+  keys using content digests, not mutable URIs.
+- Annotation-aware coercion: raw `s3://` and `oci://` strings passed to
+  `file`/`folder` parameters are auto-upgraded to remote references.
+- Output publishing: task outputs can be published to a remote artifact
+  store so downstream tasks or future runs on other machines can consume
+  them.
+- Both AWS S3 and Oracle Cloud Infrastructure (OCI) Object Storage from
+  the start, since test data lives in OCI.
+
+## Non-Goals
+
+- FUSE-mounted access (that is Phase 6C).
+- Parallel transfer or byte-range reads (that is Phase 6D).
+- Remote worker bootstrap (that is Phase 6E).
+
+## Proposed Solution
+
+### User-Facing API
+
+```python
+from ginkgo import task, flow, file, remote_file
+
+@task()
+def count_lines(path: file) -> int:
+    with open(path) as handle:
+        return sum(1 for _ in handle)
+
+@flow
+def main():
+    # Explicit remote references.
+    s3_input = remote_file("s3://my-bucket/data/sample.txt")
+    oci_input = remote_file("oci://namespace/bucket/path/to/object.csv")
+
+    # Or via annotation-aware coercion (same effect):
+    return count_lines(path="s3://my-bucket/data/sample.txt")
+```
+
+The task still receives a normal local path. Ginkgo downloads the file
+into a staging cache before task execution.
+
+### Remote Reference Types
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class RemoteRef:
+    """Base for remote object references."""
+    uri: str
+    scheme: str           # "s3", "oci"
+
+@dataclass(frozen=True, kw_only=True)
+class RemoteFileRef(RemoteRef):
+    """Remote reference to a single file."""
+
+@dataclass(frozen=True, kw_only=True)
+class RemoteFolderRef(RemoteRef):
+    """Remote reference to a directory prefix."""
+```
+
+These are **not** subclasses of `file`/`folder` (which are `str` subclasses
+that validate local existence). They are opaque references that the
+evaluator materializes into local `file`/`folder` values before task
+dispatch.
+
+URI parsing is scheme-specific:
+- **S3**: `s3://bucket/key` → bucket + key, optional `?versionId=...`
+- **OCI**: `oci://namespace/bucket/key` → namespace + bucket + key
+
+### S3-Compatible Protocol
+
+Both AWS S3 and OCI Object Storage implement the S3-compatible API. OCI
+Object Storage supports S3 compatibility mode natively, so a single
+`boto3`-based client can serve both backends by varying the endpoint URL.
+
+The backend resolution therefore maps:
+- `s3://` → S3-compatible client with default AWS endpoint
+- `oci://` → S3-compatible client with OCI-specific endpoint
+  (`https://<namespace>.compat.objectstorage.<region>.oraclecloud.com`)
+
+This means we need only one storage backend implementation, parameterized
+by endpoint and credential source.
+
+### Staging Cache
+
+Remote files are staged into a local content-addressed cache:
+
+```text
+.ginkgo/staging/
+  blobs/
+    <digest>                    # cached remote file bytes
+  metadata/
+    <uri_hash>.json             # { uri, digest, etag, version_id, size, staged_at }
+```
+
+The staging cache is separate from the artifact store. The artifact store
+holds task outputs; the staging cache holds downloaded remote inputs.
+
+Staging metadata records the content digest, ETag, and version ID (when
+available) so that cache identity is based on content, not the mutable URI.
+
+### Reproducibility Policy for Remote Inputs
+
+Remote URIs are mutable. Cache identity must be based on content, not URI.
+
+Resolution order:
+1. If the remote ref has `version_id`, use it as an immutable pin.
+2. Otherwise, fetch the object's ETag via HEAD.
+3. On first access, download and hash the content. Store the digest in
+   staging metadata.
+4. On subsequent access with matching ETag, skip re-download.
+5. If ETag changes, re-download and recompute the digest.
+
+This works identically for S3 and OCI Object Storage since both support
+ETag and versioning through the S3-compatible API.
+
+For cache keys, the input hash for a remote file is its content digest
+(same as for local files), computed after staging.
+
+### Storage Backend Protocol
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class RemoteObjectMeta:
+    """Metadata returned by remote storage operations."""
+    uri: str
+    size: int
+    etag: str | None = None
+    digest: str | None = None
+    version_id: str | None = None
+
+class RemoteStorageBackend(Protocol):
+    def head(self, *, uri: str) -> RemoteObjectMeta:
+        """Return metadata without downloading."""
+        ...
+
+    def download(self, *, uri: str, dest_path: Path) -> RemoteObjectMeta:
+        """Download an object to a local path."""
+        ...
+
+    def upload(self, *, src_path: Path, uri: str) -> RemoteObjectMeta:
+        """Upload a local file to a remote URI."""
+        ...
+
+    def list_prefix(self, *, uri: str) -> list[RemoteObjectMeta]:
+        """List objects under a prefix (for folder refs)."""
+        ...
+```
+
+A single `S3CompatibleBackend` class implements this protocol for both
+S3 and OCI Object Storage. The backend is constructed with an endpoint URL
+and credentials appropriate to the scheme.
+
+### Backend Resolution
+
+A `resolve_backend(scheme: str) -> RemoteStorageBackend` dispatcher
+constructs the correct client:
+
+- `s3://` → `S3CompatibleBackend(endpoint=None)` (default AWS endpoint)
+- `oci://` → `S3CompatibleBackend(endpoint=oci_s3_compat_endpoint)`
+
+The OCI endpoint and namespace are resolved from configuration or
+environment variables.
+
+### Evaluator Integration
+
+The materialization happens in `_resolve_task_args()`, after
+`_materialize()` resolves expression dependencies but before validation
+and cache-key building.
+
+Flow:
+1. `_materialize()` returns the raw value (a `RemoteFileRef` or string).
+2. A new `_stage_remote_refs()` step checks each resolved arg:
+   - If it's a `RemoteFileRef`/`RemoteFolderRef`, download it to the
+     staging cache and replace the value with a local `file(staged_path)`
+     or `folder(staged_path)`.
+   - If it's a raw `s3://...` or `oci://...` string and the parameter
+     annotation is `file` or `folder`, auto-coerce to a remote ref and
+     stage it.
+3. Validation and cache-key building proceed against the local staged path.
+
+### Output Publishing
+
+When the workflow is configured with a remote artifact store, task outputs
+are published after execution:
+
+1. Task produces a local `file`/`folder` output.
+2. The local artifact store stores it as before (blob/tree CAS).
+3. If a remote store is configured, the blob(s) are uploaded to the
+   remote prefix.
+4. The `ArtifactRecord` gains a `remote_uri` field pointing to the
+   published location.
+
+This makes outputs consumable from other machines.
+
+### Configuration
+
+Remote store configuration lives in `ginkgo.toml`:
+
+```toml
+[remote]
+store = "s3://my-bucket/ginkgo-artifacts/"
+region = "eu-west-1"  # optional, defaults to boto3 resolution
+
+# For OCI Object Storage:
+# store = "oci://namespace/bucket/ginkgo-artifacts/"
+# region = "uk-london-1"
+```
+
+Credentials are resolved through provider-native chains:
+- S3: boto3 chain (env vars, AWS config, IAM roles)
+- OCI: OCI config (`~/.oci/config`) or S3-compat credentials via env vars
+
+Ginkgo does not manage credentials directly.
+
+## Implementation Stages
+
+### Stage 1: Remote reference types and constructors
+
+- Add `ginkgo/core/remote.py` with `RemoteRef`, `RemoteFileRef`,
+  `RemoteFolderRef`.
+- Add `remote_file()` and `remote_folder()` constructor functions with
+  URI parsing for `s3://` and `oci://` schemes.
+- Export from `ginkgo/__init__.py`.
+- Unit tests for construction and URI parsing.
+
+### Stage 2: S3-compatible storage backend
+
+- Add `ginkgo/remote/__init__.py`, `ginkgo/remote/backend.py` with
+  `RemoteStorageBackend` protocol and `RemoteObjectMeta`.
+- Add `ginkgo/remote/s3_compat.py` with `S3CompatibleBackend` using
+  `boto3`. Parameterized by endpoint URL to support both S3 and OCI.
+- Add `ginkgo/remote/resolve.py` with `resolve_backend(scheme)`.
+- Implement `head()`, `download()`, `upload()`, `list_prefix()`.
+- Unit tests with mocked boto3 client.
+
+### Stage 3: Staging cache
+
+- Add `ginkgo/remote/staging.py` with the staging cache implementation.
+- Content-addressed staging under `.ginkgo/staging/blobs/<digest>`.
+- Staging metadata records under `.ginkgo/staging/metadata/<uri_hash>.json`.
+- ETag-based freshness checks to avoid redundant downloads.
+- Unit tests for stage/lookup/freshness.
+
+### Stage 4: Evaluator integration
+
+- Add `_stage_remote_refs()` to the evaluator, called between
+  `_materialize()` and `_validate_inputs()`.
+- Remote refs are replaced with local `file(staged_path)` /
+  `folder(staged_path)` values.
+- Update `_contains_dynamic_expression()` to handle remote ref types.
+- Annotation-aware coercion: raw `s3://` and `oci://` strings in
+  `file`/`folder` params auto-upgrade to remote refs before staging.
+- Integration tests with mocked backends.
+
+### Stage 5: Cache identity for remote inputs
+
+- Remote file inputs are hashed by their staged content digest (same
+  as local files -- the staging step already produces a local path).
+- Provenance records both the user-facing URI and the resolved content
+  digest.
+- Test that changing a remote object's content invalidates the cache.
+
+### Stage 6: Output publishing to remote store
+
+- Add optional remote publishing after local artifact storage.
+- If `[remote] store` is configured, upload blobs after task completion.
+- Record `remote_uri` in `ArtifactRecord`.
+- Integration test: publish an output, verify it exists in mocked backend.
+
+## Risks and Tradeoffs
+
+- **boto3 dependency**: adds a significant transitive dependency. Keep it
+  optional (import on first use, clear error if missing).
+- **Staging latency**: downloads happen synchronously before task execution.
+  Phase 6D adds prefetch and parallel transfer.
+- **Large files**: no byte-range or parallel download in this phase. Files
+  are downloaded whole. Acceptable for a first cut.
+- **Credential management**: deferred to provider-native chains. Phase 13
+  may add Ginkgo-managed secrets for credentials.
+- **Folder refs**: listing a prefix and downloading all objects is
+  inherently slower than a single file. Consider warning for large
+  prefixes.
+
+## Success Criteria
+
+- `remote_file("s3://bucket/key")` passed to a `file` parameter works:
+  the file is staged locally and the task receives a local path.
+- `remote_file("oci://namespace/bucket/key")` works the same way via the
+  S3-compatible endpoint.
+- `remote_folder("s3://bucket/prefix/")` works for directory-shaped inputs.
+- A raw `"s3://..."` or `"oci://..."` string passed to a `file` parameter
+  is auto-coerced.
+- Cache identity uses content digest, not the mutable URI.
+- Changing the remote object invalidates the cache.
+- Two tasks consuming the same remote file share the staged copy.
+- Task outputs can be published to remote storage when configured.
+- All existing local-only workflows continue to work unchanged.

--- a/docs/phase6d-concurrent-staging-plan.md
+++ b/docs/phase6d-concurrent-staging-plan.md
@@ -1,0 +1,307 @@
+# Phase 6D Plan: Concurrent Worker-Affine Remote Staging
+
+## Problem Definition
+
+Phase 6B established remote references and staged access as the correctness
+path for remote inputs. That works, but the current implementation stages
+remote inputs synchronously during task preparation in the evaluator thread.
+
+This has two immediate drawbacks:
+
+1. **Serial staging bottleneck**: when multiple ready tasks need independent
+   remote inputs, those downloads happen one at a time even if the run has
+   spare execution capacity.
+2. **Weak execution locality model**: staging currently happens as part of
+   scheduler-side preparation, which does not map cleanly to future Kubernetes
+   or cloud workers where staged files should live on the same worker that will
+   execute the task.
+
+The bioinformatics example makes this visible: multiple FASTQ inputs can be
+staged independently, but they are currently hydrated in sequence before their
+tasks are dispatched.
+
+## Goals
+
+- Allow multiple ready tasks to stage independent remote inputs concurrently.
+- Keep staged files worker-local and treat staging as part of task execution
+  rather than scheduler-global preprocessing.
+- Preserve the current path-based task contract: tasks still receive ordinary
+  local paths.
+- Avoid duplicate downloads when multiple tasks require the same remote input
+  concurrently.
+- Keep the design compatible with future Kubernetes or cloud worker execution.
+- Preserve explicit `staging` and `running` task lifecycle states in Rich CLI
+  and JSONL output.
+
+## Non-Goals
+
+- Implementing byte-range reads, sparse hydration, or streaming mounts.
+- Building a full distributed data-locality scheduler.
+- Replacing staged access with a FUSE-like mount.
+- Introducing a shared network filesystem for staged inputs.
+- Publishing outputs to remote storage as part of this phase.
+
+## Proposed Solution
+
+Phase 6D should make staging an explicit execution phase with worker affinity.
+
+The core model is:
+
+- the scheduler decides which task is eligible to run
+- a worker execution slot is reserved for that task
+- remote inputs for that task are staged in that same worker context
+- the task starts only after staging succeeds
+
+This gives a clearer lifecycle:
+
+```text
+waiting -> staging -> running -> succeeded|failed|cached
+```
+
+For the current local runtime, "worker context" can still be implemented with a
+local staging thread or per-task staging executor. For future Kubernetes
+execution, the same contract maps to a pod-local worker that stages inputs into
+its own writable volume before launching the task process.
+
+## Design Principles
+
+- Treat staging as part of task execution cost, not an external pre-step.
+- Keep staging local to the execution worker that will consume the files.
+- Use bounded concurrency for staging so object storage, disk, and local I/O
+  are not flooded.
+- Deduplicate in-flight staging of the same remote ref across tasks.
+- Preserve the current explicit remote reference model so worker-side staging
+  remains transport-agnostic.
+- Avoid any design that assumes the scheduler and workers share a filesystem.
+
+## Architecture
+
+### 1. Explicit Staging Phase
+
+Remote input handling should be separated from generic argument resolution.
+
+Instead of hiding staging inside `_resolve_task_args()`, the evaluator should
+represent it as a first-class phase:
+
+- resolve non-remote literals and dependencies
+- detect remote refs
+- emit `task_staging`
+- stage remote inputs
+- rewrite staged args to local `file` / `folder` paths
+- emit `task_started`
+- launch task execution
+
+This makes the lifecycle observable and removes the ambiguity where a task
+appears "running" before its remote bytes are available locally.
+
+### 2. Worker-Affine Staging
+
+Staging should happen in the same worker context that will execute the task.
+
+That implies the scheduler should:
+
+- reserve a job/core/memory slot before staging begins
+- bind the task to an execution context
+- keep the task on that same context after staging completes
+
+For local execution, this can still be implemented inside the current process,
+but it should be modeled as worker-affine so the runtime contract already
+matches a future Kubernetes worker.
+
+For Kubernetes, the intended mapping is:
+
+- one worker pod receives the task
+- that pod stages remote inputs into `emptyDir`, local SSD, or another
+  pod-local writable volume
+- the same pod runs the task against those staged paths
+
+### 3. Concurrent Staging Pool
+
+Introduce a dedicated staging executor for I/O-bound remote hydration.
+
+Properties:
+
+- thread-based by default
+- bounded concurrency, distinct from CPU task concurrency
+- configurable independently from `jobs` and `cores`
+- suitable for overlapping remote download latency
+
+Suggested default:
+
+- `staging_jobs = min(jobs, 4)` when unset
+
+Possible future config:
+
+```toml
+[remote]
+staging_jobs = 4
+```
+
+or environment override:
+
+```bash
+GINKGO_STAGING_JOBS=4
+```
+
+### 4. In-Flight Deduplication
+
+Concurrent staging makes duplicate downloads more likely. The runtime should
+therefore add an in-memory coordination layer above `StagingCache`.
+
+Behavior:
+
+- compute a normalized remote-ref identity key
+- if no staging is in progress for that key, start one
+- if staging is already in progress, attach as a waiter
+- when the first staging completes, all waiters receive the same staged path
+
+This is especially important for:
+
+- repeated shared references in fan-out workflows
+- multiple tasks consuming the same pinned remote file
+- future multi-tenant workers where redundant downloads waste local bandwidth
+
+### 5. Staging Root as Worker-Local Storage
+
+The staging root should be treated as execution-worker-local by design.
+
+The plan should explicitly assume:
+
+- local runs may use `.ginkgo/staging/`
+- cloud workers may use pod-local ephemeral storage
+- workers do not depend on the scheduler's local disk
+
+This keeps the contract compatible with:
+
+- Kubernetes `emptyDir`
+- node-local SSD
+- container-local writable volumes
+
+It intentionally avoids dependence on:
+
+- NFS
+- EFS-like shared POSIX mounts
+- scheduler-side pre-hydrated shared directories
+
+### 6. Scheduler and Worker Responsibilities
+
+The long-term division should be:
+
+**Scheduler responsibilities**
+
+- dependency resolution
+- cache-key planning
+- task readiness
+- resource-slot reservation
+- worker assignment
+- staging-state tracking
+
+**Worker responsibilities**
+
+- stage assigned remote refs locally
+- rewrite remote refs to local paths
+- execute the task
+- report outputs, logs, and failures
+
+This is a natural extension of the current local runtime and avoids a later
+architecture split when remote workers are introduced.
+
+## Proposed Runtime Flow
+
+### Local Runtime
+
+1. Scheduler marks a node ready.
+2. Scheduler selects the node for execution and reserves capacity.
+3. Node enters `staging` if it has remote inputs.
+4. A staging worker stages those inputs into the local worker cache.
+5. On success, node enters `running`.
+6. Task executes using the staged local paths.
+
+### Future Kubernetes Runtime
+
+1. Scheduler assigns a ready node to a worker pod.
+2. Worker pod stages remote inputs into pod-local storage.
+3. Worker rewrites args to local paths.
+4. Worker launches the task.
+5. Worker reports completion and output metadata.
+
+The key invariant is unchanged:
+
+- the worker that stages is the worker that runs
+
+## Implementation Stages
+
+### Stage 1: Split staging from generic arg resolution
+
+- Refactor evaluator flow so remote staging is a distinct phase.
+- Emit `task_staging` only when a task actually has remote inputs.
+- Emit `task_started` only after staging completes successfully.
+- Preserve current cache-key semantics and path rewriting.
+
+### Stage 2: Add bounded concurrent staging
+
+- Introduce a staging executor in the evaluator.
+- Allow multiple ready tasks with remote inputs to stage concurrently.
+- Keep staging concurrency independent from CPU worker count.
+- Ensure tasks without remote inputs are not delayed unnecessarily by staging
+  queue behavior.
+
+### Stage 3: Add in-flight staging deduplication
+
+- Add a staging coordinator keyed by normalized remote-ref identity.
+- Share one staging result across concurrent requesters.
+- Ensure dedup works for both remote files and later folder-manifest identities.
+
+### Stage 4: Formalize worker-local staging config
+
+- Add explicit staging concurrency config.
+- Keep staging-root config documented as worker-local.
+- Make the runtime contract clear enough for Kubernetes pod-local volumes.
+
+### Stage 5: Prepare remote-worker execution contract
+
+- Define the payload boundary where remote refs remain explicit until the worker
+  stages them.
+- Ensure current local execution can evolve into this model without changing
+  user-facing workflow code.
+
+## Risks and Tradeoffs
+
+- Reserving worker capacity during staging may reduce apparent scheduler
+  throughput.
+  This is acceptable because staging is part of the task's real execution cost.
+
+- More concurrent downloads may increase pressure on object storage or local
+  disk.
+  This should be controlled with bounded staging concurrency and, if needed
+  later, backend-specific throttling.
+
+- In-flight dedup adds coordination state to the evaluator.
+  This complexity is justified once staging becomes concurrent.
+
+- Moving to worker-affine staging may make scheduler-side cache warmup less
+  appealing.
+  That is a deliberate tradeoff in favor of portability and future cloud
+  correctness.
+
+## Success Criteria
+
+- Independent remote-input tasks can stage concurrently on a local run.
+- The bioinformatics example no longer stages all remote inputs strictly one by
+  one.
+- Duplicate concurrent staging of the same remote input is deduplicated.
+- Rich CLI and JSONL output show `staging` distinctly from `running`.
+- Staging paths are treated as worker-local rather than scheduler-global.
+- The execution contract remains compatible with future Kubernetes workers.
+
+## Future Extensions
+
+This plan should leave clean extension points for later work:
+
+- task-aware prefetch
+- folder-manifest-aware deduplication
+- byte-range or partial download strategies
+- worker-local cache eviction policies
+- optional FUSE-like mounted access as a later optimization layer
+
+None of those are prerequisites for concurrent worker-affine staged access.

--- a/ginkgo/__init__.py
+++ b/ginkgo/__init__.py
@@ -25,6 +25,8 @@ _EXPORTS = {
     "flow": ("ginkgo.core.flow", "flow"),
     "folder": ("ginkgo.core.types", "folder"),
     "notebook": ("ginkgo.core.notebook", "notebook"),
+    "remote_file": ("ginkgo.core.remote", "remote_file"),
+    "remote_folder": ("ginkgo.core.remote", "remote_folder"),
     "script": ("ginkgo.core.script", "script"),
     "secret": ("ginkgo.core.secret", "secret"),
     "shell": ("ginkgo.core.shell", "shell"),

--- a/ginkgo/cli/commands/cache.py
+++ b/ginkgo/cli/commands/cache.py
@@ -274,13 +274,17 @@ def _gc_orphan_artifacts(cache_root: Path) -> None:
         for artifact_id in meta.get("artifact_ids", {}).values():
             referenced.add(artifact_id)
 
-    # Remove orphaned artifacts.
+    # Remove orphaned artifacts via the store's delete method.
     from ginkgo.runtime.artifact_store import LocalArtifactStore
 
     store = LocalArtifactStore(root=artifacts_root)
-    for child in list(artifacts_root.iterdir()):
-        if child.name not in referenced:
-            store.delete(artifact_id=child.name)
+    refs_dir = artifacts_root / "refs"
+    if not refs_dir.exists():
+        return
+    for ref_file in list(refs_dir.iterdir()):
+        artifact_id = ref_file.stem
+        if artifact_id not in referenced:
+            store.delete(artifact_id=artifact_id)
 
 
 def explain_run_cache(*, cache_root: Path, run_snapshot: dict[str, object]) -> dict[str, object]:

--- a/ginkgo/cli/renderers/common.py
+++ b/ginkgo/cli/renderers/common.py
@@ -15,6 +15,7 @@ def _status_style(status: str) -> str:
     """Return the Rich style name for a task status."""
     return {
         "waiting": "yellow",
+        "staging": "bold magenta",
         "running": "bold cyan",
         "cached": "bold green",
         "succeeded": "green",
@@ -26,6 +27,7 @@ def _status_icon(status: str) -> str:
     """Return the icon used for a task status."""
     return {
         "waiting": "•",
+        "staging": "↓",
         "running": "◐",
         "cached": "↺",
         "succeeded": "✓",

--- a/ginkgo/cli/renderers/rich.py
+++ b/ginkgo/cli/renderers/rich.py
@@ -11,6 +11,7 @@ from ginkgo.runtime.events import (
     TaskCompleted,
     TaskFailed,
     TaskRetrying,
+    TaskStaging,
     TaskStarted,
 )
 
@@ -35,6 +36,18 @@ class RichEventRenderer:
                 "node_id": _node_id_from_task_id(event.task_id),
                 "attempt": event.attempt,
                 "max_attempts": event.resources.get("max_attempts"),
+            }
+            if event.display_label is not None:
+                payload["display_label"] = event.display_label
+            return payload
+
+        if isinstance(event, TaskStaging):
+            payload = {
+                "task": event.task_name,
+                "status": "staging",
+                "node_id": _node_id_from_task_id(event.task_id),
+                "attempt": event.attempt,
+                "remote_input_count": event.remote_input_count,
             }
             if event.display_label is not None:
                 payload["display_label"] = event.display_label

--- a/ginkgo/cli/renderers/run.py
+++ b/ginkgo/cli/renderers/run.py
@@ -167,7 +167,7 @@ class _CliRunRenderer:
         if isinstance(display_label, str):
             self._apply_display_label(node_id=node_id, display_label=display_label)
         row.status = status
-        if status == "running":
+        if status in {"staging", "running"}:
             row.started_at = row.started_at or event_time
             row.finished_at = None
         elif status in {"cached", "succeeded", "failed"}:

--- a/ginkgo/core/remote.py
+++ b/ginkgo/core/remote.py
@@ -1,0 +1,258 @@
+"""Remote object references for workflow inputs.
+
+Provides ``remote_file()`` and ``remote_folder()`` constructors that allow
+workflow authors to declare remote object storage URIs as task inputs.
+The evaluator materializes these references into local paths before task
+execution.
+
+Supported URI schemes:
+
+- ``s3://bucket/key`` — AWS S3
+- ``oci://namespace/bucket/key`` — Oracle Cloud Infrastructure Object Storage
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+_SUPPORTED_SCHEMES = frozenset({"s3", "oci"})
+
+
+@dataclass(frozen=True, kw_only=True)
+class RemoteRef:
+    """Base for remote object references.
+
+    Parameters
+    ----------
+    uri : str
+        Full URI (e.g. ``s3://bucket/key``).
+    scheme : str
+        URI scheme (``"s3"`` or ``"oci"``).
+    bucket : str
+        Bucket/container authority used by the storage backend.
+        For S3 this is the bucket name. For OCI this is normalized to
+        ``"<bucket>@<namespace>"``.
+    key : str
+        Object key within the bucket.
+    namespace : str | None
+        Optional OCI namespace. ``None`` for S3.
+    version_id : str | None
+        Optional immutable version pin.
+    """
+
+    uri: str
+    scheme: str
+    bucket: str
+    key: str
+    namespace: str | None = None
+    version_id: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class RemoteFileRef(RemoteRef):
+    """Remote reference to a single file."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class RemoteFolderRef(RemoteRef):
+    """Remote reference to a directory prefix."""
+
+
+def remote_file(uri: str, *, version_id: str | None = None) -> RemoteFileRef:
+    """Construct a remote file reference from a URI.
+
+    Parameters
+    ----------
+    uri : str
+        Remote URI (e.g. ``s3://bucket/key`` or ``oci://namespace/bucket/key``).
+    version_id : str | None
+        Optional version ID for immutable pinning.
+
+    Returns
+    -------
+    RemoteFileRef
+
+    Raises
+    ------
+    ValueError
+        If the URI scheme is unsupported or the URI is malformed.
+    """
+    parsed = _parse_uri(uri)
+    return RemoteFileRef(
+        uri=uri,
+        scheme=parsed["scheme"],
+        bucket=parsed["bucket"],
+        key=parsed["key"],
+        namespace=parsed.get("namespace"),
+        version_id=version_id,
+    )
+
+
+def remote_folder(uri: str, *, version_id: str | None = None) -> RemoteFolderRef:
+    """Construct a remote folder reference from a URI.
+
+    Parameters
+    ----------
+    uri : str
+        Remote URI pointing to a prefix (e.g. ``s3://bucket/prefix/``).
+    version_id : str | None
+        Optional version ID for immutable pinning.
+
+    Returns
+    -------
+    RemoteFolderRef
+
+    Raises
+    ------
+    ValueError
+        If the URI scheme is unsupported or the URI is malformed.
+    """
+    parsed = _parse_uri(uri)
+    return RemoteFolderRef(
+        uri=uri,
+        scheme=parsed["scheme"],
+        bucket=parsed["bucket"],
+        key=parsed["key"],
+        namespace=parsed.get("namespace"),
+        version_id=version_id,
+    )
+
+
+def is_remote_uri(value: str) -> bool:
+    """Check whether a string looks like a supported remote URI.
+
+    Parameters
+    ----------
+    value : str
+        String to check.
+
+    Returns
+    -------
+    bool
+        ``True`` if the string starts with a supported scheme.
+    """
+    try:
+        scheme = value.split("://", 1)[0].lower()
+    except (AttributeError, IndexError):
+        return False
+    return scheme in _SUPPORTED_SCHEMES
+
+
+def _parse_uri(uri: str) -> dict[str, str]:
+    """Parse a remote URI into scheme, bucket, and key components.
+
+    Parameters
+    ----------
+    uri : str
+        Remote URI to parse.
+
+    Returns
+    -------
+    dict[str, str]
+        Parsed components with keys ``scheme``, ``bucket``, ``key``.
+
+    Raises
+    ------
+    ValueError
+        If the scheme is unsupported or the URI is malformed.
+    """
+    parsed = urlparse(uri)
+    scheme = parsed.scheme.lower()
+
+    if scheme not in _SUPPORTED_SCHEMES:
+        raise ValueError(
+            f"Unsupported remote URI scheme {scheme!r} in {uri!r}. "
+            f"Supported schemes: {', '.join(sorted(_SUPPORTED_SCHEMES))}"
+        )
+
+    if scheme == "s3":
+        return _parse_s3_uri(parsed, uri)
+    if scheme == "oci":
+        return _parse_oci_uri(parsed, uri)
+
+    raise ValueError(f"Unsupported scheme: {scheme!r}")
+
+
+def _parse_s3_uri(parsed: object, uri: str) -> dict[str, str]:
+    """Parse an S3 URI: ``s3://bucket/key``.
+
+    Parameters
+    ----------
+    parsed : ParseResult
+        Result from ``urlparse``.
+    uri : str
+        Original URI for error messages.
+
+    Returns
+    -------
+    dict[str, str]
+    """
+    bucket = parsed.netloc  # type: ignore[union-attr]
+    if not bucket:
+        raise ValueError(f"S3 URI missing bucket: {uri!r}")
+
+    key = parsed.path.lstrip("/")  # type: ignore[union-attr]
+    if not key:
+        raise ValueError(f"S3 URI missing key: {uri!r}")
+
+    return {"scheme": "s3", "bucket": bucket, "key": key}
+
+
+def _parse_oci_uri(parsed: object, uri: str) -> dict[str, str]:
+    """Parse an OCI Object Storage URI.
+
+    Supports both of these forms:
+
+    - ``oci://namespace/bucket/key``
+    - ``oci://bucket@namespace/key``
+
+    Parameters
+    ----------
+    parsed : ParseResult
+        Result from ``urlparse``.
+    uri : str
+        Original URI for error messages.
+
+    Returns
+    -------
+    dict[str, str]
+    """
+    authority = parsed.netloc  # type: ignore[union-attr]
+    if not authority:
+        raise ValueError(f"OCI URI missing namespace or bucket: {uri!r}")
+
+    key = parsed.path.lstrip("/")  # type: ignore[union-attr]
+    if not key:
+        raise ValueError(
+            "OCI URI must have the form oci://namespace/bucket/key "
+            f"or oci://bucket@namespace/key: {uri!r}"
+        )
+
+    if "@" in authority:
+        bucket, namespace = authority.split("@", 1)
+        if not bucket or not namespace:
+            raise ValueError(f"OCI URI must have the form oci://bucket@namespace/key: {uri!r}")
+        return {
+            "scheme": "oci",
+            "bucket": f"{bucket}@{namespace}",
+            "key": key,
+            "namespace": namespace,
+        }
+
+    path_parts = key.split("/", 1)
+    if len(path_parts) < 2 or not path_parts[1]:
+        raise ValueError(
+            "OCI URI must have the form oci://namespace/bucket/key "
+            f"or oci://bucket@namespace/key: {uri!r}"
+        )
+
+    namespace = authority
+    bucket = path_parts[0]
+    object_key = path_parts[1]
+    return {
+        "scheme": "oci",
+        "bucket": f"{bucket}@{namespace}",
+        "key": object_key,
+        "namespace": namespace,
+    }

--- a/ginkgo/remote/__init__.py
+++ b/ginkgo/remote/__init__.py
@@ -1,0 +1,1 @@
+"""Remote storage backends for Ginkgo."""

--- a/ginkgo/remote/backend.py
+++ b/ginkgo/remote/backend.py
@@ -1,0 +1,106 @@
+"""Remote storage backend protocol and metadata types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, kw_only=True)
+class RemoteObjectMeta:
+    """Metadata returned by remote storage operations.
+
+    Parameters
+    ----------
+    uri : str
+        Full URI of the remote object.
+    size : int
+        Object size in bytes.
+    etag : str | None
+        Provider-assigned ETag for freshness checks.
+    digest : str | None
+        Content digest if known (e.g. BLAKE3 after download).
+    version_id : str | None
+        Object version identifier for immutable pinning.
+    """
+
+    uri: str
+    size: int
+    etag: str | None = None
+    digest: str | None = None
+    version_id: str | None = None
+
+
+@runtime_checkable
+class RemoteStorageBackend(Protocol):
+    """Protocol for remote object storage operations."""
+
+    def head(self, *, bucket: str, key: str) -> RemoteObjectMeta:
+        """Return metadata for an object without downloading it.
+
+        Parameters
+        ----------
+        bucket : str
+            Bucket name (S3) or ``namespace/bucket`` (OCI).
+        key : str
+            Object key.
+
+        Returns
+        -------
+        RemoteObjectMeta
+        """
+        ...
+
+    def download(self, *, bucket: str, key: str, dest_path: Path) -> RemoteObjectMeta:
+        """Download an object to a local path.
+
+        Parameters
+        ----------
+        bucket : str
+            Bucket name.
+        key : str
+            Object key.
+        dest_path : Path
+            Local destination path.
+
+        Returns
+        -------
+        RemoteObjectMeta
+            Includes size and ETag from the download response.
+        """
+        ...
+
+    def upload(self, *, src_path: Path, bucket: str, key: str) -> RemoteObjectMeta:
+        """Upload a local file to remote storage.
+
+        Parameters
+        ----------
+        src_path : Path
+            Local file to upload.
+        bucket : str
+            Destination bucket.
+        key : str
+            Destination key.
+
+        Returns
+        -------
+        RemoteObjectMeta
+        """
+        ...
+
+    def list_prefix(self, *, bucket: str, prefix: str) -> list[RemoteObjectMeta]:
+        """List objects under a key prefix.
+
+        Parameters
+        ----------
+        bucket : str
+            Bucket name.
+        prefix : str
+            Key prefix to list.
+
+        Returns
+        -------
+        list[RemoteObjectMeta]
+        """
+        ...

--- a/ginkgo/remote/fsspec_backends.py
+++ b/ginkgo/remote/fsspec_backends.py
@@ -1,0 +1,238 @@
+"""Remote storage backends built on filesystem adapters."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from ginkgo.remote.backend import RemoteObjectMeta
+
+
+class S3FileSystemBackend:
+    """S3 backend implemented with ``s3fs``."""
+
+    def __init__(self, *, region: str | None = None) -> None:
+        self._region = region
+        self._filesystem: Any | None = None
+
+    def _get_filesystem(self) -> Any:
+        if self._filesystem is not None:
+            return self._filesystem
+
+        try:
+            import s3fs
+        except ImportError as exc:
+            raise ImportError(
+                "s3fs is required for S3 remote storage support. Install it with: pip install s3fs"
+            ) from exc
+
+        client_kwargs: dict[str, Any] = {}
+        if self._region is not None:
+            client_kwargs["region_name"] = self._region
+
+        kwargs: dict[str, Any] = {}
+        if client_kwargs:
+            kwargs["client_kwargs"] = client_kwargs
+
+        self._filesystem = s3fs.S3FileSystem(**kwargs)
+        return self._filesystem
+
+    def head(self, *, bucket: str, key: str) -> RemoteObjectMeta:
+        fs = self._get_filesystem()
+        path = _join_remote_path(bucket=bucket, key=key)
+        info = fs.info(path)
+        return _remote_meta_from_info(
+            scheme="s3",
+            bucket=bucket,
+            key=key,
+            info=info,
+        )
+
+    def download(self, *, bucket: str, key: str, dest_path: Path) -> RemoteObjectMeta:
+        fs = self._get_filesystem()
+        path = _join_remote_path(bucket=bucket, key=key)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with fs.open(path, "rb") as source, dest_path.open("wb") as destination:
+            while True:
+                chunk = source.read(65536)
+                if not chunk:
+                    break
+                destination.write(chunk)
+        return self.head(bucket=bucket, key=key)
+
+    def upload(self, *, src_path: Path, bucket: str, key: str) -> RemoteObjectMeta:
+        fs = self._get_filesystem()
+        path = _join_remote_path(bucket=bucket, key=key)
+        with src_path.open("rb") as source, fs.open(path, "wb") as destination:
+            while True:
+                chunk = source.read(65536)
+                if not chunk:
+                    break
+                destination.write(chunk)
+        return self.head(bucket=bucket, key=key)
+
+    def list_prefix(self, *, bucket: str, prefix: str) -> list[RemoteObjectMeta]:
+        fs = self._get_filesystem()
+        base = _join_remote_path(bucket=bucket, key=prefix)
+        found = fs.find(base, detail=True)
+        return _list_results_to_meta(
+            scheme="s3",
+            results=found,
+        )
+
+
+class OCIFileSystemBackend:
+    """OCI Object Storage backend implemented with ``ocifs``."""
+
+    def __init__(
+        self,
+        *,
+        config_path: str | None = None,
+        profile: str | None = None,
+        region: str | None = None,
+    ) -> None:
+        self._config_path = config_path
+        self._profile = profile
+        self._region = region
+        self._filesystem: Any | None = None
+
+    def _get_filesystem(self) -> Any:
+        if self._filesystem is not None:
+            return self._filesystem
+
+        try:
+            import ocifs
+        except ImportError as exc:
+            raise ImportError(
+                "ocifs is required for OCI remote storage support. "
+                "Install it with: pip install ocifs"
+            ) from exc
+
+        kwargs: dict[str, Any] = {}
+        if self._config_path is not None:
+            kwargs["config"] = os.path.expanduser(self._config_path)
+        if self._profile is not None:
+            kwargs["profile"] = self._profile
+        if self._region is not None:
+            kwargs["region"] = self._region
+
+        self._filesystem = ocifs.OCIFileSystem(**kwargs)
+        return self._filesystem
+
+    def head(self, *, bucket: str, key: str) -> RemoteObjectMeta:
+        fs = self._get_filesystem()
+        path = _join_remote_path(bucket=bucket, key=key)
+        info = fs.info(path)
+        return _remote_meta_from_info(
+            scheme="oci",
+            bucket=bucket,
+            key=key,
+            info=info,
+        )
+
+    def download(self, *, bucket: str, key: str, dest_path: Path) -> RemoteObjectMeta:
+        fs = self._get_filesystem()
+        path = _join_remote_path(bucket=bucket, key=key)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with fs.open(path, "rb") as source, dest_path.open("wb") as destination:
+            while True:
+                chunk = source.read(65536)
+                if not chunk:
+                    break
+                destination.write(chunk)
+        return self.head(bucket=bucket, key=key)
+
+    def upload(self, *, src_path: Path, bucket: str, key: str) -> RemoteObjectMeta:
+        fs = self._get_filesystem()
+        path = _join_remote_path(bucket=bucket, key=key)
+        with src_path.open("rb") as source, fs.open(path, "wb") as destination:
+            while True:
+                chunk = source.read(65536)
+                if not chunk:
+                    break
+                destination.write(chunk)
+        return self.head(bucket=bucket, key=key)
+
+    def list_prefix(self, *, bucket: str, prefix: str) -> list[RemoteObjectMeta]:
+        fs = self._get_filesystem()
+        base = _join_remote_path(bucket=bucket, key=prefix)
+        found = fs.find(base, detail=True)
+        return _list_results_to_meta(
+            scheme="oci",
+            results=found,
+        )
+
+
+def _join_remote_path(*, bucket: str, key: str) -> str:
+    key = key.lstrip("/")
+    if not key:
+        return bucket
+    return f"{bucket}/{key}"
+
+
+def _remote_meta_from_info(
+    *,
+    scheme: str,
+    bucket: str,
+    key: str,
+    info: dict[str, Any],
+) -> RemoteObjectMeta:
+    return RemoteObjectMeta(
+        uri=f"{scheme}://{bucket}/{key}",
+        size=_extract_size(info),
+        etag=_extract_metadata_value(info, "etag", "ETag"),
+        version_id=_extract_metadata_value(info, "version_id", "VersionId", "versionId"),
+    )
+
+
+def _list_results_to_meta(
+    *,
+    scheme: str,
+    results: dict[str, dict[str, Any]] | list[str],
+) -> list[RemoteObjectMeta]:
+    if isinstance(results, dict):
+        items = results.items()
+    else:
+        items = ((path, {}) for path in results)
+
+    remote_objects: list[RemoteObjectMeta] = []
+    for path, info in items:
+        normalized = path.lstrip("/")
+        bucket, _, key = normalized.partition("/")
+        if not key:
+            continue
+        remote_objects.append(
+            RemoteObjectMeta(
+                uri=f"{scheme}://{bucket}/{key}",
+                size=_extract_size(info),
+                etag=_extract_metadata_value(info, "etag", "ETag"),
+                version_id=_extract_metadata_value(
+                    info,
+                    "version_id",
+                    "VersionId",
+                    "versionId",
+                ),
+            )
+        )
+    return remote_objects
+
+
+def _extract_size(info: dict[str, Any]) -> int:
+    for key in ("size", "Size", "ContentLength"):
+        value = info.get(key)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+def _extract_metadata_value(info: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = info.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = value.strip('"')
+            return stripped or None
+        return str(value)
+    return None

--- a/ginkgo/remote/publisher.py
+++ b/ginkgo/remote/publisher.py
@@ -1,0 +1,125 @@
+"""Remote artifact publisher.
+
+Uploads locally stored artifacts to a remote object store, making them
+available to other machines or future runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ginkgo.remote.backend import RemoteStorageBackend
+from ginkgo.runtime.artifact_model import ArtifactRecord, deserialize_tree_manifest
+
+
+@dataclass(kw_only=True)
+class RemotePublisher:
+    """Publishes local artifacts to a remote object store.
+
+    Parameters
+    ----------
+    backend : RemoteStorageBackend
+        The remote storage backend to use for uploads.
+    bucket : str
+        Destination bucket name.
+    prefix : str
+        Key prefix under which artifacts are published.
+    local_blobs_dir : Path
+        Local blobs directory to read from.
+    local_trees_dir : Path
+        Local trees directory to read from.
+    local_refs_dir : Path
+        Local refs directory to update with remote URIs.
+    """
+
+    backend: RemoteStorageBackend
+    bucket: str
+    prefix: str
+    local_blobs_dir: Path
+    local_trees_dir: Path
+    local_refs_dir: Path
+
+    def publish(self, *, record: ArtifactRecord) -> ArtifactRecord:
+        """Upload an artifact's content to the remote store.
+
+        For blob artifacts, uploads the blob file.  For tree artifacts,
+        uploads all constituent blobs and the tree manifest.
+
+        Parameters
+        ----------
+        record : ArtifactRecord
+            The local artifact record to publish.
+
+        Returns
+        -------
+        ArtifactRecord
+            Updated record with ``remote_uri`` set.
+        """
+        if record.remote_uri is not None:
+            return record
+
+        if record.kind == "blob":
+            return self._publish_blob(record)
+        return self._publish_tree(record)
+
+    def _publish_blob(self, record: ArtifactRecord) -> ArtifactRecord:
+        """Upload a single blob."""
+        blob_path = self.local_blobs_dir / record.digest_hex
+        remote_key = f"{self.prefix}blobs/{record.digest_hex}"
+        self.backend.upload(src_path=blob_path, bucket=self.bucket, key=remote_key)
+
+        remote_uri = f"s3://{self.bucket}/{remote_key}"
+        updated = ArtifactRecord(
+            artifact_id=record.artifact_id,
+            kind=record.kind,
+            digest_algorithm=record.digest_algorithm,
+            digest_hex=record.digest_hex,
+            extension=record.extension,
+            size=record.size,
+            created_at=record.created_at,
+            storage_backend=record.storage_backend,
+            remote_uri=remote_uri,
+        )
+
+        # Update the local ref file with the remote URI.
+        ref_path = self.local_refs_dir / f"{record.artifact_id}.json"
+        if ref_path.exists():
+            ref_path.write_text(updated.to_json(), encoding="utf-8")
+
+        return updated
+
+    def _publish_tree(self, record: ArtifactRecord) -> ArtifactRecord:
+        """Upload a tree manifest and all its constituent blobs."""
+        # Upload individual blobs.
+        tree_path = self.local_trees_dir / f"{record.digest_hex}.json"
+        if tree_path.exists():
+            tree_ref = deserialize_tree_manifest(tree_path.read_text(encoding="utf-8"))
+            for entry in tree_ref.entries:
+                blob_path = self.local_blobs_dir / entry.blob_digest
+                if blob_path.exists():
+                    remote_key = f"{self.prefix}blobs/{entry.blob_digest}"
+                    self.backend.upload(src_path=blob_path, bucket=self.bucket, key=remote_key)
+
+            # Upload the tree manifest itself.
+            manifest_key = f"{self.prefix}trees/{record.digest_hex}.json"
+            self.backend.upload(src_path=tree_path, bucket=self.bucket, key=manifest_key)
+
+        remote_uri = f"s3://{self.bucket}/{self.prefix}trees/{record.digest_hex}.json"
+        updated = ArtifactRecord(
+            artifact_id=record.artifact_id,
+            kind=record.kind,
+            digest_algorithm=record.digest_algorithm,
+            digest_hex=record.digest_hex,
+            extension=record.extension,
+            size=record.size,
+            created_at=record.created_at,
+            storage_backend=record.storage_backend,
+            remote_uri=remote_uri,
+        )
+
+        ref_path = self.local_refs_dir / f"{record.artifact_id}.json"
+        if ref_path.exists():
+            ref_path.write_text(updated.to_json(), encoding="utf-8")
+
+        return updated

--- a/ginkgo/remote/resolve.py
+++ b/ginkgo/remote/resolve.py
@@ -1,0 +1,97 @@
+"""Backend resolution for remote storage schemes."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from ginkgo.config import load_runtime_config
+from ginkgo.remote.backend import RemoteStorageBackend
+from ginkgo.remote.fsspec_backends import OCIFileSystemBackend, S3FileSystemBackend
+
+
+def resolve_backend(
+    scheme: str,
+    *,
+    region: str | None = None,
+) -> RemoteStorageBackend:
+    """Return a storage backend for the given URI scheme.
+
+    Parameters
+    ----------
+    scheme : str
+        URI scheme (``"s3"`` or ``"oci"``).
+    region : str | None
+        Region override.  Falls back to environment variables or provider
+        defaults.
+
+    Returns
+    -------
+    RemoteStorageBackend
+
+    Raises
+    ------
+    ValueError
+        If the scheme is unsupported.
+    """
+    settings = _load_remote_settings(project_root=Path.cwd())
+
+    if scheme == "s3":
+        return S3FileSystemBackend(region=region or settings.get("s3_region"))
+
+    if scheme == "oci":
+        return OCIFileSystemBackend(
+            config_path=settings.get("oci_config_path"),
+            profile=settings.get("oci_profile"),
+            region=region or settings.get("oci_region"),
+        )
+
+    raise ValueError(f"Unsupported remote scheme: {scheme!r}")
+
+
+def _load_remote_settings(*, project_root: Path) -> dict[str, str]:
+    config = load_runtime_config(project_root=project_root)
+    remote_config = config.get("remote", {})
+    oci_config = remote_config.get("oci", {}) if isinstance(remote_config, dict) else {}
+
+    return {
+        "s3_region": _first_defined(
+            os.environ.get("AWS_REGION"),
+            os.environ.get("AWS_DEFAULT_REGION"),
+            _config_string(remote_config, "region"),
+        ),
+        "oci_config_path": _first_defined(
+            os.environ.get("GINKGO_REMOTE_OCI_CONFIG"),
+            os.environ.get("OCI_CONFIG_FILE"),
+            _config_string(oci_config, "config"),
+            "~/.oci/config",
+        ),
+        "oci_profile": _first_defined(
+            os.environ.get("GINKGO_REMOTE_OCI_PROFILE"),
+            os.environ.get("OCI_CONFIG_PROFILE"),
+            _config_string(oci_config, "profile"),
+        ),
+        "oci_region": _first_defined(
+            os.environ.get("GINKGO_REMOTE_OCI_REGION"),
+            os.environ.get("OCI_REGION"),
+            _config_string(oci_config, "region"),
+            _config_string(remote_config, "region"),
+        ),
+    }
+
+
+def _config_string(mapping: Any, key: str) -> str | None:
+    if not isinstance(mapping, dict):
+        return None
+    value = mapping.get(key)
+    if value is None:
+        return None
+    return str(value)
+
+
+def _first_defined(*values: str | None) -> str | None:
+    for value in values:
+        if value:
+            return value
+    return None

--- a/ginkgo/remote/s3_compat.py
+++ b/ginkgo/remote/s3_compat.py
@@ -1,0 +1,162 @@
+"""S3-compatible storage backend.
+
+Supports both AWS S3 and Oracle Cloud Infrastructure Object Storage via
+the S3-compatible API.  The backend is parameterized by endpoint URL to
+support both providers with a single implementation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ginkgo.remote.backend import RemoteObjectMeta
+
+
+class S3CompatibleBackend:
+    """S3-compatible object storage backend.
+
+    Parameters
+    ----------
+    endpoint_url : str | None
+        Custom endpoint URL for non-AWS providers (e.g. OCI Object Storage).
+        ``None`` uses the default AWS S3 endpoint.
+    region : str | None
+        AWS region or OCI region.  Defaults to ``boto3`` resolution.
+    """
+
+    def __init__(
+        self,
+        *,
+        endpoint_url: str | None = None,
+        region: str | None = None,
+    ) -> None:
+        self._endpoint_url = endpoint_url
+        self._region = region
+        self._client = None
+
+    def _get_client(self) -> object:
+        """Lazily create the boto3 S3 client."""
+        if self._client is not None:
+            return self._client
+
+        try:
+            import boto3
+        except ImportError as exc:
+            raise ImportError(
+                "boto3 is required for remote storage support. Install it with: pip install boto3"
+            ) from exc
+
+        kwargs: dict[str, object] = {"service_name": "s3"}
+        if self._endpoint_url is not None:
+            kwargs["endpoint_url"] = self._endpoint_url
+        if self._region is not None:
+            kwargs["region_name"] = self._region
+
+        self._client = boto3.client(**kwargs)  # type: ignore[arg-type]
+        return self._client
+
+    def head(self, *, bucket: str, key: str) -> RemoteObjectMeta:
+        """Return metadata for an object without downloading it.
+
+        Parameters
+        ----------
+        bucket : str
+            Bucket name.
+        key : str
+            Object key.
+
+        Returns
+        -------
+        RemoteObjectMeta
+        """
+        client = self._get_client()
+        response = client.head_object(Bucket=bucket, Key=key)  # type: ignore[union-attr]
+        return RemoteObjectMeta(
+            uri=f"s3://{bucket}/{key}",
+            size=response["ContentLength"],
+            etag=response.get("ETag", "").strip('"'),
+            version_id=response.get("VersionId"),
+        )
+
+    def download(self, *, bucket: str, key: str, dest_path: Path) -> RemoteObjectMeta:
+        """Download an object to a local path.
+
+        Parameters
+        ----------
+        bucket : str
+            Bucket name.
+        key : str
+            Object key.
+        dest_path : Path
+            Local destination path.
+
+        Returns
+        -------
+        RemoteObjectMeta
+        """
+        client = self._get_client()
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        response = client.get_object(Bucket=bucket, Key=key)  # type: ignore[union-attr]
+
+        with dest_path.open("wb") as handle:
+            for chunk in response["Body"].iter_chunks(chunk_size=65536):
+                handle.write(chunk)
+
+        return RemoteObjectMeta(
+            uri=f"s3://{bucket}/{key}",
+            size=response["ContentLength"],
+            etag=response.get("ETag", "").strip('"'),
+            version_id=response.get("VersionId"),
+        )
+
+    def upload(self, *, src_path: Path, bucket: str, key: str) -> RemoteObjectMeta:
+        """Upload a local file to remote storage.
+
+        Parameters
+        ----------
+        src_path : Path
+            Local file to upload.
+        bucket : str
+            Destination bucket.
+        key : str
+            Destination key.
+
+        Returns
+        -------
+        RemoteObjectMeta
+        """
+        client = self._get_client()
+        client.upload_file(str(src_path), bucket, key)  # type: ignore[union-attr]
+
+        # Fetch metadata for the uploaded object.
+        return self.head(bucket=bucket, key=key)
+
+    def list_prefix(self, *, bucket: str, prefix: str) -> list[RemoteObjectMeta]:
+        """List objects under a key prefix.
+
+        Parameters
+        ----------
+        bucket : str
+            Bucket name.
+        prefix : str
+            Key prefix to list.
+
+        Returns
+        -------
+        list[RemoteObjectMeta]
+        """
+        client = self._get_client()
+        paginator = client.get_paginator("list_objects_v2")  # type: ignore[union-attr]
+        results: list[RemoteObjectMeta] = []
+
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                results.append(
+                    RemoteObjectMeta(
+                        uri=f"s3://{bucket}/{obj['Key']}",
+                        size=obj["Size"],
+                        etag=obj.get("ETag", "").strip('"'),
+                    )
+                )
+
+        return results

--- a/ginkgo/remote/staging.py
+++ b/ginkgo/remote/staging.py
@@ -1,0 +1,343 @@
+"""Local staging cache for remote artifacts.
+
+Downloads remote files into a content-addressed local cache so that tasks
+receive normal filesystem paths.  ETag-based freshness checks avoid
+redundant downloads on subsequent runs.
+
+Layout::
+
+    .ginkgo/staging/
+      blobs/<digest>                # cached file bytes
+      metadata/<uri_hash>.json      # freshness and identity metadata
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import shutil
+
+from ginkgo.config import load_runtime_config
+from ginkgo.core.remote import RemoteFileRef, RemoteFolderRef, RemoteRef
+from ginkgo.remote.backend import RemoteObjectMeta, RemoteStorageBackend
+from ginkgo.remote.resolve import resolve_backend
+from ginkgo.runtime.hashing import hash_file, hash_str
+
+
+@dataclass(frozen=True, kw_only=True)
+class StagingEntry:
+    """Metadata for a staged remote object.
+
+    Parameters
+    ----------
+    uri : str
+        Original remote URI.
+    digest : str
+        BLAKE3 content digest of the staged file.
+    etag : str | None
+        Provider ETag at time of download.
+    version_id : str | None
+        Provider version ID at time of download.
+    size : int
+        File size in bytes.
+    staged_at : str
+        ISO-8601 timestamp of when the file was staged.
+    blob_path : str
+        Relative path to the blob within the staging cache.
+    """
+
+    uri: str
+    digest: str
+    etag: str | None
+    version_id: str | None
+    size: int
+    staged_at: str
+    blob_path: str
+
+    def to_json(self) -> str:
+        """Serialize to JSON."""
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, data: str) -> StagingEntry:
+        """Deserialize from JSON."""
+        return cls(**json.loads(data))
+
+
+class StagingCache:
+    """Content-addressed local cache for remote file downloads.
+
+    Parameters
+    ----------
+    root : Path | None
+        Root directory for the staging cache.  Defaults to
+        ``.ginkgo/staging`` under the current working directory.
+    """
+
+    def __init__(self, *, root: Path | None = None) -> None:
+        self._root = root if root is not None else _default_staging_root()
+        self._blobs_dir = self._root / "blobs"
+        self._metadata_dir = self._root / "metadata"
+        self._folders_dir = self._root / "folders"
+        for directory in (self._blobs_dir, self._metadata_dir, self._folders_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    def stage_file(
+        self,
+        *,
+        ref: RemoteFileRef,
+        backend: RemoteStorageBackend | None = None,
+    ) -> Path:
+        """Stage a remote file and return the local path.
+
+        If the file is already cached and the remote ETag has not changed,
+        returns the cached path without re-downloading.
+
+        Parameters
+        ----------
+        ref : RemoteFileRef
+            Remote file reference.
+        backend : RemoteStorageBackend | None
+            Storage backend to use.  Resolved from the ref's scheme if
+            ``None``.
+
+        Returns
+        -------
+        Path
+            Local path to the staged file.
+        """
+        backend = backend or resolve_backend(ref.scheme)
+        uri_key = _uri_hash(ref.uri)
+        metadata_path = self._metadata_dir / f"{uri_key}.json"
+
+        # Check for a cached entry.
+        existing = self._load_entry(metadata_path)
+        if existing is not None:
+            blob_path = self._blobs_dir / existing.digest
+            if blob_path.exists():
+                # Check freshness via ETag if available.
+                if not self._needs_refresh(existing=existing, ref=ref, backend=backend):
+                    return blob_path
+
+        # Download the file to a temp location, then move into the cache.
+        return self._download_and_cache(
+            ref=ref,
+            backend=backend,
+            uri_key=uri_key,
+            metadata_path=metadata_path,
+        )
+
+    def stage_folder(
+        self,
+        *,
+        ref: RemoteFolderRef,
+        backend: RemoteStorageBackend | None = None,
+    ) -> Path:
+        """Stage a remote folder (prefix) and return the local directory path.
+
+        Downloads all objects under the prefix into a local directory that
+        mirrors the remote key structure.
+
+        Parameters
+        ----------
+        ref : RemoteFolderRef
+            Remote folder reference.
+        backend : RemoteStorageBackend | None
+            Storage backend to use.
+
+        Returns
+        -------
+        Path
+            Local directory path containing the staged files.
+        """
+        backend = backend or resolve_backend(ref.scheme)
+        uri_key = _uri_hash(ref.uri)
+
+        objects = backend.list_prefix(bucket=ref.bucket, prefix=ref.key)
+        folder_digest = _folder_manifest_digest(uri=ref.uri, objects=objects)
+        folder_dir = self._folders_dir / folder_digest
+
+        if folder_dir.exists():
+            return folder_dir
+
+        temp_dir = self._folders_dir / f".tmp-{folder_digest}"
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+        temp_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            for obj in objects:
+                # Derive relative path within the folder.
+                relative = obj.uri.split(ref.key, 1)[-1]
+                if not relative:
+                    continue
+
+                dest = temp_dir / relative
+                dest.parent.mkdir(parents=True, exist_ok=True)
+
+                # Extract the object key from the URI.
+                obj_key = obj.uri.split(f"{ref.bucket}/", 1)[-1]
+                backend.download(bucket=ref.bucket, key=obj_key, dest_path=dest)
+
+            temp_dir.rename(folder_dir)
+        except Exception:
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+            raise
+
+        metadata_path = self._metadata_dir / f"{uri_key}.json"
+        metadata_path.write_text(
+            json.dumps(
+                {
+                    "uri": ref.uri,
+                    "folder_digest": folder_digest,
+                    "object_count": len(objects),
+                    "staged_at": datetime.now(timezone.utc).isoformat(),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+
+        return folder_dir
+
+    def lookup(self, *, uri: str) -> StagingEntry | None:
+        """Look up the staging entry for a URI without downloading.
+
+        Parameters
+        ----------
+        uri : str
+            Remote URI.
+
+        Returns
+        -------
+        StagingEntry | None
+            Cached entry, or ``None`` if not staged.
+        """
+        uri_key = _uri_hash(uri)
+        metadata_path = self._metadata_dir / f"{uri_key}.json"
+        return self._load_entry(metadata_path)
+
+    def _needs_refresh(
+        self,
+        *,
+        existing: StagingEntry,
+        ref: RemoteRef,
+        backend: RemoteStorageBackend,
+    ) -> bool:
+        """Check whether a cached entry needs re-downloading."""
+        # Pinned version — always fresh.
+        if ref.version_id is not None and existing.version_id == ref.version_id:
+            return False
+
+        # Check remote ETag.
+        try:
+            remote_meta = backend.head(bucket=ref.bucket, key=ref.key)
+        except Exception:
+            # If HEAD fails, assume we need a refresh.
+            return True
+
+        if remote_meta.etag and existing.etag and remote_meta.etag == existing.etag:
+            return False
+
+        return True
+
+    def _download_and_cache(
+        self,
+        *,
+        ref: RemoteFileRef,
+        backend: RemoteStorageBackend,
+        uri_key: str,
+        metadata_path: Path,
+    ) -> Path:
+        """Download a remote file and store it in the staging cache."""
+        import tempfile
+
+        # Download to a temp file first.
+        temp_path = Path(tempfile.mktemp(prefix="ginkgo-stage-", dir=str(self._blobs_dir)))
+        try:
+            meta = backend.download(
+                bucket=ref.bucket,
+                key=ref.key,
+                dest_path=temp_path,
+            )
+
+            # Compute content digest.
+            digest = hash_file(temp_path)
+
+            # Move to content-addressed location.
+            blob_path = self._blobs_dir / digest
+            if not blob_path.exists():
+                temp_path.rename(blob_path)
+            else:
+                temp_path.unlink()
+
+            # Write metadata.
+            entry = StagingEntry(
+                uri=ref.uri,
+                digest=digest,
+                etag=meta.etag,
+                version_id=meta.version_id or ref.version_id,
+                size=meta.size,
+                staged_at=datetime.now(timezone.utc).isoformat(),
+                blob_path=f"blobs/{digest}",
+            )
+            metadata_path.write_text(entry.to_json(), encoding="utf-8")
+
+            return blob_path
+
+        except Exception:
+            # Clean up temp file on failure.
+            if temp_path.exists():
+                temp_path.unlink()
+            raise
+
+    def _load_entry(self, metadata_path: Path) -> StagingEntry | None:
+        """Load a staging entry from disk."""
+        if not metadata_path.exists():
+            return None
+        try:
+            return StagingEntry.from_json(metadata_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, TypeError, KeyError):
+            return None
+
+
+def _uri_hash(uri: str) -> str:
+    """Return a stable hash of a URI for use as a cache key."""
+    return hash_str(uri)
+
+
+def _folder_manifest_digest(
+    *,
+    uri: str,
+    objects: list[RemoteObjectMeta],
+) -> str:
+    manifest = [
+        {
+            "uri": obj.uri,
+            "size": obj.size,
+            "etag": obj.etag,
+            "version_id": obj.version_id,
+        }
+        for obj in sorted(objects, key=lambda item: item.uri)
+    ]
+    return hash_str(json.dumps({"uri": uri, "objects": manifest}, sort_keys=True))
+
+
+def _default_staging_root() -> Path:
+    env_root = os.environ.get("GINKGO_STAGING_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+
+    config = load_runtime_config(project_root=Path.cwd())
+    remote_config = config.get("remote", {})
+    if isinstance(remote_config, dict):
+        staging_root = remote_config.get("staging_root")
+        if staging_root:
+            return Path(str(staging_root)).expanduser()
+
+    return Path.cwd() / ".ginkgo" / "staging"

--- a/ginkgo/runtime/artifact_model.py
+++ b/ginkgo/runtime/artifact_model.py
@@ -1,0 +1,193 @@
+"""Data model for content-addressed artifacts.
+
+Defines the immutable reference types and metadata records used by the
+artifact store.  All artifact identity flows through these types rather
+than bare strings.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, kw_only=True)
+class BlobRef:
+    """Reference to a single content-addressed blob.
+
+    Parameters
+    ----------
+    digest_algorithm : str
+        Hash algorithm used (e.g. ``"blake3"``).
+    digest_hex : str
+        Hex-encoded content digest.
+    size : int
+        Byte count of the stored blob.
+    extension : str
+        Original file extension including the leading dot (e.g. ``".csv"``),
+        or empty string if the source had no extension.
+    """
+
+    digest_algorithm: str
+    digest_hex: str
+    size: int
+    extension: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class TreeEntry:
+    """One file entry in a tree manifest.
+
+    Parameters
+    ----------
+    relative_path : str
+        POSIX-style relative path within the directory.
+    blob_digest : str
+        Hex digest of the file content.
+    size : int
+        Byte count of the file.
+    mode : int
+        Original file permission mode.
+    """
+
+    relative_path: str
+    blob_digest: str
+    size: int
+    mode: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class TreeRef:
+    """Reference to a directory manifest.
+
+    Parameters
+    ----------
+    digest_algorithm : str
+        Hash algorithm used for the manifest digest.
+    digest_hex : str
+        Hex digest of the serialized manifest content.
+    entries : tuple[TreeEntry, ...]
+        Ordered file entries that compose the directory.
+    """
+
+    digest_algorithm: str
+    digest_hex: str
+    entries: tuple[TreeEntry, ...]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ArtifactRecord:
+    """Metadata record persisted alongside stored content.
+
+    Parameters
+    ----------
+    artifact_id : str
+        Unique artifact identifier (content digest for managed artifacts).
+    kind : str
+        ``"blob"`` or ``"tree"``.
+    digest_algorithm : str
+        Hash algorithm used.
+    digest_hex : str
+        Hex-encoded content digest.
+    extension : str
+        Original file extension for blobs, empty string for trees.
+    size : int
+        Total byte count.
+    created_at : str
+        ISO-8601 creation timestamp.
+    storage_backend : str
+        Storage backend identifier (``"local"`` for now).
+    """
+
+    artifact_id: str
+    kind: str
+    digest_algorithm: str
+    digest_hex: str
+    extension: str
+    size: int
+    created_at: str
+    storage_backend: str
+    remote_uri: str | None = None
+
+    def to_json(self) -> str:
+        """Serialize to a JSON string.
+
+        Returns
+        -------
+        str
+            JSON representation with sorted keys.
+        """
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, data: str) -> ArtifactRecord:
+        """Deserialize from a JSON string.
+
+        Parameters
+        ----------
+        data : str
+            JSON string produced by :meth:`to_json`.
+
+        Returns
+        -------
+        ArtifactRecord
+        """
+        return cls(**json.loads(data))
+
+    @classmethod
+    def from_path(cls, path: Path) -> ArtifactRecord:
+        """Load from a JSON file on disk.
+
+        Parameters
+        ----------
+        path : Path
+            Path to the JSON file.
+
+        Returns
+        -------
+        ArtifactRecord
+        """
+        return cls.from_json(path.read_text(encoding="utf-8"))
+
+
+def serialize_tree_manifest(ref: TreeRef) -> str:
+    """Serialize a tree manifest to JSON.
+
+    Parameters
+    ----------
+    ref : TreeRef
+        Tree reference to serialize.
+
+    Returns
+    -------
+    str
+        JSON string with sorted keys.
+    """
+    payload = {
+        "digest_algorithm": ref.digest_algorithm,
+        "digest_hex": ref.digest_hex,
+        "entries": [asdict(entry) for entry in ref.entries],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def deserialize_tree_manifest(data: str) -> TreeRef:
+    """Deserialize a tree manifest from JSON.
+
+    Parameters
+    ----------
+    data : str
+        JSON string produced by :func:`serialize_tree_manifest`.
+
+    Returns
+    -------
+    TreeRef
+    """
+    payload = json.loads(data)
+    entries = tuple(TreeEntry(**entry) for entry in payload["entries"])
+    return TreeRef(
+        digest_algorithm=payload["digest_algorithm"],
+        digest_hex=payload["digest_hex"],
+        entries=entries,
+    )

--- a/ginkgo/runtime/artifact_store.py
+++ b/ginkgo/runtime/artifact_store.py
@@ -3,29 +3,42 @@
 The ``ArtifactStore`` protocol defines the contract for storing and retrieving
 binary artifacts.  ``LocalArtifactStore`` is the default implementation that
 stores artifacts on the local filesystem under ``.ginkgo/artifacts/``.
+
+Storage layout::
+
+    .ginkgo/artifacts/
+      blobs/<digest>              # raw file bytes, read-only
+      trees/<tree_digest>.json    # directory manifest
+      refs/<artifact_id>.json     # artifact metadata record
 """
 
 from __future__ import annotations
 
 import shutil
 import stat
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from ginkgo.runtime.hashing import hash_bytes, hash_directory, hash_file
+from ginkgo.runtime.artifact_model import (
+    ArtifactRecord,
+    TreeEntry,
+    TreeRef,
+    deserialize_tree_manifest,
+    serialize_tree_manifest,
+)
+from ginkgo.runtime.hashing import hash_bytes, hash_file
+
+
+DIGEST_ALGORITHM = "blake3"
 
 
 @runtime_checkable
 class ArtifactStore(Protocol):
-    """Protocol for content-addressed artifact storage.
+    """Protocol for content-addressed artifact storage."""
 
-    Artifact IDs use the format ``<blake3>.<ext>`` for files and ``<blake3>``
-    for directories.  This identity scheme is consumed directly by downstream
-    phases (remote artifact store, asset catalog, versioned assets).
-    """
-
-    def store(self, *, src_path: Path) -> str:
-        """Copy bytes into the store and return a content-addressed artifact ID.
+    def store(self, *, src_path: Path) -> ArtifactRecord:
+        """Copy bytes into the store and return an artifact record.
 
         Parameters
         ----------
@@ -34,9 +47,8 @@ class ArtifactStore(Protocol):
 
         Returns
         -------
-        str
-            Artifact ID in the form ``<blake3>.<ext>`` (file) or ``<blake3>``
-            (directory).
+        ArtifactRecord
+            Metadata record for the stored artifact.
         """
         ...
 
@@ -90,8 +102,8 @@ class ArtifactStore(Protocol):
         """
         ...
 
-    def store_bytes(self, *, data: bytes, extension: str) -> str:
-        """Store raw bytes and return a content-addressed artifact ID.
+    def store_bytes(self, *, data: bytes, extension: str) -> ArtifactRecord:
+        """Store raw bytes and return an artifact record.
 
         Parameters
         ----------
@@ -102,8 +114,7 @@ class ArtifactStore(Protocol):
 
         Returns
         -------
-        str
-            Artifact ID.
+        ArtifactRecord
         """
         ...
 
@@ -123,7 +134,7 @@ class ArtifactStore(Protocol):
 
 
 class LocalArtifactStore:
-    """Local filesystem artifact store.
+    """Local filesystem artifact store using blob/tree CAS layout.
 
     Parameters
     ----------
@@ -134,9 +145,13 @@ class LocalArtifactStore:
 
     def __init__(self, *, root: Path | None = None) -> None:
         self._root = root if root is not None else Path.cwd() / ".ginkgo" / "artifacts"
-        self._root.mkdir(parents=True, exist_ok=True)
+        self._blobs_dir = self._root / "blobs"
+        self._trees_dir = self._root / "trees"
+        self._refs_dir = self._root / "refs"
+        for directory in (self._blobs_dir, self._trees_dir, self._refs_dir):
+            directory.mkdir(parents=True, exist_ok=True)
 
-    def store(self, *, src_path: Path) -> str:
+    def store(self, *, src_path: Path) -> ArtifactRecord:
         """Copy a file or directory into the store.
 
         Parameters
@@ -146,8 +161,8 @@ class LocalArtifactStore:
 
         Returns
         -------
-        str
-            Content-addressed artifact ID.
+        ArtifactRecord
+            Metadata record for the stored artifact.
         """
         if src_path.is_dir():
             return self._store_directory(src_path)
@@ -156,26 +171,32 @@ class LocalArtifactStore:
     def retrieve(self, *, artifact_id: str, dest_path: Path) -> None:
         """Create a symlink at *dest_path* pointing to the stored artifact.
 
+        For blob artifacts, creates a symlink to the blob file.  For tree
+        artifacts, reconstructs the directory by creating symlinks from each
+        manifest entry to its corresponding blob.
+
         Parameters
         ----------
         artifact_id : str
             Artifact ID returned by :meth:`store`.
         dest_path : Path
-            Target symlink location.  Parent directories are created if needed.
+            Target symlink location.
         """
-        target = self._root / artifact_id
-        if not target.exists():
+        ref_path = self._refs_dir / f"{artifact_id}.json"
+        if not ref_path.exists():
             raise FileNotFoundError(f"Artifact not found in store: {artifact_id}")
 
+        record = ArtifactRecord.from_path(ref_path)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        if dest_path.is_symlink() or dest_path.exists():
-            if dest_path.is_symlink():
-                dest_path.unlink()
-            elif dest_path.is_dir():
-                shutil.rmtree(dest_path)
-            else:
-                dest_path.unlink()
-        dest_path.symlink_to(target)
+
+        # Clean up any existing path at dest.
+        _remove_dest(dest_path)
+
+        if record.kind == "blob":
+            blob_path = self._blobs_dir / record.digest_hex
+            dest_path.symlink_to(blob_path)
+        else:
+            self._retrieve_tree(artifact_id=artifact_id, dest_path=dest_path)
 
     def exists(self, *, artifact_id: str) -> bool:
         """Check whether an artifact exists in the store.
@@ -189,7 +210,7 @@ class LocalArtifactStore:
         -------
         bool
         """
-        return (self._root / artifact_id).exists()
+        return (self._refs_dir / f"{artifact_id}.json").exists()
 
     def delete(self, *, artifact_id: str) -> None:
         """Remove an artifact from the store.
@@ -199,18 +220,36 @@ class LocalArtifactStore:
         artifact_id : str
             The artifact ID to remove.
         """
-        target = self._root / artifact_id
-        if not target.exists():
+        ref_path = self._refs_dir / f"{artifact_id}.json"
+        if not ref_path.exists():
             return
-        if target.is_dir():
-            _make_writable_recursive(target)
-            shutil.rmtree(target)
-        else:
-            target.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            target.unlink()
+
+        record = ArtifactRecord.from_path(ref_path)
+
+        if record.kind == "tree":
+            # Remove tree manifest.
+            tree_path = self._trees_dir / f"{record.digest_hex}.json"
+            if tree_path.exists():
+                tree_path.unlink()
+
+        # Remove blob(s).  For trees, only remove blobs not referenced
+        # by other artifacts.  For simplicity in the local case we remove
+        # the blob unconditionally -- orphaned blob cleanup can be added
+        # later if needed.
+        if record.kind == "blob":
+            blob_path = self._blobs_dir / record.digest_hex
+            if blob_path.exists():
+                blob_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+                blob_path.unlink()
+
+        ref_path.unlink()
 
     def artifact_path(self, *, artifact_id: str) -> Path:
-        """Return the absolute path for an artifact.
+        """Return the absolute path for an artifact's primary content.
+
+        For blobs, returns the blob file path.  For trees, returns the
+        blob directory (callers should use :meth:`retrieve` instead for
+        tree artifacts).
 
         Parameters
         ----------
@@ -221,39 +260,17 @@ class LocalArtifactStore:
         -------
         Path
         """
-        return self._root / artifact_id
+        ref_path = self._refs_dir / f"{artifact_id}.json"
+        if not ref_path.exists():
+            return self._blobs_dir / artifact_id
 
-    def _store_file(self, src_path: Path) -> str:
-        """Store a single file, returning its artifact ID."""
-        digest = hash_file(src_path)
-        ext = src_path.suffix.lstrip(".")
-        artifact_id = f"{digest}.{ext}" if ext else digest
-        dest = self._root / artifact_id
+        record = ArtifactRecord.from_path(ref_path)
+        if record.kind == "blob":
+            return self._blobs_dir / record.digest_hex
+        return self._trees_dir / f"{record.digest_hex}.json"
 
-        # Content-addressed dedup: skip if already present.
-        if dest.exists():
-            return artifact_id
-
-        shutil.copy2(src_path, dest)
-        dest.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 0o444
-        return artifact_id
-
-    def _store_directory(self, src_path: Path) -> str:
-        """Store a directory tree, returning its artifact ID."""
-        digest = _hash_directory(src_path)
-        artifact_id = digest
-        dest = self._root / artifact_id
-
-        # Content-addressed dedup: skip if already present.
-        if dest.exists():
-            return artifact_id
-
-        shutil.copytree(src_path, dest)
-        _set_read_only_recursive(dest)
-        return artifact_id
-
-    def store_bytes(self, *, data: bytes, extension: str) -> str:
-        """Store raw bytes, returning a content-addressed artifact ID.
+    def store_bytes(self, *, data: bytes, extension: str) -> ArtifactRecord:
+        """Store raw bytes, returning an artifact record.
 
         Parameters
         ----------
@@ -264,19 +281,28 @@ class LocalArtifactStore:
 
         Returns
         -------
-        str
-            Artifact ID in the form ``<blake3>.<ext>``.
+        ArtifactRecord
         """
         digest = hash_bytes(data)
-        artifact_id = f"{digest}.{extension}" if extension else digest
-        dest = self._root / artifact_id
+        blob_path = self._blobs_dir / digest
 
-        if dest.exists():
-            return artifact_id
+        if not blob_path.exists():
+            blob_path.write_bytes(data)
+            blob_path.chmod(_READ_ONLY_FILE)
 
-        dest.write_bytes(data)
-        dest.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 0o444
-        return artifact_id
+        ext = f".{extension}" if extension else ""
+        record = ArtifactRecord(
+            artifact_id=digest,
+            kind="blob",
+            digest_algorithm=DIGEST_ALGORITHM,
+            digest_hex=digest,
+            extension=ext,
+            size=len(data),
+            created_at=_now_iso(),
+            storage_backend="local",
+        )
+        self._write_ref(record)
+        return record
 
     def read_bytes(self, *, artifact_id: str) -> bytes:
         """Read raw bytes for an artifact.
@@ -290,35 +316,156 @@ class LocalArtifactStore:
         -------
         bytes
         """
-        target = self._root / artifact_id
-        if not target.exists():
-            raise FileNotFoundError(f"Artifact not found in store: {artifact_id}")
-        return target.read_bytes()
-
-
-def _hash_directory(path: Path) -> str:
-    """Return a BLAKE3 digest over a directory's recursive contents."""
-    return hash_directory(path)
-
-
-def _set_read_only_recursive(path: Path) -> None:
-    """Set a directory tree to read-only (files 0o444, dirs 0o555)."""
-    for child in path.rglob("*"):
-        if child.is_dir():
-            child.chmod(
-                stat.S_IRUSR
-                | stat.S_IXUSR
-                | stat.S_IRGRP
-                | stat.S_IXGRP
-                | stat.S_IROTH
-                | stat.S_IXOTH
-            )
+        ref_path = self._refs_dir / f"{artifact_id}.json"
+        if ref_path.exists():
+            record = ArtifactRecord.from_path(ref_path)
+            blob_path = self._blobs_dir / record.digest_hex
         else:
-            child.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-    # Set the root directory itself.
-    path.chmod(
-        stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
-    )
+            blob_path = self._blobs_dir / artifact_id
+
+        if not blob_path.exists():
+            raise FileNotFoundError(f"Artifact not found in store: {artifact_id}")
+        return blob_path.read_bytes()
+
+    # -- internal helpers --------------------------------------------------
+
+    def _store_file(self, src_path: Path) -> ArtifactRecord:
+        """Store a single file as a blob."""
+        digest = hash_file(src_path)
+        blob_path = self._blobs_dir / digest
+
+        if not blob_path.exists():
+            shutil.copy2(src_path, blob_path)
+            blob_path.chmod(_READ_ONLY_FILE)
+
+        size = blob_path.stat().st_size
+        ext = src_path.suffix  # includes leading dot
+
+        record = ArtifactRecord(
+            artifact_id=digest,
+            kind="blob",
+            digest_algorithm=DIGEST_ALGORITHM,
+            digest_hex=digest,
+            extension=ext,
+            size=size,
+            created_at=_now_iso(),
+            storage_backend="local",
+        )
+        self._write_ref(record)
+        return record
+
+    def _store_directory(self, src_path: Path) -> ArtifactRecord:
+        """Store a directory as individual blobs plus a tree manifest."""
+        real_src = src_path.resolve()
+        entries: list[TreeEntry] = []
+        total_size = 0
+
+        # Walk files in sorted order for deterministic manifests.
+        for child in sorted(real_src.rglob("*"), key=lambda p: str(p.relative_to(real_src))):
+            if child.is_dir():
+                continue
+
+            rel = child.relative_to(real_src).as_posix()
+            digest = hash_file(child)
+            file_size = child.stat().st_size
+            file_mode = child.stat().st_mode & 0o777
+
+            # Store the blob.
+            blob_path = self._blobs_dir / digest
+            if not blob_path.exists():
+                shutil.copy2(child, blob_path)
+                blob_path.chmod(_READ_ONLY_FILE)
+
+            entries.append(
+                TreeEntry(
+                    relative_path=rel,
+                    blob_digest=digest,
+                    size=file_size,
+                    mode=file_mode,
+                )
+            )
+            total_size += file_size
+
+        # Build and store the tree manifest.
+        manifest_json = serialize_tree_manifest(
+            TreeRef(
+                digest_algorithm=DIGEST_ALGORITHM,
+                digest_hex="",  # placeholder, recomputed below
+                entries=tuple(entries),
+            )
+        )
+        tree_digest = hash_bytes(manifest_json.encode("utf-8"))
+
+        # Rewrite with the real digest.
+        tree_ref = TreeRef(
+            digest_algorithm=DIGEST_ALGORITHM,
+            digest_hex=tree_digest,
+            entries=tuple(entries),
+        )
+        manifest_json = serialize_tree_manifest(tree_ref)
+        tree_path = self._trees_dir / f"{tree_digest}.json"
+        tree_path.write_text(manifest_json, encoding="utf-8")
+
+        record = ArtifactRecord(
+            artifact_id=tree_digest,
+            kind="tree",
+            digest_algorithm=DIGEST_ALGORITHM,
+            digest_hex=tree_digest,
+            extension="",
+            size=total_size,
+            created_at=_now_iso(),
+            storage_backend="local",
+        )
+        self._write_ref(record)
+        return record
+
+    def _retrieve_tree(self, *, artifact_id: str, dest_path: Path) -> None:
+        """Reconstruct a directory from its tree manifest."""
+        ref_path = self._refs_dir / f"{artifact_id}.json"
+        record = ArtifactRecord.from_path(ref_path)
+        tree_path = self._trees_dir / f"{record.digest_hex}.json"
+
+        if not tree_path.exists():
+            raise FileNotFoundError(f"Tree manifest not found: {record.digest_hex}")
+
+        tree_ref = deserialize_tree_manifest(tree_path.read_text(encoding="utf-8"))
+
+        dest_path.mkdir(parents=True, exist_ok=True)
+
+        for entry in tree_ref.entries:
+            entry_dest = dest_path / entry.relative_path
+            entry_dest.parent.mkdir(parents=True, exist_ok=True)
+            blob_path = self._blobs_dir / entry.blob_digest
+
+            # Symlink each file to its blob.
+            if entry_dest.is_symlink() or entry_dest.exists():
+                entry_dest.unlink()
+            entry_dest.symlink_to(blob_path)
+
+    def _write_ref(self, record: ArtifactRecord) -> None:
+        """Write an artifact metadata record to the refs directory."""
+        ref_path = self._refs_dir / f"{record.artifact_id}.json"
+        ref_path.write_text(record.to_json(), encoding="utf-8")
+
+
+# -- module-level helpers --------------------------------------------------
+
+_READ_ONLY_FILE = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH  # 0o444
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _remove_dest(dest_path: Path) -> None:
+    """Remove an existing file, symlink, or directory at *dest_path*."""
+    if dest_path.is_symlink():
+        dest_path.unlink()
+    elif dest_path.is_dir():
+        shutil.rmtree(dest_path)
+    elif dest_path.exists():
+        dest_path.unlink()
 
 
 def _make_writable_recursive(path: Path) -> None:

--- a/ginkgo/runtime/cache.py
+++ b/ginkgo/runtime/cache.py
@@ -14,6 +14,7 @@ from typing import Any, get_args, get_origin
 from ginkgo.core.secret import SecretRef
 from ginkgo.core.task import TaskDef
 from ginkgo.core.types import file, folder, tmp_dir
+from ginkgo.runtime.artifact_model import ArtifactRecord
 from ginkgo.runtime.artifact_store import LocalArtifactStore
 from ginkgo.runtime.hashing import hash_bytes, hash_directory, hash_file, hash_str
 from ginkgo.runtime.secrets import redact_value, secret_identity
@@ -43,11 +44,15 @@ class CacheStore:
     artifact_store : LocalArtifactStore | None
         Shared artifact store for content-addressed binary and file/folder
         artifacts.  Created automatically when ``None``.
+    publisher : RemotePublisher | None
+        Optional remote publisher for uploading artifacts after local storage.
+        When set, artifacts are published to the remote store automatically.
     """
 
     root: Path | None = None
     backend: Any | None = None  # TaskBackend; typed as Any to avoid circular import
     artifact_store: LocalArtifactStore | None = None
+    publisher: Any | None = None  # RemotePublisher; typed as Any to avoid circular import
     _root: Path = field(init=False, repr=False)
     _artifact_store: LocalArtifactStore = field(init=False, repr=False)
 
@@ -142,6 +147,10 @@ class CacheStore:
         # entry already exists (handles re-execution after symlink replacement).
         artifact_ids = self._store_output_artifacts(result=result, task_def=task_def)
 
+        # Publish artifacts to remote store if a publisher is configured.
+        if self.publisher is not None:
+            self._publish_artifacts(artifact_ids)
+
         entry_dir = self._entry_dir(cache_key)
         if not entry_dir.exists():
             temp_dir = Path(tempfile.mkdtemp(prefix=f"{cache_key}.tmp-", dir=self._root))
@@ -234,8 +243,8 @@ class CacheStore:
         """
         if path.is_symlink():
             target = path.resolve()
-            # Symlink points into our artifact store — valid.
-            if str(target).startswith(str(self._artifact_store._root)):
+            # Symlink points into our artifact store blobs — valid.
+            if str(target).startswith(str(self._artifact_store._blobs_dir)):
                 return True
             # Symlink to somewhere else — treat as modified.
             return False
@@ -252,16 +261,37 @@ class CacheStore:
         return False
 
     def _validate_folder_symlink(self, path: Path) -> bool:
-        """Validate a single folder output symlink."""
+        """Validate a single folder output.
+
+        Tree artifacts are reconstructed directories containing symlinks to
+        individual blobs.  A valid folder output is a directory whose file
+        entries are symlinks pointing into the artifact store's blob directory.
+        """
         if path.is_symlink():
             target = path.resolve()
             if str(target).startswith(str(self._artifact_store._root)):
                 return True
             return False
 
+        if path.is_dir():
+            # Tree artifacts: directory with symlinked files pointing to blobs.
+            blobs_prefix = str(self._artifact_store._blobs_dir)
+            for child in path.rglob("*"):
+                if child.is_dir() and not child.is_symlink():
+                    continue
+                if child.is_symlink():
+                    target = child.resolve()
+                    if not str(target).startswith(blobs_prefix):
+                        return False
+                else:
+                    # Regular file inside what should be a reconstructed tree.
+                    return False
+            return True
+
         if path.exists():
             return False
 
+        # Path is absent — try to recreate from the artifact store.
         artifact_id = self._find_artifact_for_path(path, is_dir=True)
         if artifact_id is not None and self._artifact_store.exists(artifact_id=artifact_id):
             self._artifact_store.retrieve(artifact_id=artifact_id, dest_path=path)
@@ -314,6 +344,24 @@ class CacheStore:
         )
         return artifact_ids
 
+    def _publish_artifacts(self, artifact_ids: dict[str, str]) -> None:
+        """Publish stored artifacts to the remote store.
+
+        Loads each artifact record from the refs directory and publishes it
+        via the configured publisher.
+
+        Parameters
+        ----------
+        artifact_ids : dict[str, str]
+            Mapping from output path strings to artifact IDs.
+        """
+        refs_dir = self._artifact_store._refs_dir
+        for artifact_id in artifact_ids.values():
+            ref_path = refs_dir / f"{artifact_id}.json"
+            if ref_path.exists():
+                record = ArtifactRecord.from_path(ref_path)
+                self.publisher.publish(record=record)
+
     def _collect_output_artifacts(
         self,
         *,
@@ -349,8 +397,8 @@ class CacheStore:
                 # Already a symlink (e.g. from a previous run) — skip.
                 return
             if path.is_file():
-                artifact_id = self._artifact_store.store(src_path=path)
-                artifact_ids[str(path)] = artifact_id
+                record = self._artifact_store.store(src_path=path)
+                artifact_ids[str(path)] = record.artifact_id
             return
 
         if annotation is folder or isinstance(value, folder):
@@ -358,8 +406,8 @@ class CacheStore:
             if path.is_symlink():
                 return
             if path.is_dir():
-                artifact_id = self._artifact_store.store(src_path=path)
-                artifact_ids[str(path)] = artifact_id
+                record = self._artifact_store.store(src_path=path)
+                artifact_ids[str(path)] = record.artifact_id
             return
 
     def _symlink_output_artifacts(self, *, result: Any, task_def: TaskDef) -> None:

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -32,6 +32,7 @@ import yaml
 
 from ginkgo.core.expr import Expr, ExprList, OutputIndex
 from ginkgo.core.notebook import NotebookExpr
+from ginkgo.core.remote import RemoteFileRef, RemoteFolderRef, RemoteRef, is_remote_uri
 from ginkgo.core.script import ScriptExpr
 from ginkgo.core.secret import SecretRef
 from ginkgo.core.shell import ShellExpr
@@ -55,6 +56,7 @@ from ginkgo.runtime.events import (
     TaskLog,
     TaskReady,
     TaskRetrying,
+    TaskStaging,
     TaskStarted,
 )
 from ginkgo.runtime.module_loader import load_module, resolve_module_file
@@ -279,7 +281,9 @@ class _ConcurrentEvaluator:
         if self.memory is not None and self.memory < 1:
             raise ValueError("memory must be at least 1 when provided")
 
-        self._cache_store = CacheStore(backend=self.backend)
+        publisher = self._load_remote_publisher()
+        self._cache_store = CacheStore(backend=self.backend, publisher=publisher)
+        self._staging_cache = None  # Lazily created on first remote ref.
 
     def evaluate(self, expr: Any) -> Any:
         """Resolve a root expression or nested container concurrently."""
@@ -491,6 +495,7 @@ class _ConcurrentEvaluator:
         resolved_args = self._resolve_task_args(
             expr=node.expr,
             task_def=node.task_def,
+            node=node,
             include_tmp_dirs=False,
         )
         self._validate_inputs(task_def=node.task_def, resolved_args=resolved_args)
@@ -651,6 +656,21 @@ class _ConcurrentEvaluator:
             node = self._nodes[node_id]
             node.attempt += 1
             node.state = "running"
+            node.resolved_args = self._resolve_task_args(
+                expr=node.expr,
+                task_def=node.task_def,
+                node=node,
+                include_tmp_dirs=True,
+                existing_args=node.resolved_args,
+                tmp_paths=node.tmp_paths,
+            )
+            node.execution_args = self._resolve_execution_args(node=node)
+            node.secret_values = collect_resolved_secret_values(
+                template=node.resolved_args,
+                resolved=node.execution_args,
+            )
+            self._record_task_metadata(node)
+            self._validate_task_contract(node=node)
             self._emit_event(
                 TaskStarted(
                     run_id=self._run_id,
@@ -675,20 +695,6 @@ class _ConcurrentEvaluator:
                     attempt=node.attempt,
                     retries=node.task_def.retries,
                 )
-            node.resolved_args = self._resolve_task_args(
-                expr=node.expr,
-                task_def=node.task_def,
-                include_tmp_dirs=True,
-                existing_args=node.resolved_args,
-                tmp_paths=node.tmp_paths,
-            )
-            node.execution_args = self._resolve_execution_args(node=node)
-            node.secret_values = collect_resolved_secret_values(
-                template=node.resolved_args,
-                resolved=node.execution_args,
-            )
-            self._record_task_metadata(node)
-            self._validate_task_contract(node=node)
 
             if node.task_def.kind in {"notebook", "script", "shell"}:
                 assert self._shell_executor is not None
@@ -888,6 +894,7 @@ class _ConcurrentEvaluator:
         *,
         expr: Expr,
         task_def: TaskDef,
+        node: _TaskNode | None = None,
         include_tmp_dirs: bool,
         existing_args: dict[str, Any] | None = None,
         tmp_paths: list[Path] | None = None,
@@ -919,7 +926,135 @@ class _ConcurrentEvaluator:
 
             raise TypeError(f"{task_def.fn.__name__}() missing required argument: '{name}'")
 
+        # Stage remote references and coerce remote URI strings.
+        resolved_args = self._stage_remote_refs(
+            node=node,
+            task_def=task_def,
+            resolved_args=resolved_args,
+        )
+
         return resolved_args
+
+    def _stage_remote_refs(
+        self,
+        *,
+        node: _TaskNode | None,
+        task_def: TaskDef,
+        resolved_args: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Stage remote references into local paths.
+
+        Handles two cases:
+
+        1. Explicit ``RemoteFileRef`` / ``RemoteFolderRef`` values.
+        2. Annotation-aware coercion: raw ``s3://`` or ``oci://`` strings
+           passed to ``file`` or ``folder`` parameters.
+        """
+        remote_input_count = _count_remote_inputs(resolved_args)
+        if node is not None and remote_input_count > 0:
+            self._emit_event(
+                TaskStaging(
+                    run_id=self._run_id,
+                    task_id=_task_id_for_node(node.node_id),
+                    task_name=node.task_def.name,
+                    attempt=node.attempt,
+                    display_label=node.display_label,
+                    remote_input_count=remote_input_count,
+                )
+            )
+
+        staged: dict[str, Any] = {}
+        for name, value in resolved_args.items():
+            annotation = task_def.type_hints.get(
+                name,
+                task_def.signature.parameters[name].annotation
+                if name in task_def.signature.parameters
+                else Any,
+            )
+            staged[name] = self._stage_remote_value(annotation=annotation, value=value)
+        return staged
+
+    def _stage_remote_value(self, *, annotation: Any, value: Any) -> Any:
+        """Stage a single value, recursing into containers."""
+        # Explicit remote refs.
+        if isinstance(value, RemoteFileRef):
+            return file(str(self._get_staging_cache().stage_file(ref=value)))
+        if isinstance(value, RemoteFolderRef):
+            return folder(str(self._get_staging_cache().stage_folder(ref=value)))
+
+        # Annotation-aware coercion: raw URI string → remote ref → staged path.
+        if isinstance(value, str) and is_remote_uri(value):
+            if annotation is file:
+                from ginkgo.core.remote import remote_file
+
+                ref = remote_file(value)
+                return file(str(self._get_staging_cache().stage_file(ref=ref)))
+            if annotation is folder:
+                from ginkgo.core.remote import remote_folder
+
+                ref = remote_folder(value)
+                return folder(str(self._get_staging_cache().stage_folder(ref=ref)))
+
+        # Recurse into typed containers.
+        origin = get_origin(annotation)
+        if origin in {list, tuple} and isinstance(value, (list, tuple)):
+            inner_args = get_args(annotation)
+            inner_annotation = inner_args[0] if inner_args else Any
+            staged_items = [
+                self._stage_remote_value(annotation=inner_annotation, value=item) for item in value
+            ]
+            return type(value)(staged_items)
+
+        return value
+
+    def _get_staging_cache(self) -> Any:
+        """Lazily create and return the staging cache."""
+        if self._staging_cache is None:
+            from ginkgo.remote.staging import StagingCache
+
+            self._staging_cache = StagingCache()
+        return self._staging_cache
+
+    def _load_remote_publisher(self) -> Any | None:
+        """Load a remote publisher from ginkgo.toml if configured.
+
+        Looks for a ``[remote] store`` key containing a remote URI string
+        (e.g. ``s3://bucket/prefix/``).
+
+        Returns
+        -------
+        RemotePublisher | None
+            A publisher instance, or ``None`` if not configured.
+        """
+        from ginkgo.config import load_runtime_config
+
+        config = load_runtime_config(project_root=Path.cwd())
+        store_uri = config.get("remote", {}).get("store")
+        if store_uri is None:
+            return None
+
+        from ginkgo.core.remote import _parse_uri
+        from ginkgo.remote.publisher import RemotePublisher
+        from ginkgo.remote.resolve import resolve_backend
+
+        parsed = _parse_uri(store_uri)
+        backend = resolve_backend(parsed["scheme"])
+
+        # The key from the URI becomes the prefix for all published artifacts.
+        prefix = parsed["key"]
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+
+        # Artifact store directories.
+        artifacts_root = Path.cwd() / ".ginkgo" / "artifacts"
+        return RemotePublisher(
+            backend=backend,
+            bucket=parsed["bucket"],
+            prefix=prefix,
+            local_blobs_dir=artifacts_root / "blobs",
+            local_trees_dir=artifacts_root / "trees",
+            local_refs_dir=artifacts_root / "refs",
+        )
 
     def _resolve_execution_args(self, *, node: _TaskNode) -> dict[str, Any]:
         """Resolve runtime-only inputs such as secret references."""
@@ -1975,10 +2110,14 @@ class _ConcurrentEvaluator:
             return
 
         if annotation is file:
+            if _is_remote_path_value(value):
+                return
             self._validate_file_path(path=value, label=label)
             return
 
         if annotation is folder:
+            if _is_remote_path_value(value):
+                return
             self._validate_folder_path(path=value, label=label)
             return
 
@@ -2233,6 +2372,14 @@ class _ConcurrentEvaluator:
                 "node_id": int(event.task_id.split("_")[-1]),
                 "attempt": event.attempt,
                 "max_attempts": event.resources.get("max_attempts"),
+            }
+        elif isinstance(event, TaskStaging):
+            payload = {
+                "task": event.task_name,
+                "status": "staging",
+                "node_id": int(event.task_id.split("_")[-1]),
+                "attempt": event.attempt,
+                "remote_input_count": event.remote_input_count,
             }
         elif isinstance(event, TaskCacheHit):
             payload = {
@@ -2607,6 +2754,26 @@ def _artifact_index(annotation: Any, value: Any, *, name: str = "return") -> lis
         ]
 
     return [{"name": name, "type": "value", "summary": summarise_value(value)}]
+
+
+def _is_remote_path_value(value: Any) -> bool:
+    """Return whether a value is a remote reference or supported remote URI."""
+    if isinstance(value, RemoteRef):
+        return True
+    return isinstance(value, str) and is_remote_uri(value)
+
+
+def _count_remote_inputs(value: Any) -> int:
+    """Count nested remote refs and supported remote URI strings."""
+    if isinstance(value, RemoteRef):
+        return 1
+    if isinstance(value, str) and is_remote_uri(value):
+        return 1
+    if isinstance(value, list | tuple):
+        return sum(_count_remote_inputs(item) for item in value)
+    if isinstance(value, dict):
+        return sum(_count_remote_inputs(item) for item in value.values())
+    return 0
 
 
 def _classify_failure(*, exc: BaseException) -> dict[str, Any]:

--- a/ginkgo/runtime/events.py
+++ b/ginkgo/runtime/events.py
@@ -97,6 +97,15 @@ class TaskStarted(TaskEvent):
 
 
 @dataclass(kw_only=True, frozen=True)
+class TaskStaging(TaskEvent):
+    """Task is staging remote inputs before dispatch."""
+
+    event: str = "task_staging"
+    status: Literal["staging"] = "staging"
+    remote_input_count: int = 0
+
+
+@dataclass(kw_only=True, frozen=True)
 class TaskLog(TaskEvent):
     """Task log chunk event."""
 

--- a/ginkgo/runtime/value_codec.py
+++ b/ginkgo/runtime/value_codec.py
@@ -271,10 +271,10 @@ def _encode_binary_payload(
 
     # Route through the artifact store when available (cache persistence).
     if artifact_store is not None:
-        artifact_id = artifact_store.store_bytes(data=data, extension=extension)
+        record = artifact_store.store_bytes(data=data, extension=extension)
         return {
             "__ginkgo_type__": "binary",
-            "artifact_id": artifact_id,
+            "artifact_id": record.artifact_id,
             "codec": codec_name,
             "storage": "artifact_store",
         }

--- a/pixi.lock
+++ b/pixi.lock
@@ -47,39 +47,60 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/30/7016a8bf2e02cb960974a4101dabb9da590540e584d446421375d72b5cf9/oci-2.168.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/e1/64c264db50b68de8a438b60ceeb921b2f22da3ebb7ad6255150225d0beac/s3fs-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
@@ -92,9 +113,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/32/5c15bb8ea20ed54d43c734f253a2a5da95d41474caecf4ef3682df9f68f5/ty-0.0.25-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/f4/f3f61c203bc980dd9bba0ba7ed3c6e81ddfd36b286330f9487c2c7d041aa/ty-0.0.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blake3-1.0.8-py314haad56a0_1.conda
@@ -129,39 +152,60 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/30/7016a8bf2e02cb960974a4101dabb9da590540e584d446421375d72b5cf9/oci-2.168.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/e1/64c264db50b68de8a438b60ceeb921b2f22da3ebb7ad6255150225d0beac/s3fs-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
@@ -174,9 +218,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/93/ffc5a20cc9e14fa9b32b0c54884864bede30d144ce2ae013805bce0c86d0/ty-0.0.25-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/71/25/37081461e13d38a190e5646948d7bc42084f7bd1c6b44f12550be3923e7e/ty-0.0.26-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -213,11 +259,87 @@ packages:
   - hypothesis ; extra == 'tests'
   - pytest ; extra == 'tests'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+  name: aiobotocore
+  version: 3.3.0
+  sha256: 9125ab2b63740dfe3b66b8d5a90d13aed9587b850aa53225ef214a04a1aa7fdc
+  requires_dist:
+  - aiohttp>=3.12.0,<4.0.0
+  - aioitertools>=0.5.1,<1.0.0
+  - botocore>=1.42.62,<1.42.71
+  - python-dateutil>=2.1,<3.0.0
+  - jmespath>=0.7.1,<2.0.0
+  - multidict>=6.0.0,<7.0.0
+  - typing-extensions>=4.14.0,<5.0.0 ; python_full_version < '3.11'
+  - wrapt>=1.10.10,<3.0.0
+  - httpx>=0.25.1,<0.29 ; extra == 'httpx'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+  name: aiohappyeyeballs
+  version: 2.6.1
+  sha256: f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: aiohttp
+  version: 3.13.3
+  sha256: bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1
+  requires_dist:
+  - aiohappyeyeballs>=2.5.0
+  - aiosignal>=1.4.0
+  - async-timeout>=4.0,<6.0 ; python_full_version < '3.11'
+  - attrs>=17.3.0
+  - frozenlist>=1.1.1
+  - multidict>=4.5,<7.0
+  - propcache>=0.2.0
+  - yarl>=1.17.0,<2.0
+  - aiodns>=3.3.0 ; extra == 'speedups'
+  - brotli>=1.2 ; platform_python_implementation == 'CPython' and extra == 'speedups'
+  - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
+  - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and extra == 'speedups'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
+  name: aiohttp
+  version: 3.13.3
+  sha256: c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f
+  requires_dist:
+  - aiohappyeyeballs>=2.5.0
+  - aiosignal>=1.4.0
+  - async-timeout>=4.0,<6.0 ; python_full_version < '3.11'
+  - attrs>=17.3.0
+  - frozenlist>=1.1.1
+  - multidict>=4.5,<7.0
+  - propcache>=0.2.0
+  - yarl>=1.17.0,<2.0
+  - aiodns>=3.3.0 ; extra == 'speedups'
+  - brotli>=1.2 ; platform_python_implementation == 'CPython' and extra == 'speedups'
+  - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
+  - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and extra == 'speedups'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+  name: aioitertools
+  version: 0.13.0
+  sha256: 0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be
+  requires_dist:
+  - typing-extensions>=4.0 ; python_full_version < '3.10'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+  name: aiosignal
+  version: 1.4.0
+  sha256: 053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e
+  requires_dist:
+  - frozenlist>=1.1.0
+  - typing-extensions>=4.2 ; python_full_version < '3.13'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
   name: alabaster
   version: 1.0.0
   sha256: fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+  name: attrs
+  version: 26.1.0
+  sha256: c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
   name: babel
   version: 2.18.0
@@ -278,6 +400,17 @@ packages:
   - pkg:pypi/blake3?source=hash-mapping
   size: 334818
   timestamp: 1763135726465
+- pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+  name: botocore
+  version: 1.42.70
+  sha256: 54ed9d25f05f810efd22b0dfda0bb9178df3ad8952b2e4359e05156c9321bd3c
+  requires_dist:
+  - jmespath>=0.7.1,<2.0.0
+  - python-dateutil>=2.1,<3.0.0
+  - urllib3>=1.25.4,<1.27 ; python_full_version < '3.10'
+  - urllib3>=1.25.4,!=2.2.0,<3 ; python_full_version >= '3.10'
+  - awscrt==0.31.2 ; extra == 'crt'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -313,6 +446,20 @@ packages:
   version: 2026.2.25
   sha256: 027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: cffi
+  version: 2.0.0
+  sha256: afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775
+  requires_dist:
+  - pycparser ; implementation_name != 'PyPy'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
+  name: cffi
+  version: 2.0.0
+  sha256: c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13
+  requires_dist:
+  - pycparser ; implementation_name != 'PyPy'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
   name: cfgv
   version: 3.5.0
@@ -328,6 +475,10 @@ packages:
   version: 3.4.6
   sha256: 7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
+  name: circuitbreaker
+  version: 2.1.3
+  sha256: 87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -339,6 +490,66 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
+- pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+  name: cryptography
+  version: 46.0.6
+  sha256: 22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97
+  requires_dist:
+  - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
+  - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - nox[uv]>=2024.4.15 ; extra == 'nox'
+  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - pytest>=7.4.0 ; extra == 'test'
+  - pytest-benchmark>=4.0 ; extra == 'test'
+  - pytest-cov>=2.10.1 ; extra == 'test'
+  - pytest-xdist>=3.5.0 ; extra == 'test'
+  - pretend>=0.7 ; extra == 'test'
+  - certifi>=2024 ; extra == 'test'
+  - pytest-randomly ; extra == 'test-randomorder'
+  - sphinx>=5.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=3.0.0 ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - pyenchant>=3 ; extra == 'docstest'
+  - readme-renderer>=30.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=7.3.1 ; extra == 'docstest'
+  - build>=1.0.0 ; extra == 'sdist'
+  - ruff>=0.11.11 ; extra == 'pep8test'
+  - mypy>=1.14 ; extra == 'pep8test'
+  - check-sdist ; extra == 'pep8test'
+  - click>=8.0.1 ; extra == 'pep8test'
+  requires_python: '>=3.8,!=3.9.0,!=3.9.1'
+- pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
+  name: cryptography
+  version: 46.0.6
+  sha256: 64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8
+  requires_dist:
+  - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
+  - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - nox[uv]>=2024.4.15 ; extra == 'nox'
+  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - pytest>=7.4.0 ; extra == 'test'
+  - pytest-benchmark>=4.0 ; extra == 'test'
+  - pytest-cov>=2.10.1 ; extra == 'test'
+  - pytest-xdist>=3.5.0 ; extra == 'test'
+  - pretend>=0.7 ; extra == 'test'
+  - certifi>=2024 ; extra == 'test'
+  - pytest-randomly ; extra == 'test-randomorder'
+  - sphinx>=5.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=3.0.0 ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - pyenchant>=3 ; extra == 'docstest'
+  - readme-renderer>=30.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=7.3.1 ; extra == 'docstest'
+  - build>=1.0.0 ; extra == 'sdist'
+  - ruff>=0.11.11 ; extra == 'pep8test'
+  - mypy>=1.14 ; extra == 'pep8test'
+  - check-sdist ; extra == 'pep8test'
+  - click>=8.0.1 ; extra == 'pep8test'
+  requires_python: '>=3.8,!=3.9.0,!=3.9.1'
 - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
   name: distlib
   version: 0.4.0
@@ -364,6 +575,124 @@ packages:
   version: 3.25.2
   sha256: ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
+  name: frozenlist
+  version: 1.8.0
+  sha256: 4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: frozenlist
+  version: 1.8.0
+  sha256: cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
+  name: fsspec
+  version: 2026.2.0
+  sha256: 98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437
+  requires_dist:
+  - adlfs ; extra == 'abfs'
+  - adlfs ; extra == 'adl'
+  - pyarrow>=1 ; extra == 'arrow'
+  - dask ; extra == 'dask'
+  - distributed ; extra == 'dask'
+  - pre-commit ; extra == 'dev'
+  - ruff>=0.5 ; extra == 'dev'
+  - numpydoc ; extra == 'doc'
+  - sphinx ; extra == 'doc'
+  - sphinx-design ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - yarl ; extra == 'doc'
+  - dropbox ; extra == 'dropbox'
+  - dropboxdrivefs ; extra == 'dropbox'
+  - requests ; extra == 'dropbox'
+  - adlfs ; extra == 'full'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'full'
+  - dask ; extra == 'full'
+  - distributed ; extra == 'full'
+  - dropbox ; extra == 'full'
+  - dropboxdrivefs ; extra == 'full'
+  - fusepy ; extra == 'full'
+  - gcsfs>2024.2.0 ; extra == 'full'
+  - libarchive-c ; extra == 'full'
+  - ocifs ; extra == 'full'
+  - panel ; extra == 'full'
+  - paramiko ; extra == 'full'
+  - pyarrow>=1 ; extra == 'full'
+  - pygit2 ; extra == 'full'
+  - requests ; extra == 'full'
+  - s3fs>2024.2.0 ; extra == 'full'
+  - smbprotocol ; extra == 'full'
+  - tqdm ; extra == 'full'
+  - fusepy ; extra == 'fuse'
+  - gcsfs>2024.2.0 ; extra == 'gcs'
+  - pygit2 ; extra == 'git'
+  - requests ; extra == 'github'
+  - gcsfs ; extra == 'gs'
+  - panel ; extra == 'gui'
+  - pyarrow>=1 ; extra == 'hdfs'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'http'
+  - libarchive-c ; extra == 'libarchive'
+  - ocifs ; extra == 'oci'
+  - s3fs>2024.2.0 ; extra == 's3'
+  - paramiko ; extra == 'sftp'
+  - smbprotocol ; extra == 'smb'
+  - paramiko ; extra == 'ssh'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test'
+  - numpy ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-asyncio!=0.22.0 ; extra == 'test'
+  - pytest-benchmark ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-recording ; extra == 'test'
+  - pytest-rerunfailures ; extra == 'test'
+  - requests ; extra == 'test'
+  - aiobotocore>=2.5.4,<3.0.0 ; extra == 'test-downstream'
+  - dask[dataframe,test] ; extra == 'test-downstream'
+  - moto[server]>4,<5 ; extra == 'test-downstream'
+  - pytest-timeout ; extra == 'test-downstream'
+  - xarray ; extra == 'test-downstream'
+  - adlfs ; extra == 'test-full'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test-full'
+  - backports-zstd ; python_full_version < '3.14' and extra == 'test-full'
+  - cloudpickle ; extra == 'test-full'
+  - dask ; extra == 'test-full'
+  - distributed ; extra == 'test-full'
+  - dropbox ; extra == 'test-full'
+  - dropboxdrivefs ; extra == 'test-full'
+  - fastparquet ; extra == 'test-full'
+  - fusepy ; extra == 'test-full'
+  - gcsfs ; extra == 'test-full'
+  - jinja2 ; extra == 'test-full'
+  - kerchunk ; extra == 'test-full'
+  - libarchive-c ; extra == 'test-full'
+  - lz4 ; extra == 'test-full'
+  - notebook ; extra == 'test-full'
+  - numpy ; extra == 'test-full'
+  - ocifs ; extra == 'test-full'
+  - pandas<3.0.0 ; extra == 'test-full'
+  - panel ; extra == 'test-full'
+  - paramiko ; extra == 'test-full'
+  - pyarrow ; extra == 'test-full'
+  - pyarrow>=1 ; extra == 'test-full'
+  - pyftpdlib ; extra == 'test-full'
+  - pygit2 ; extra == 'test-full'
+  - pytest ; extra == 'test-full'
+  - pytest-asyncio!=0.22.0 ; extra == 'test-full'
+  - pytest-benchmark ; extra == 'test-full'
+  - pytest-cov ; extra == 'test-full'
+  - pytest-mock ; extra == 'test-full'
+  - pytest-recording ; extra == 'test-full'
+  - pytest-rerunfailures ; extra == 'test-full'
+  - python-snappy ; extra == 'test-full'
+  - requests ; extra == 'test-full'
+  - smbprotocol ; extra == 'test-full'
+  - tqdm ; extra == 'test-full'
+  - urllib3 ; extra == 'test-full'
+  - zarr ; extra == 'test-full'
+  - zstandard ; python_full_version < '3.14' and extra == 'test-full'
+  - tqdm ; extra == 'tqdm'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl
   name: furo
   version: 2025.12.19
@@ -378,15 +707,18 @@ packages:
 - pypi: ./
   name: ginkgo
   version: 0.1.0
-  sha256: 2b4ced0c45a007f42ca34a295316b1c03035f61877159d2eb5677c89e4981f6c
+  sha256: b851fc667f14d1095cb7a9130f8fb2d19f00b2a87b363ccb0a83889a14552a1c
   requires_dist:
   - blake3>=1.0.0
+  - fsspec>=2024.10.0
   - numpy>=2.0
+  - ocifs>=1.3.2
   - ortools>=9.11
   - pandas>=2.0
   - pyarrow>=23.0.1,<24
   - pyyaml>=6.0
   - rich>=13.9
+  - s3fs>=2024.10.0
   - papermill>=2.6 ; extra == 'notebooks'
   - marimo>=0.11 ; extra == 'notebooks'
   - nbconvert>=7.16 ; extra == 'notebooks'
@@ -459,6 +791,11 @@ packages:
   - markupsafe>=2.0
   - babel>=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+  name: jmespath
+  version: 1.1.0
+  sha256: a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -718,6 +1055,20 @@ packages:
   version: 0.1.2
   sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
+  name: multidict
+  version: 6.7.1
+  sha256: 0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1
+  requires_dist:
+  - typing-extensions>=4.1.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: multidict
+  version: 6.7.1
+  sha256: 7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709
+  requires_dist:
+  - typing-extensions>=4.1.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl
   name: myst-parser
   version: 5.0.0
@@ -789,6 +1140,34 @@ packages:
   version: 2.4.3
   sha256: 679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/d7/30/7016a8bf2e02cb960974a4101dabb9da590540e584d446421375d72b5cf9/oci-2.168.3-py3-none-any.whl
+  name: oci
+  version: 2.168.3
+  sha256: 370294488351dbb7cddc208bbbf64535e2b1f065e61f7f893de0ba1ac61c2d9a
+  requires_dist:
+  - certifi
+  - cryptography>=3.2.1,<47.0.0
+  - pyopenssl>=17.5.0,<=25.3.0
+  - python-dateutil>=2.5.3,<3.0.0
+  - pytz>=2016.10
+  - configparser==4.0.2 ; python_full_version < '3'
+  - urllib3==1.26.2 ; python_full_version < '3.10'
+  - circuitbreaker>=1.3.1,<2.0.0 ; python_full_version < '3.7'
+  - urllib3>=2.6.3 ; python_full_version >= '3.10'
+  - circuitbreaker>=1.3.1,<3.0.0 ; python_full_version >= '3.7'
+  - docstring-parser>=0.16 ; python_full_version >= '3.10' and python_full_version < '4' and extra == 'adk'
+  - pydantic>=2.10.6 ; python_full_version >= '3.10' and python_full_version < '4' and extra == 'adk'
+  - rich>=13.9.4 ; python_full_version >= '3.10' and python_full_version < '4' and extra == 'adk'
+  - mcp>=1.6.0 ; python_full_version >= '3.10' and python_full_version < '4' and extra == 'adk'
+- pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
+  name: ocifs
+  version: 1.3.4
+  sha256: b81bbe65405c1f1af3603af867e51c2f7534c4b72d799179a9215afa047c6e10
+  requires_dist:
+  - fsspec>=0.8.7
+  - oci>=2.43.1
+  - requests
+  requires_python: '>=3.6'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
   sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
   md5: f61eb8cd60ff9057122a3d338b99c00f
@@ -1056,6 +1435,16 @@ packages:
   - pyyaml>=5.1
   - virtualenv>=20.10.0
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: propcache
+  version: 0.4.1
+  sha256: 8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
+  name: propcache
+  version: 0.4.1
+  sha256: 9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
   name: protobuf
   version: 6.33.6
@@ -1076,6 +1465,11 @@ packages:
   version: 23.0.1
   sha256: 5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+  name: pycparser
+  version: '3.0'
+  sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -1087,6 +1481,19 @@ packages:
   - pkg:pypi/pygments?source=hash-mapping
   size: 889287
   timestamp: 1750615908735
+- pypi: https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl
+  name: pyopenssl
+  version: 25.3.0
+  sha256: 1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6
+  requires_dist:
+  - cryptography>=45.0.7,<47
+  - typing-extensions>=4.9 ; python_full_version >= '3.8' and python_full_version < '3.13'
+  - pytest-rerunfailures ; extra == 'test'
+  - pretend ; extra == 'test'
+  - pytest>=3.0.1 ; extra == 'test'
+  - sphinx!=5.2.0,!=5.2.0.post0,!=7.2.5 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
   sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
   md5: 2b694bad8a50dc2f712f5368de866480
@@ -1168,10 +1575,10 @@ packages:
   requires_dist:
   - six>=1.5
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- pypi: https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl
   name: python-discovery
-  version: 1.2.0
-  sha256: 1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a
+  version: 1.2.1
+  sha256: b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502
   requires_dist:
   - filelock>=3.15.4
   - platformdirs>=4.3.6,<5
@@ -1196,6 +1603,10 @@ packages:
   purls: []
   size: 6989
   timestamp: 1752805904792
+- pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
+  name: pytz
+  version: 2026.1.post1
+  sha256: f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
   sha256: b318fb070c7a1f89980ef124b80a0b5ccf3928143708a85e0053cde0169c699d
   md5: 2035f68f96be30dc60a5dfd7452c7941
@@ -1249,18 +1660,24 @@ packages:
   purls: []
   size: 313930
   timestamp: 1765813902568
-- pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
   name: requests
-  version: 2.32.5
-  sha256: 2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
+  version: 2.33.0
+  sha256: 3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b
   requires_dist:
   - charset-normalizer>=2,<4
   - idna>=2.5,<4
-  - urllib3>=1.21.1,<3
-  - certifi>=2017.4.17
+  - urllib3>=1.26,<3
+  - certifi>=2023.5.7
   - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
-  - chardet>=3.0.2,<6 ; extra == 'use-chardet-on-py3'
-  requires_python: '>=3.9'
+  - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
+  - pytest-httpbin==2.1.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - pysocks>=1.5.6,!=1.5.7 ; extra == 'test'
+  - pytest>=3 ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
   name: rich
   version: 14.3.3
@@ -1306,6 +1723,15 @@ packages:
   - pkg:pypi/ruff?source=compressed-mapping
   size: 8432798
   timestamp: 1774012820989
+- pypi: https://files.pythonhosted.org/packages/57/e1/64c264db50b68de8a438b60ceeb921b2f22da3ebb7ad6255150225d0beac/s3fs-2026.2.0-py3-none-any.whl
+  name: s3fs
+  version: 2026.2.0
+  sha256: 65198835b86b1d5771112b0085d1da52a6ede36508b1aaa6cae2aedc765dfe10
+  requires_dist:
+  - aiobotocore>=2.19.0,<4.0.0
+  - fsspec==2026.2.0
+  - aiohttp!=4.0.0a0,!=4.0.0a1
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
   name: six
   version: 1.17.0
@@ -1472,15 +1898,15 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 21453
   timestamp: 1768146676791
-- pypi: https://files.pythonhosted.org/packages/0e/93/ffc5a20cc9e14fa9b32b0c54884864bede30d144ce2ae013805bce0c86d0/ty-0.0.25-py3-none-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/71/25/37081461e13d38a190e5646948d7bc42084f7bd1c6b44f12550be3923e7e/ty-0.0.26-py3-none-macosx_11_0_arm64.whl
   name: ty
-  version: 0.0.25
-  sha256: 0a8fb3c1e28f73618941811e2568dca195178a1a6314651d4ee97086a4497253
+  version: 0.0.26
+  sha256: a01b7de5693379646d423b68f119719a1338a20017ba48a93eefaff1ee56f97b
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/56/32/5c15bb8ea20ed54d43c734f253a2a5da95d41474caecf4ef3682df9f68f5/ty-0.0.25-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/cc/f4/f3f61c203bc980dd9bba0ba7ed3c6e81ddfd36b286330f9487c2c7d041aa/ty-0.0.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ty
-  version: 0.0.25
-  sha256: 7ad98da1393161096235a387cc36abecd31861060c68416761eccdb7c1bc326b
+  version: 0.0.26
+  sha256: 8a2c766a94d79b4f82995d41229702caf2d76e5c440ec7e543d05c70e98bf8ab
   requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
@@ -1525,6 +1951,22 @@ packages:
   - python-discovery>=1
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: wrapt
+  version: 2.1.2
+  sha256: de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e
+  requires_dist:
+  - pytest ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl
+  name: wrapt
+  version: 2.1.2
+  sha256: 6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9
+  requires_dist:
+  - pytest ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a
@@ -1546,6 +1988,24 @@ packages:
   purls: []
   size: 83386
   timestamp: 1753484079473
+- pypi: https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl
+  name: yarl
+  version: 1.23.0
+  sha256: 23f371bd662cf44a7630d4d113101eafc0cfa7518a2760d20760b26021454719
+  requires_dist:
+  - idna>=2.0
+  - multidict>=4.0
+  - propcache>=0.2.1
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: yarl
+  version: 1.23.0
+  sha256: 1c57676bdedc94cd3bc37724cf6f8cd2779f02f6aba48de45feca073e714fe52
+  requires_dist:
+  - idna>=2.0
+  - multidict>=4.0
+  - propcache>=0.2.1
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,15 @@ requires-python = ">= 3.11"
 license = "Apache-2.0"
 dependencies = [
     "blake3>=1.0.0",
+    "fsspec>=2024.10.0",
     "numpy>=2.0",
+    "ocifs>=1.3.2",
     "ortools>=9.11",
     "pandas>=2.0",
     "pyarrow>=23.0.1,<24",
     "pyyaml>=6.0",
     "rich>=13.9",
+    "s3fs>=2024.10.0",
 ]
 
 [project.optional-dependencies]
@@ -37,11 +40,14 @@ platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.pypi-dependencies]
 ginkgo = { path = ".", editable = true }
+fsspec = ">=2024.10.0"
 numpy = ">=2.0"
+ocifs = ">=1.3.2"
 ortools = ">=9.11"
 pandas = ">=2.0"
 pyarrow = ">=18.0"
 rich = ">=13.9"
+s3fs = ">=2024.10.0"
 
 [tool.pixi.dependencies]
 python = ">=3.11"

--- a/tests/test_artifact_model.py
+++ b/tests/test_artifact_model.py
@@ -1,0 +1,136 @@
+"""Unit tests for artifact model types."""
+
+from __future__ import annotations
+
+import json
+
+from ginkgo.runtime.artifact_model import (
+    ArtifactRecord,
+    BlobRef,
+    TreeEntry,
+    TreeRef,
+    deserialize_tree_manifest,
+    serialize_tree_manifest,
+)
+
+
+class TestBlobRef:
+    def test_immutable(self) -> None:
+        ref = BlobRef(
+            digest_algorithm="blake3",
+            digest_hex="abc123",
+            size=1024,
+            extension=".csv",
+        )
+        assert ref.digest_hex == "abc123"
+        assert ref.extension == ".csv"
+
+    def test_no_extension(self) -> None:
+        ref = BlobRef(
+            digest_algorithm="blake3",
+            digest_hex="abc123",
+            size=0,
+            extension="",
+        )
+        assert ref.extension == ""
+
+
+class TestTreeEntry:
+    def test_fields(self) -> None:
+        entry = TreeEntry(
+            relative_path="data/sample.csv",
+            blob_digest="def456",
+            size=512,
+            mode=0o644,
+        )
+        assert entry.relative_path == "data/sample.csv"
+        assert entry.mode == 0o644
+
+
+class TestTreeRef:
+    def test_entries_are_tuple(self) -> None:
+        ref = TreeRef(
+            digest_algorithm="blake3",
+            digest_hex="tree_digest",
+            entries=(
+                TreeEntry(
+                    relative_path="a.txt",
+                    blob_digest="aaa",
+                    size=10,
+                    mode=0o644,
+                ),
+            ),
+        )
+        assert isinstance(ref.entries, tuple)
+        assert len(ref.entries) == 1
+
+
+class TestArtifactRecord:
+    def _make_record(self) -> ArtifactRecord:
+        return ArtifactRecord(
+            artifact_id="abc123",
+            kind="blob",
+            digest_algorithm="blake3",
+            digest_hex="abc123",
+            extension=".csv",
+            size=1024,
+            created_at="2026-01-01T00:00:00Z",
+            storage_backend="local",
+        )
+
+    def test_json_round_trip(self) -> None:
+        record = self._make_record()
+        serialized = record.to_json()
+        restored = ArtifactRecord.from_json(serialized)
+        assert restored == record
+
+    def test_json_is_valid(self) -> None:
+        record = self._make_record()
+        parsed = json.loads(record.to_json())
+        assert parsed["kind"] == "blob"
+        assert parsed["artifact_id"] == "abc123"
+
+    def test_from_path(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        record = self._make_record()
+        path = Path(str(tmp_path)) / "ref.json"
+        path.write_text(record.to_json(), encoding="utf-8")
+        restored = ArtifactRecord.from_path(path)
+        assert restored == record
+
+
+class TestTreeManifestSerialization:
+    def test_round_trip(self) -> None:
+        ref = TreeRef(
+            digest_algorithm="blake3",
+            digest_hex="tree_abc",
+            entries=(
+                TreeEntry(
+                    relative_path="a.txt",
+                    blob_digest="aaa",
+                    size=10,
+                    mode=0o644,
+                ),
+                TreeEntry(
+                    relative_path="sub/b.txt",
+                    blob_digest="bbb",
+                    size=20,
+                    mode=0o644,
+                ),
+            ),
+        )
+        serialized = serialize_tree_manifest(ref)
+        restored = deserialize_tree_manifest(serialized)
+        assert restored == ref
+
+    def test_empty_tree(self) -> None:
+        ref = TreeRef(
+            digest_algorithm="blake3",
+            digest_hex="empty",
+            entries=(),
+        )
+        serialized = serialize_tree_manifest(ref)
+        restored = deserialize_tree_manifest(serialized)
+        assert restored == ref
+        assert len(restored.entries) == 0

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -20,12 +20,13 @@ class TestStoreFile:
         src = tmp_path / "hello.txt"
         src.write_text("hello world")
 
-        artifact_id = store.store(src_path=src)
-        assert artifact_id.endswith(".txt")
-        assert store.exists(artifact_id=artifact_id)
+        record = store.store(src_path=src)
+        assert record.kind == "blob"
+        assert record.extension == ".txt"
+        assert store.exists(artifact_id=record.artifact_id)
 
         dest = tmp_path / "restored.txt"
-        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+        store.retrieve(artifact_id=record.artifact_id, dest_path=dest)
         assert dest.is_symlink()
         assert dest.read_text() == "hello world"
 
@@ -33,16 +34,16 @@ class TestStoreFile:
         src = tmp_path / "data.csv"
         src.write_text("a,b,c")
 
-        id1 = store.store(src_path=src)
-        id2 = store.store(src_path=src)
-        assert id1 == id2
+        r1 = store.store(src_path=src)
+        r2 = store.store(src_path=src)
+        assert r1.artifact_id == r2.artifact_id
 
     def test_read_only(self, store, tmp_path):
         src = tmp_path / "readonly.txt"
         src.write_text("locked")
 
-        artifact_id = store.store(src_path=src)
-        artifact_path = store.artifact_path(artifact_id=artifact_id)
+        record = store.store(src_path=src)
+        artifact_path = store.artifact_path(artifact_id=record.artifact_id)
         mode = artifact_path.stat().st_mode
         assert not (mode & stat.S_IWUSR)
         assert not (mode & stat.S_IWGRP)
@@ -52,8 +53,18 @@ class TestStoreFile:
         src = tmp_path / "noext"
         src.write_text("content")
 
-        artifact_id = store.store(src_path=src)
-        assert "." not in artifact_id
+        record = store.store(src_path=src)
+        assert record.extension == ""
+        assert "." not in record.artifact_id
+
+    def test_artifact_id_is_digest_only(self, store, tmp_path):
+        src = tmp_path / "file.csv"
+        src.write_text("data")
+
+        record = store.store(src_path=src)
+        # Artifact ID is now a bare digest, no extension.
+        assert "." not in record.artifact_id
+        assert record.artifact_id == record.digest_hex
 
 
 class TestStoreDirectory:
@@ -64,33 +75,44 @@ class TestStoreDirectory:
         (src_dir / "sub").mkdir()
         (src_dir / "sub" / "b.txt").write_text("bbb")
 
-        artifact_id = store.store(src_path=src_dir)
-        assert store.exists(artifact_id=artifact_id)
+        record = store.store(src_path=src_dir)
+        assert record.kind == "tree"
+        assert store.exists(artifact_id=record.artifact_id)
 
         dest = tmp_path / "restored_dir"
-        store.retrieve(artifact_id=artifact_id, dest_path=dest)
-        assert dest.is_symlink()
+        store.retrieve(artifact_id=record.artifact_id, dest_path=dest)
+        assert dest.is_dir()
         assert (dest / "a.txt").read_text() == "aaa"
         assert (dest / "sub" / "b.txt").read_text() == "bbb"
+        # Individual files are symlinks to blobs.
+        assert (dest / "a.txt").is_symlink()
+        assert (dest / "sub" / "b.txt").is_symlink()
 
     def test_idempotent(self, store, tmp_path):
         src_dir = tmp_path / "mydir"
         src_dir.mkdir()
         (src_dir / "x.txt").write_text("xxx")
 
-        id1 = store.store(src_path=src_dir)
-        id2 = store.store(src_path=src_dir)
-        assert id1 == id2
+        r1 = store.store(src_path=src_dir)
+        r2 = store.store(src_path=src_dir)
+        assert r1.artifact_id == r2.artifact_id
 
-    def test_contents_read_only(self, store, tmp_path):
-        src_dir = tmp_path / "mydir"
-        src_dir.mkdir()
-        (src_dir / "f.txt").write_text("data")
+    def test_blob_dedup_across_directories(self, store, tmp_path):
+        """Two directories sharing identical files reuse the same blobs."""
+        dir_a = tmp_path / "dir_a"
+        dir_a.mkdir()
+        (dir_a / "shared.txt").write_text("same content")
 
-        artifact_id = store.store(src_path=src_dir)
-        stored_file = store.artifact_path(artifact_id=artifact_id) / "f.txt"
-        mode = stored_file.stat().st_mode
-        assert not (mode & stat.S_IWUSR)
+        dir_b = tmp_path / "dir_b"
+        dir_b.mkdir()
+        (dir_b / "shared.txt").write_text("same content")
+
+        store.store(src_path=dir_a)
+        store.store(src_path=dir_b)
+
+        # Only one blob for the shared content.
+        blobs = list((store._blobs_dir).iterdir())
+        assert len(blobs) == 1
 
 
 class TestDirectoryHashing:
@@ -139,41 +161,41 @@ class TestDirectoryHashing:
 class TestStoreBytes:
     def test_round_trip(self, store):
         data = b"binary payload"
-        artifact_id = store.store_bytes(data=data, extension="bin")
-        assert store.exists(artifact_id=artifact_id)
-        assert store.read_bytes(artifact_id=artifact_id) == data
+        record = store.store_bytes(data=data, extension="bin")
+        assert store.exists(artifact_id=record.artifact_id)
+        assert store.read_bytes(artifact_id=record.artifact_id) == data
 
     def test_idempotent(self, store):
         data = b"same content"
-        id1 = store.store_bytes(data=data, extension="pkl")
-        id2 = store.store_bytes(data=data, extension="pkl")
-        assert id1 == id2
+        r1 = store.store_bytes(data=data, extension="pkl")
+        r2 = store.store_bytes(data=data, extension="pkl")
+        assert r1.artifact_id == r2.artifact_id
 
 
 class TestRetrieve:
-    def test_creates_symlink(self, store, tmp_path):
+    def test_creates_symlink_for_blob(self, store, tmp_path):
         src = tmp_path / "file.dat"
         src.write_bytes(b"\x00\x01\x02")
 
-        artifact_id = store.store(src_path=src)
+        record = store.store(src_path=src)
         dest = tmp_path / "link.dat"
-        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+        store.retrieve(artifact_id=record.artifact_id, dest_path=dest)
 
         assert dest.is_symlink()
         target = dest.resolve()
-        assert target == store.artifact_path(artifact_id=artifact_id).resolve()
+        assert target == store.artifact_path(artifact_id=record.artifact_id).resolve()
 
     def test_missing_artifact_raises(self, store, tmp_path):
         with pytest.raises(FileNotFoundError):
-            store.retrieve(artifact_id="nonexistent.txt", dest_path=tmp_path / "out")
+            store.retrieve(artifact_id="nonexistent", dest_path=tmp_path / "out")
 
     def test_creates_parent_dirs(self, store, tmp_path):
         src = tmp_path / "file.txt"
         src.write_text("content")
-        artifact_id = store.store(src_path=src)
+        record = store.store(src_path=src)
 
         dest = tmp_path / "deep" / "nested" / "link.txt"
-        store.retrieve(artifact_id=artifact_id, dest_path=dest)
+        store.retrieve(artifact_id=record.artifact_id, dest_path=dest)
         assert dest.is_symlink()
 
 
@@ -182,33 +204,70 @@ class TestDelete:
         src = tmp_path / "to_delete.txt"
         src.write_text("bye")
 
-        artifact_id = store.store(src_path=src)
-        assert store.exists(artifact_id=artifact_id)
+        record = store.store(src_path=src)
+        assert store.exists(artifact_id=record.artifact_id)
 
-        store.delete(artifact_id=artifact_id)
-        assert not store.exists(artifact_id=artifact_id)
+        store.delete(artifact_id=record.artifact_id)
+        assert not store.exists(artifact_id=record.artifact_id)
 
     def test_delete_directory(self, store, tmp_path):
         src_dir = tmp_path / "dir_del"
         src_dir.mkdir()
         (src_dir / "f.txt").write_text("data")
 
-        artifact_id = store.store(src_path=src_dir)
-        assert store.exists(artifact_id=artifact_id)
+        record = store.store(src_path=src_dir)
+        assert store.exists(artifact_id=record.artifact_id)
 
-        store.delete(artifact_id=artifact_id)
-        assert not store.exists(artifact_id=artifact_id)
+        store.delete(artifact_id=record.artifact_id)
+        assert not store.exists(artifact_id=record.artifact_id)
 
     def test_delete_nonexistent_is_noop(self, store):
-        store.delete(artifact_id="does_not_exist.txt")
+        store.delete(artifact_id="does_not_exist")
 
 
 class TestExists:
     def test_true_for_stored(self, store, tmp_path):
         src = tmp_path / "f.txt"
         src.write_text("content")
-        artifact_id = store.store(src_path=src)
-        assert store.exists(artifact_id=artifact_id) is True
+        record = store.store(src_path=src)
+        assert store.exists(artifact_id=record.artifact_id) is True
 
     def test_false_for_missing(self, store):
-        assert store.exists(artifact_id="missing.txt") is False
+        assert store.exists(artifact_id="missing") is False
+
+
+class TestStorageLayout:
+    """Verify the blobs/trees/refs directory structure."""
+
+    def test_blob_stored_under_blobs_dir(self, store, tmp_path):
+        src = tmp_path / "file.csv"
+        src.write_text("data")
+
+        record = store.store(src_path=src)
+        blob_path = store._blobs_dir / record.digest_hex
+        assert blob_path.exists()
+        assert blob_path.read_text() == "data"
+
+    def test_tree_manifest_stored_under_trees_dir(self, store, tmp_path):
+        src_dir = tmp_path / "mydir"
+        src_dir.mkdir()
+        (src_dir / "a.txt").write_text("aaa")
+
+        record = store.store(src_path=src_dir)
+        tree_path = store._trees_dir / f"{record.digest_hex}.json"
+        assert tree_path.exists()
+
+    def test_ref_stored_under_refs_dir(self, store, tmp_path):
+        src = tmp_path / "file.txt"
+        src.write_text("content")
+
+        record = store.store(src_path=src)
+        ref_path = store._refs_dir / f"{record.artifact_id}.json"
+        assert ref_path.exists()
+
+    def test_subdirs_created_on_init(self, tmp_path):
+        root = tmp_path / "new_store"
+        LocalArtifactStore(root=root)
+        assert (root / "blobs").is_dir()
+        assert (root / "trees").is_dir()
+        assert (root / "refs").is_dir()

--- a/tests/test_cache_integrity.py
+++ b/tests/test_cache_integrity.py
@@ -167,33 +167,41 @@ class TestFileOutputSymlinks:
 
 
 class TestFolderOutputSymlinks:
-    def test_output_is_symlinked_after_execution(self, tmp_path):
+    def test_output_is_directory_with_symlinked_files_after_execution(self, tmp_path):
         output = tmp_path / "outdir"
         result = evaluate(write_folder_task(output_dir=str(output)))
-        assert Path(str(result)).is_symlink()
-        assert (Path(str(result)) / "a.txt").read_text().strip() == "a"
-        assert (Path(str(result)) / "b.txt").read_text().strip() == "b"
+        result_path = Path(str(result))
+        # Tree artifacts are reconstructed directories, not symlinks.
+        assert result_path.is_dir()
+        assert (result_path / "a.txt").read_text().strip() == "a"
+        assert (result_path / "b.txt").read_text().strip() == "b"
+        # Individual files are symlinks to blobs.
+        assert (result_path / "a.txt").is_symlink()
+        assert (result_path / "b.txt").is_symlink()
 
     def test_folder_contents_are_read_only(self, tmp_path):
         output = tmp_path / "ro_dir"
         result = evaluate(write_folder_task(output_dir=str(output)))
-        target = Path(str(result)).resolve()
-        file_mode = (target / "a.txt").stat().st_mode
+        result_path = Path(str(result))
+        # Files are symlinks to read-only blobs.
+        file_mode = (result_path / "a.txt").resolve().stat().st_mode
         assert not (file_mode & stat.S_IWUSR)
 
-    def test_deleted_symlink_is_recreated(self, tmp_path, capsys):
+    def test_deleted_folder_is_recreated(self, tmp_path, capsys):
         output = tmp_path / "dir_recreate"
         evaluate(write_folder_task(output_dir=str(output)))
         capsys.readouterr()
 
-        # Remove the symlink.
-        output.unlink()
+        # Remove the reconstructed directory.
+        import shutil
+
+        shutil.rmtree(output)
         assert not output.exists()
 
         result = evaluate(write_folder_task(output_dir=str(output)))
         captured = capsys.readouterr()
         assert '"status": "cached"' in captured.err
-        assert Path(str(result)).is_symlink()
+        assert Path(str(result)).is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import shutil
 import subprocess
@@ -207,12 +208,15 @@ class TestExamples:
         assert third_manifest["status"] == "succeeded"
         assert all(task["status"] == "cached" for task in third_manifest["tasks"].values())
 
-    @pytest.mark.skip(reason="bioinfo example uses remote OCI URIs pending phase 6")
     def test_bioinfo_example_runs_and_caches(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
+        profile = os.environ.get("GINKGO_REMOTE_OCI_PROFILE")
+        if not profile:
+            pytest.skip("Set GINKGO_REMOTE_OCI_PROFILE to run the OCI bioinfo example")
+
         example_dir = _copy_example(name="bioinfo", destination_root=tmp_path)
         monkeypatch.chdir(example_dir)
 
@@ -230,7 +234,8 @@ class TestExamples:
         assert len(filtered_fastqs) == 4
         assert len(qc_tables) == 2
         assert len(count_files) == 2
-        assert sorted(summary["sample_id"].tolist()) == ["ERR3058522", "ERR3058532"]
+        assert sorted(summary["sample_id"].unique().tolist()) == ["ERR3058522", "ERR3058532"]
+        assert len(summary) == 4
         assert "read_count_r1" in summary.columns
 
         with _mock_docker():

--- a/tests/test_jsonl_renderer.py
+++ b/tests/test_jsonl_renderer.py
@@ -1,0 +1,30 @@
+"""Focused tests for JSONL runtime event rendering."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from ginkgo.cli.renderers.jsonl import JsonlEventRenderer
+from ginkgo.runtime.events import TaskStaging
+
+
+def test_jsonl_renderer_emits_task_staging_event() -> None:
+    stream = io.StringIO()
+    renderer = JsonlEventRenderer(stream=stream)
+
+    renderer(
+        TaskStaging(
+            run_id="run_123",
+            task_id="task_0001",
+            task_name="example.task",
+            attempt=1,
+            status="staging",
+            remote_input_count=2,
+        )
+    )
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["event"] == "task_staging"
+    assert payload["status"] == "staging"
+    assert payload["remote_input_count"] == 2

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,176 @@
+"""Unit tests for the remote artifact publisher."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from ginkgo.remote.backend import RemoteObjectMeta
+from ginkgo.remote.publisher import RemotePublisher
+from ginkgo.runtime.artifact_model import (
+    ArtifactRecord,
+    TreeEntry,
+    TreeRef,
+    serialize_tree_manifest,
+)
+
+
+def _make_record(
+    *,
+    kind: str = "blob",
+    digest_hex: str = "abc123",
+    artifact_id: str = "abc123",
+    remote_uri: str | None = None,
+) -> ArtifactRecord:
+    return ArtifactRecord(
+        artifact_id=artifact_id,
+        kind=kind,
+        digest_algorithm="blake3",
+        digest_hex=digest_hex,
+        extension=".csv",
+        size=100,
+        created_at="2026-01-01T00:00:00Z",
+        storage_backend="local",
+        remote_uri=remote_uri,
+    )
+
+
+def _make_publisher(tmp_path: Path) -> tuple[RemotePublisher, MagicMock]:
+    blobs_dir = tmp_path / "blobs"
+    trees_dir = tmp_path / "trees"
+    refs_dir = tmp_path / "refs"
+    for d in (blobs_dir, trees_dir, refs_dir):
+        d.mkdir()
+
+    backend = MagicMock()
+    backend.upload.return_value = RemoteObjectMeta(uri="s3://bkt/key", size=100)
+
+    publisher = RemotePublisher(
+        backend=backend,
+        bucket="test-bucket",
+        prefix="artifacts/",
+        local_blobs_dir=blobs_dir,
+        local_trees_dir=trees_dir,
+        local_refs_dir=refs_dir,
+    )
+    return publisher, backend
+
+
+class TestPublishBlob:
+    def test_uploads_blob_and_sets_remote_uri(self, tmp_path) -> None:
+        publisher, backend = _make_publisher(tmp_path)
+        blob_path = tmp_path / "blobs" / "abc123"
+        blob_path.write_bytes(b"data")
+
+        record = _make_record()
+        result = publisher.publish(record=record)
+
+        assert result.remote_uri == "s3://test-bucket/artifacts/blobs/abc123"
+        backend.upload.assert_called_once_with(
+            src_path=blob_path, bucket="test-bucket", key="artifacts/blobs/abc123"
+        )
+
+    def test_updates_ref_file(self, tmp_path) -> None:
+        publisher, _ = _make_publisher(tmp_path)
+        blob_path = tmp_path / "blobs" / "abc123"
+        blob_path.write_bytes(b"data")
+
+        # Create a ref file.
+        ref_path = tmp_path / "refs" / "abc123.json"
+        record = _make_record()
+        ref_path.write_text(record.to_json(), encoding="utf-8")
+
+        result = publisher.publish(record=record)
+
+        # Ref file should now contain remote_uri.
+        updated_ref = json.loads(ref_path.read_text(encoding="utf-8"))
+        assert updated_ref["remote_uri"] == result.remote_uri
+
+    def test_skips_already_published(self, tmp_path) -> None:
+        publisher, backend = _make_publisher(tmp_path)
+        record = _make_record(remote_uri="s3://already/published")
+
+        result = publisher.publish(record=record)
+
+        assert result is record
+        backend.upload.assert_not_called()
+
+
+class TestPublishTree:
+    def test_uploads_blobs_and_manifest(self, tmp_path) -> None:
+        publisher, backend = _make_publisher(tmp_path)
+
+        # Create tree manifest and constituent blobs.
+        tree_ref = TreeRef(
+            digest_algorithm="blake3",
+            digest_hex="tree_digest",
+            entries=(
+                TreeEntry(relative_path="a.txt", blob_digest="blob_a", size=5, mode=0o644),
+                TreeEntry(relative_path="b.txt", blob_digest="blob_b", size=3, mode=0o644),
+            ),
+        )
+        manifest_path = tmp_path / "trees" / "tree_digest.json"
+        manifest_path.write_text(serialize_tree_manifest(tree_ref), encoding="utf-8")
+        (tmp_path / "blobs" / "blob_a").write_bytes(b"aaaaa")
+        (tmp_path / "blobs" / "blob_b").write_bytes(b"bbb")
+
+        record = _make_record(kind="tree", digest_hex="tree_digest", artifact_id="tree_digest")
+        result = publisher.publish(record=record)
+
+        assert result.remote_uri == "s3://test-bucket/artifacts/trees/tree_digest.json"
+        # Two blob uploads + one manifest upload.
+        assert backend.upload.call_count == 3
+
+    def test_updates_ref_file_for_tree(self, tmp_path) -> None:
+        publisher, _ = _make_publisher(tmp_path)
+
+        tree_ref = TreeRef(
+            digest_algorithm="blake3",
+            digest_hex="tree_digest",
+            entries=(),
+        )
+        manifest_path = tmp_path / "trees" / "tree_digest.json"
+        manifest_path.write_text(serialize_tree_manifest(tree_ref), encoding="utf-8")
+
+        ref_path = tmp_path / "refs" / "tree_id.json"
+        record = _make_record(kind="tree", digest_hex="tree_digest", artifact_id="tree_id")
+        ref_path.write_text(record.to_json(), encoding="utf-8")
+
+        result = publisher.publish(record=record)
+
+        updated_ref = json.loads(ref_path.read_text(encoding="utf-8"))
+        assert updated_ref["remote_uri"] == result.remote_uri
+
+    def test_skips_missing_blobs(self, tmp_path) -> None:
+        """Missing local blobs are silently skipped during tree publish."""
+        publisher, backend = _make_publisher(tmp_path)
+
+        tree_ref = TreeRef(
+            digest_algorithm="blake3",
+            digest_hex="tree_digest",
+            entries=(
+                TreeEntry(relative_path="exists.txt", blob_digest="blob_yes", size=3, mode=0o644),
+                TreeEntry(relative_path="gone.txt", blob_digest="blob_no", size=3, mode=0o644),
+            ),
+        )
+        manifest_path = tmp_path / "trees" / "tree_digest.json"
+        manifest_path.write_text(serialize_tree_manifest(tree_ref), encoding="utf-8")
+        (tmp_path / "blobs" / "blob_yes").write_bytes(b"yes")
+        # blob_no intentionally missing.
+
+        record = _make_record(kind="tree", digest_hex="tree_digest", artifact_id="tree_digest")
+        publisher.publish(record=record)
+
+        # One blob upload + one manifest upload (missing blob skipped).
+        assert backend.upload.call_count == 2
+
+    def test_missing_manifest_still_sets_uri(self, tmp_path) -> None:
+        """If the tree manifest file is missing, remote_uri is still set."""
+        publisher, backend = _make_publisher(tmp_path)
+
+        record = _make_record(kind="tree", digest_hex="no_manifest", artifact_id="no_manifest")
+        result = publisher.publish(record=record)
+
+        assert result.remote_uri is not None
+        backend.upload.assert_not_called()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,122 @@
+"""Unit tests for remote reference types and URI parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from ginkgo.core.remote import (
+    RemoteFileRef,
+    RemoteFolderRef,
+    is_remote_uri,
+    remote_file,
+    remote_folder,
+)
+
+
+class TestRemoteFile:
+    def test_s3_uri(self) -> None:
+        ref = remote_file("s3://my-bucket/data/sample.txt")
+        assert isinstance(ref, RemoteFileRef)
+        assert ref.scheme == "s3"
+        assert ref.bucket == "my-bucket"
+        assert ref.key == "data/sample.txt"
+        assert ref.uri == "s3://my-bucket/data/sample.txt"
+        assert ref.version_id is None
+
+    def test_s3_uri_with_version(self) -> None:
+        ref = remote_file("s3://bucket/key.csv", version_id="abc123")
+        assert ref.version_id == "abc123"
+
+    def test_oci_uri(self) -> None:
+        ref = remote_file("oci://mynamespace/mybucket/path/to/object.csv")
+        assert isinstance(ref, RemoteFileRef)
+        assert ref.scheme == "oci"
+        assert ref.bucket == "mybucket@mynamespace"
+        assert ref.namespace == "mynamespace"
+        assert ref.key == "path/to/object.csv"
+
+    def test_oci_uri_nested_key(self) -> None:
+        ref = remote_file("oci://ns/bkt/a/b/c.txt")
+        assert ref.bucket == "bkt@ns"
+        assert ref.namespace == "ns"
+        assert ref.key == "a/b/c.txt"
+
+    def test_oci_bucket_at_namespace_uri(self) -> None:
+        ref = remote_file("oci://mybucket@mynamespace/path/to/object.csv")
+        assert ref.bucket == "mybucket@mynamespace"
+        assert ref.namespace == "mynamespace"
+        assert ref.key == "path/to/object.csv"
+
+    def test_unsupported_scheme_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported remote URI scheme"):
+            remote_file("ftp://host/file.txt")
+
+    def test_s3_missing_bucket_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing bucket"):
+            remote_file("s3:///key")
+
+    def test_s3_missing_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing key"):
+            remote_file("s3://bucket")
+
+    def test_oci_missing_namespace_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing namespace"):
+            remote_file("oci:///bucket/key")
+
+    def test_oci_missing_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="oci://namespace/bucket/key"):
+            remote_file("oci://namespace/bucket")
+
+    def test_immutable(self) -> None:
+        ref = remote_file("s3://b/k.txt")
+        with pytest.raises(AttributeError):
+            ref.uri = "s3://other/key"  # type: ignore[misc]
+
+
+class TestRemoteFolder:
+    def test_s3_prefix(self) -> None:
+        ref = remote_folder("s3://bucket/prefix/subdir/")
+        assert isinstance(ref, RemoteFolderRef)
+        assert ref.scheme == "s3"
+        assert ref.bucket == "bucket"
+        assert ref.key == "prefix/subdir/"
+
+    def test_oci_prefix(self) -> None:
+        ref = remote_folder("oci://ns/bkt/prefix/")
+        assert isinstance(ref, RemoteFolderRef)
+        assert ref.bucket == "bkt@ns"
+        assert ref.key == "prefix/"
+
+
+class TestIsRemoteUri:
+    def test_s3(self) -> None:
+        assert is_remote_uri("s3://bucket/key") is True
+
+    def test_oci(self) -> None:
+        assert is_remote_uri("oci://ns/bkt/key") is True
+
+    def test_local_path(self) -> None:
+        assert is_remote_uri("/tmp/file.txt") is False
+
+    def test_unsupported_scheme(self) -> None:
+        assert is_remote_uri("ftp://host/file") is False
+
+    def test_empty_string(self) -> None:
+        assert is_remote_uri("") is False
+
+    def test_not_a_string(self) -> None:
+        assert is_remote_uri(42) is False  # type: ignore[arg-type]
+
+
+class TestExportedFromGinkgo:
+    def test_remote_file_importable(self) -> None:
+        from ginkgo import remote_file as rf
+
+        ref = rf("s3://b/k.txt")
+        assert ref.scheme == "s3"
+
+    def test_remote_folder_importable(self) -> None:
+        from ginkgo import remote_folder as rf
+
+        ref = rf("s3://b/prefix/")
+        assert ref.scheme == "s3"

--- a/tests/test_remote_backend.py
+++ b/tests/test_remote_backend.py
@@ -1,0 +1,178 @@
+"""Unit tests for filesystem-backed remote storage backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.remote.backend import RemoteObjectMeta
+from ginkgo.remote.fsspec_backends import OCIFileSystemBackend, S3FileSystemBackend
+from ginkgo.remote.resolve import resolve_backend
+
+
+@pytest.fixture()
+def mock_filesystem() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def s3_backend(mock_filesystem: MagicMock) -> S3FileSystemBackend:
+    backend = S3FileSystemBackend(region="eu-west-1")
+    backend._filesystem = mock_filesystem
+    return backend
+
+
+@pytest.fixture()
+def oci_backend(mock_filesystem: MagicMock) -> OCIFileSystemBackend:
+    backend = OCIFileSystemBackend(config_path="~/.oci/config", profile="uk")
+    backend._filesystem = mock_filesystem
+    return backend
+
+
+class TestHead:
+    def test_s3_returns_metadata(
+        self, s3_backend: S3FileSystemBackend, mock_filesystem: MagicMock
+    ) -> None:
+        mock_filesystem.info.return_value = {
+            "size": 1024,
+            "ETag": '"abc123"',
+            "VersionId": "v1",
+        }
+
+        meta = s3_backend.head(bucket="my-bucket", key="data/file.csv")
+
+        assert isinstance(meta, RemoteObjectMeta)
+        assert meta.uri == "s3://my-bucket/data/file.csv"
+        assert meta.size == 1024
+        assert meta.etag == "abc123"
+        assert meta.version_id == "v1"
+        mock_filesystem.info.assert_called_once_with("my-bucket/data/file.csv")
+
+    def test_oci_returns_metadata(
+        self, oci_backend: OCIFileSystemBackend, mock_filesystem: MagicMock
+    ) -> None:
+        mock_filesystem.info.return_value = {
+            "size": 33,
+            "etag": "etag-1",
+        }
+
+        meta = oci_backend.head(bucket="bucket@namespace", key="path/data.fastq.gz")
+
+        assert meta.uri == "oci://bucket@namespace/path/data.fastq.gz"
+        assert meta.size == 33
+        assert meta.etag == "etag-1"
+
+
+class TestDownload:
+    def test_s3_downloads_to_path(
+        self,
+        s3_backend: S3FileSystemBackend,
+        mock_filesystem: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        source = MagicMock()
+        source.read.side_effect = [b"hello ", b"world", b""]
+        mock_filesystem.open.return_value.__enter__.return_value = source
+        mock_filesystem.info.return_value = {"size": 11, "ETag": '"etag123"'}
+
+        dest = tmp_path / "downloaded.txt"
+        meta = s3_backend.download(bucket="bkt", key="key.txt", dest_path=dest)
+
+        assert dest.read_bytes() == b"hello world"
+        assert meta.size == 11
+        assert meta.etag == "etag123"
+
+
+class TestUpload:
+    def test_oci_uploads_file(
+        self,
+        oci_backend: OCIFileSystemBackend,
+        mock_filesystem: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        src = tmp_path / "upload_me.txt"
+        src.write_text("payload", encoding="utf-8")
+
+        destination = MagicMock()
+        mock_filesystem.open.return_value.__enter__.return_value = destination
+        mock_filesystem.info.return_value = {"size": 7, "etag": "uploaded-etag"}
+
+        meta = oci_backend.upload(
+            src_path=src,
+            bucket="bucket@namespace",
+            key="dest/file.txt",
+        )
+
+        assert meta.etag == "uploaded-etag"
+        mock_filesystem.open.assert_called_once_with("bucket@namespace/dest/file.txt", "wb")
+
+
+class TestListPrefix:
+    def test_lists_s3_objects(
+        self,
+        s3_backend: S3FileSystemBackend,
+        mock_filesystem: MagicMock,
+    ) -> None:
+        mock_filesystem.find.return_value = {
+            "bkt/prefix/a.txt": {"size": 10, "ETag": '"e1"'},
+            "bkt/prefix/b.txt": {"size": 20, "ETag": '"e2"'},
+        }
+
+        results = s3_backend.list_prefix(bucket="bkt", prefix="prefix/")
+
+        assert len(results) == 2
+        assert results[0].uri == "s3://bkt/prefix/a.txt"
+        assert results[1].size == 20
+
+    def test_lists_oci_objects(
+        self,
+        oci_backend: OCIFileSystemBackend,
+        mock_filesystem: MagicMock,
+    ) -> None:
+        mock_filesystem.find.return_value = {
+            "bucket@ns/prefix/a.txt": {"size": 10, "etag": "e1"},
+            "bucket@ns/prefix/sub/b.txt": {"size": 20, "etag": "e2"},
+        }
+
+        results = oci_backend.list_prefix(bucket="bucket@ns", prefix="prefix/")
+
+        assert len(results) == 2
+        assert results[0].uri == "oci://bucket@ns/prefix/a.txt"
+        assert results[1].uri == "oci://bucket@ns/prefix/sub/b.txt"
+
+
+class TestResolveBackend:
+    def test_s3_scheme(self) -> None:
+        backend = resolve_backend("s3")
+        assert isinstance(backend, S3FileSystemBackend)
+
+    def test_oci_scheme_uses_env_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GINKGO_REMOTE_OCI_PROFILE", "uk")
+
+        backend = resolve_backend("oci")
+        assert isinstance(backend, OCIFileSystemBackend)
+        assert backend._profile == "uk"
+
+    def test_unsupported_scheme_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported"):
+            resolve_backend("ftp")
+
+
+class TestLazyImports:
+    def test_missing_s3fs_raises_clear_error(self) -> None:
+        backend = S3FileSystemBackend()
+        backend._filesystem = None
+
+        with patch.dict("sys.modules", {"s3fs": None}):
+            with pytest.raises(ImportError, match="s3fs is required"):
+                backend._get_filesystem()
+
+    def test_missing_ocifs_raises_clear_error(self) -> None:
+        backend = OCIFileSystemBackend()
+        backend._filesystem = None
+
+        with patch.dict("sys.modules", {"ocifs": None}):
+            with pytest.raises(ImportError, match="ocifs is required"):
+                backend._get_filesystem()

--- a/tests/test_remote_evaluator.py
+++ b/tests/test_remote_evaluator.py
@@ -1,0 +1,154 @@
+"""Integration tests for remote file staging in the evaluator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ginkgo import evaluate, file, task
+from ginkgo.core.remote import remote_file
+from ginkgo.remote.backend import RemoteObjectMeta
+from ginkgo.remote.staging import StagingCache
+
+
+@task()
+def read_file_content(*, path: file) -> str:
+    """Read and return the content of a file."""
+    return Path(str(path)).read_text(encoding="utf-8").strip()
+
+
+@task()
+def count_files_in_list(*, paths: list[file]) -> int:
+    """Count the number of file paths received."""
+    return len(paths)
+
+
+def _make_mock_staging_cache(tmp_path: Path, content: bytes = b"staged content"):
+    """Create a real staging cache with a mocked backend."""
+    cache = StagingCache(root=tmp_path / "staging")
+    backend = MagicMock()
+
+    def _download(*, bucket, key, dest_path):
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(content)
+        return RemoteObjectMeta(
+            uri=f"s3://{bucket}/{key}",
+            size=len(content),
+            etag="test-etag",
+        )
+
+    def _head(*, bucket, key):
+        return RemoteObjectMeta(
+            uri=f"s3://{bucket}/{key}",
+            size=len(content),
+            etag="test-etag",
+        )
+
+    backend.download.side_effect = _download
+    backend.head.side_effect = _head
+    return cache, backend
+
+
+class TestRemoteFileEvaluator:
+    def test_remote_file_ref_is_staged_before_task(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cache, backend = _make_mock_staging_cache(tmp_path, b"hello from s3")
+
+        ref = remote_file("s3://test-bucket/data/greeting.txt")
+
+        with (
+            patch(
+                "ginkgo.runtime.evaluator._ConcurrentEvaluator._get_staging_cache",
+                return_value=cache,
+            ),
+            patch(
+                "ginkgo.remote.staging.resolve_backend",
+                return_value=backend,
+            ),
+        ):
+            result = evaluate(read_file_content(path=ref))
+            captured = capsys.readouterr()
+
+        assert result == "hello from s3"
+        assert '"status": "staging"' in captured.err
+
+    def test_raw_s3_uri_string_coerced_for_file_param(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cache, backend = _make_mock_staging_cache(tmp_path, b"auto coerced")
+
+        # Pass a raw s3:// string to a file-annotated parameter.
+        with (
+            patch(
+                "ginkgo.runtime.evaluator._ConcurrentEvaluator._get_staging_cache",
+                return_value=cache,
+            ),
+            patch(
+                "ginkgo.remote.staging.resolve_backend",
+                return_value=backend,
+            ),
+        ):
+            result = evaluate(read_file_content(path="s3://bucket/auto.txt"))
+
+        assert result == "auto coerced"
+
+    def test_remote_file_in_list_is_staged(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cache, backend = _make_mock_staging_cache(tmp_path, b"list item")
+
+        refs = [
+            remote_file("s3://bucket/a.txt"),
+            remote_file("s3://bucket/b.txt"),
+        ]
+
+        with (
+            patch(
+                "ginkgo.runtime.evaluator._ConcurrentEvaluator._get_staging_cache",
+                return_value=cache,
+            ),
+            patch(
+                "ginkgo.remote.staging.resolve_backend",
+                return_value=backend,
+            ),
+        ):
+            result = evaluate(count_files_in_list(paths=refs))
+
+        assert result == 2
+
+    def test_local_file_unchanged(self, tmp_path, monkeypatch) -> None:
+        """Local file paths are not affected by remote staging."""
+        monkeypatch.chdir(tmp_path)
+        local = tmp_path / "local.txt"
+        local.write_text("local content")
+
+        result = evaluate(read_file_content(path=file(str(local))))
+        assert result == "local content"
+
+    def test_cache_hit_with_remote_input(self, tmp_path, monkeypatch, capsys) -> None:
+        """Remote input should produce a cache hit on rerun with same content."""
+        monkeypatch.chdir(tmp_path)
+        cache, backend = _make_mock_staging_cache(tmp_path, b"cacheable")
+
+        ref = remote_file("s3://bucket/cacheable.txt")
+
+        with (
+            patch(
+                "ginkgo.runtime.evaluator._ConcurrentEvaluator._get_staging_cache",
+                return_value=cache,
+            ),
+            patch(
+                "ginkgo.remote.staging.resolve_backend",
+                return_value=backend,
+            ),
+        ):
+            result1 = evaluate(read_file_content(path=ref))
+            capsys.readouterr()
+            result2 = evaluate(read_file_content(path=ref))
+            captured = capsys.readouterr()
+
+        assert result1 == result2 == "cacheable"
+        assert '"status": "cached"' in captured.err

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,0 +1,161 @@
+"""Unit tests for the remote staging cache."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ginkgo.core.remote import remote_file, remote_folder
+from ginkgo.remote.backend import RemoteObjectMeta
+from ginkgo.remote.staging import StagingCache, StagingEntry
+
+
+def _make_mock_backend(*, content: bytes = b"hello world", etag: str = "etag1"):
+    """Create a mock backend that writes fixed content on download."""
+    backend = MagicMock()
+
+    def _download(*, bucket, key, dest_path):
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(content)
+        return RemoteObjectMeta(
+            uri=f"s3://{bucket}/{key}",
+            size=len(content),
+            etag=etag,
+        )
+
+    def _head(*, bucket, key):
+        return RemoteObjectMeta(
+            uri=f"s3://{bucket}/{key}",
+            size=len(content),
+            etag=etag,
+        )
+
+    backend.download.side_effect = _download
+    backend.head.side_effect = _head
+    return backend
+
+
+class TestStageFile:
+    def test_downloads_and_returns_path(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        backend = _make_mock_backend()
+        ref = remote_file("s3://bucket/data/file.txt")
+
+        path = cache.stage_file(ref=ref, backend=backend)
+
+        assert path.exists()
+        assert path.read_bytes() == b"hello world"
+        backend.download.assert_called_once()
+
+    def test_cached_file_not_redownloaded(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        backend = _make_mock_backend()
+        ref = remote_file("s3://bucket/data/file.txt")
+
+        path1 = cache.stage_file(ref=ref, backend=backend)
+        path2 = cache.stage_file(ref=ref, backend=backend)
+
+        assert path1 == path2
+        # download called once, head called once for freshness check.
+        assert backend.download.call_count == 1
+
+    def test_changed_etag_triggers_redownload(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        ref = remote_file("s3://bucket/data/file.txt")
+
+        # First download.
+        backend1 = _make_mock_backend(content=b"v1", etag="etag-v1")
+        cache.stage_file(ref=ref, backend=backend1)
+
+        # Second download with changed etag.
+        backend2 = _make_mock_backend(content=b"v2", etag="etag-v2")
+        path = cache.stage_file(ref=ref, backend=backend2)
+
+        assert path.read_bytes() == b"v2"
+        assert backend2.download.call_count == 1
+
+    def test_pinned_version_skips_head_check(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        backend = _make_mock_backend()
+        ref = remote_file("s3://bucket/key.txt", version_id="v42")
+
+        cache.stage_file(ref=ref, backend=backend)
+        cache.stage_file(ref=ref, backend=backend)
+
+        # head should not be called on reuse since version_id is pinned.
+        backend.head.assert_not_called()
+        assert backend.download.call_count == 1
+
+    def test_content_addressed_dedup(self, tmp_path) -> None:
+        """Two different URIs with identical content share one blob."""
+        cache = StagingCache(root=tmp_path / "staging")
+        backend = _make_mock_backend(content=b"shared")
+
+        ref_a = remote_file("s3://bucket/a.txt")
+        ref_b = remote_file("s3://bucket/b.txt")
+
+        path_a = cache.stage_file(ref=ref_a, backend=backend)
+        path_b = cache.stage_file(ref=ref_b, backend=backend)
+
+        assert path_a == path_b  # Same blob.
+        blobs = list((tmp_path / "staging" / "blobs").iterdir())
+        assert len(blobs) == 1
+
+
+class TestStageFolder:
+    def test_stages_prefix_contents(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        backend = MagicMock()
+
+        backend.list_prefix.return_value = [
+            RemoteObjectMeta(uri="s3://bkt/prefix/a.txt", size=3),
+            RemoteObjectMeta(uri="s3://bkt/prefix/sub/b.txt", size=3),
+        ]
+
+        def _download(*, bucket, key, dest_path):
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            dest_path.write_text(key.split("/")[-1])
+            return RemoteObjectMeta(uri=f"s3://{bucket}/{key}", size=3)
+
+        backend.download.side_effect = _download
+
+        ref = remote_folder("s3://bkt/prefix/")
+        folder_path = cache.stage_folder(ref=ref, backend=backend)
+
+        assert folder_path.is_dir()
+        assert (folder_path / "a.txt").read_text() == "a.txt"
+        assert (folder_path / "sub" / "b.txt").read_text() == "b.txt"
+
+
+class TestLookup:
+    def test_returns_entry_after_staging(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        backend = _make_mock_backend()
+        ref = remote_file("s3://bucket/lookup.txt")
+
+        cache.stage_file(ref=ref, backend=backend)
+        entry = cache.lookup(uri=ref.uri)
+
+        assert entry is not None
+        assert isinstance(entry, StagingEntry)
+        assert entry.uri == "s3://bucket/lookup.txt"
+        assert entry.etag == "etag1"
+        assert len(entry.digest) == 64  # BLAKE3 hex digest
+
+    def test_returns_none_for_unstaged(self, tmp_path) -> None:
+        cache = StagingCache(root=tmp_path / "staging")
+        assert cache.lookup(uri="s3://bucket/never-staged.txt") is None
+
+
+class TestStagingEntry:
+    def test_json_round_trip(self) -> None:
+        entry = StagingEntry(
+            uri="s3://b/k",
+            digest="abc123",
+            etag="etag",
+            version_id=None,
+            size=100,
+            staged_at="2026-01-01T00:00:00Z",
+            blob_path="blobs/abc123",
+        )
+        restored = StagingEntry.from_json(entry.to_json())
+        assert restored == entry


### PR DESCRIPTION
## Summary
- add Phase 6 blob/tree artifact modeling, remote refs, staging cache, and remote backend support
- switch remote staging toward filesystem-backed adapters for S3 and OCI, including real OCI-backed bioinfo example coverage
- emit an explicit `staging` task status in Rich and JSONL output, and update the implementation plan with the staged-access Phase 6 direction plus a new 6D concurrent-staging plan

## Testing
- `.pixi/envs/default/bin/pytest tests/test_remote.py tests/test_remote_backend.py tests/test_staging.py tests/test_remote_evaluator.py -q`
- `GINKGO_REMOTE_OCI_PROFILE=uk GINKGO_REMOTE_OCI_CONFIG=$HOME/.oci/config .pixi/envs/default/bin/pytest tests/test_examples.py -q -k bioinfo`
- `.pixi/envs/default/bin/pytest tests/test_remote_evaluator.py tests/test_jsonl_renderer.py -q`
- `.pixi/envs/default/bin/pytest tests/test_cli.py -q -k "run_agent_emits_jsonl_events or run_agent_verbose_emits_task_log_events"`
