### PR TITLE
Show notebooks and assets materialised at end of run

### DIFF
--- a/ginkgo/cli/commands/run.py
+++ b/ginkgo/cli/commands/run.py
@@ -404,13 +404,8 @@ def _load_run_assets(*, manifest: dict[str, Any]) -> list[_AssetSummary]:
             if not isinstance(key, str) or key in seen_keys:
                 continue
             seen_keys.add(key)
-            path = asset.get("artifact_path")
-            assets.append(
-                _AssetSummary(
-                    asset_key=key,
-                    artifact_path=str(path) if path is not None else None,
-                )
-            )
+            name = asset.get("name") or asset.get("asset_key") or key
+            assets.append(_AssetSummary(name=str(name)))
     return assets
 
 

--- a/ginkgo/cli/commands/run.py
+++ b/ginkgo/cli/commands/run.py
@@ -372,14 +372,25 @@ def _load_run_notebooks(
     for task in tasks.values():
         if not isinstance(task, dict):
             continue
+
+        # Executed tasks record rendered_html (relative to run_dir).
+        # Cached tasks skip _record_notebook_manifest, but the return value
+        # stored in "output" is the HTML path from the original run.
         rendered_html = task.get("rendered_html")
-        if not isinstance(rendered_html, str):
+        if isinstance(rendered_html, str):
+            html_path = (run_dir / rendered_html).resolve()
+        elif task.get("kind") == "notebook":
+            output = task.get("output")
+            if not isinstance(output, str) or not output.endswith(".html"):
+                continue
+            html_path = Path(output)
+        else:
             continue
+
         node_id = task.get("node_id")
         task_label = (
             renderer.label_for_node(int(node_id)) if isinstance(node_id, int) else None
         ) or _task_base_name(task.get("task"))
-        html_path = (run_dir / rendered_html).resolve()
         notebooks.append(_NotebookSummary(task_label=task_label, html_path=html_path))
     return notebooks
 

--- a/ginkgo/cli/commands/run.py
+++ b/ginkgo/cli/commands/run.py
@@ -364,7 +364,12 @@ def _load_run_notebooks(
     manifest: dict[str, Any],
     renderer: _CliRunRenderer,
 ) -> list[_NotebookSummary]:
-    """Extract notebook HTML artifacts from a completed run manifest."""
+    """Extract notebook HTML artifacts from a completed run manifest.
+
+    Reads ``rendered_html`` from each task entry. Freshly executed notebooks
+    record a path relative to ``run_dir``; cache hits replay an absolute
+    path pointing at the original run's HTML. ``Path /`` handles both.
+    """
     notebooks: list[_NotebookSummary] = []
     tasks = manifest.get("tasks", {})
     if not isinstance(tasks, dict):
@@ -372,21 +377,10 @@ def _load_run_notebooks(
     for task in tasks.values():
         if not isinstance(task, dict):
             continue
-
-        # Executed tasks record rendered_html (relative to run_dir).
-        # Cached tasks skip _record_notebook_manifest, but the return value
-        # stored in "output" is the HTML path from the original run.
         rendered_html = task.get("rendered_html")
-        if isinstance(rendered_html, str):
-            html_path = (run_dir / rendered_html).resolve()
-        elif task.get("kind") == "notebook":
-            output = task.get("output")
-            if not isinstance(output, str) or not output.endswith(".html"):
-                continue
-            html_path = Path(output)
-        else:
+        if not isinstance(rendered_html, str):
             continue
-
+        html_path = (run_dir / rendered_html).resolve()
         node_id = task.get("node_id")
         task_label = (
             renderer.label_for_node(int(node_id)) if isinstance(node_id, int) else None

--- a/ginkgo/cli/commands/run.py
+++ b/ginkgo/cli/commands/run.py
@@ -8,11 +8,18 @@ import time
 from contextlib import ExitStack
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 from ginkgo.cli.common import RUNS_ROOT, RunMode, console
 from ginkgo.cli.renderers.common import _environment_label, _format_duration
 from ginkgo.cli.renderers.jsonl import JsonlEventRenderer
-from ginkgo.cli.renderers.models import _FailureDetails, _ResourceRenderState, _RunSummary
+from ginkgo.cli.renderers.models import (
+    _AssetSummary,
+    _FailureDetails,
+    _NotebookSummary,
+    _ResourceRenderState,
+    _RunSummary,
+)
 from ginkgo.cli.renderers.rich import RichEventRenderer
 from ginkgo.cli.renderers.run import _CliRunRenderer
 from ginkgo.cli.workspace import resolve_workflow_path
@@ -280,6 +287,12 @@ def run_workflow(
                     elapsed=time.perf_counter() - run_started,
                     success=True,
                     resources=resource_summary,
+                    notebooks=_load_run_notebooks(
+                        run_dir=recorder.run_dir,
+                        manifest=manifest,
+                        renderer=renderer,
+                    ),
+                    assets=_load_run_assets(manifest=manifest),
                 )
     finally:
         if notification_service is not None:
@@ -343,6 +356,68 @@ def _discover_flow(module: ModuleType) -> FlowDef:
     if len(flows) != 1:
         raise RuntimeError(f"Expected exactly one @flow in {module.__file__}, found {len(flows)}")
     return next(iter(flows.values()))
+
+
+def _load_run_notebooks(
+    *,
+    run_dir: Path,
+    manifest: dict[str, Any],
+    renderer: _CliRunRenderer,
+) -> list[_NotebookSummary]:
+    """Extract notebook HTML artifacts from a completed run manifest."""
+    notebooks: list[_NotebookSummary] = []
+    tasks = manifest.get("tasks", {})
+    if not isinstance(tasks, dict):
+        return notebooks
+    for task in tasks.values():
+        if not isinstance(task, dict):
+            continue
+        rendered_html = task.get("rendered_html")
+        if not isinstance(rendered_html, str):
+            continue
+        node_id = task.get("node_id")
+        task_label = (
+            renderer.label_for_node(int(node_id)) if isinstance(node_id, int) else None
+        ) or _task_base_name(task.get("task"))
+        html_path = (run_dir / rendered_html).resolve()
+        notebooks.append(_NotebookSummary(task_label=task_label, html_path=html_path))
+    return notebooks
+
+
+def _load_run_assets(*, manifest: dict[str, Any]) -> list[_AssetSummary]:
+    """Extract asset materialisations from a completed run manifest."""
+    assets: list[_AssetSummary] = []
+    seen_keys: set[str] = set()
+    tasks = manifest.get("tasks", {})
+    if not isinstance(tasks, dict):
+        return assets
+    for task in tasks.values():
+        if not isinstance(task, dict):
+            continue
+        task_assets = task.get("assets")
+        if not isinstance(task_assets, list):
+            continue
+        for asset in task_assets:
+            if not isinstance(asset, dict):
+                continue
+            key = asset.get("asset_key")
+            if not isinstance(key, str) or key in seen_keys:
+                continue
+            seen_keys.add(key)
+            path = asset.get("artifact_path")
+            assets.append(
+                _AssetSummary(
+                    asset_key=key,
+                    artifact_path=str(path) if path is not None else None,
+                )
+            )
+    return assets
+
+
+def _task_base_name(task_name: object) -> str:
+    """Return the final dotted segment of a task identifier."""
+    text = str(task_name or "unknown")
+    return text.rsplit(".", maxsplit=1)[-1]
 
 
 def _task_counts(manifest: dict[str, object]) -> dict[str, int]:

--- a/ginkgo/cli/renderers/models.py
+++ b/ginkgo/cli/renderers/models.py
@@ -110,5 +110,4 @@ class _NotebookSummary:
 class _AssetSummary:
     """Asset materialised in a run."""
 
-    asset_key: str
-    artifact_path: str | None
+    name: str

--- a/ginkgo/cli/renderers/models.py
+++ b/ginkgo/cli/renderers/models.py
@@ -96,3 +96,19 @@ class _ResourceRenderState:
     """Live resource summary provider for CLI rendering."""
 
     provider: Callable[[], dict[str, object]]
+
+
+@dataclass(frozen=True, kw_only=True)
+class _NotebookSummary:
+    """Rendered notebook artifact produced in a run."""
+
+    task_label: str
+    html_path: Path
+
+
+@dataclass(frozen=True, kw_only=True)
+class _AssetSummary:
+    """Asset materialised in a run."""
+
+    asset_key: str
+    artifact_path: str | None

--- a/ginkgo/cli/renderers/run.py
+++ b/ginkgo/cli/renderers/run.py
@@ -33,7 +33,9 @@ from ginkgo.cli.renderers.common import (
     _truncate_task_label,
 )
 from ginkgo.cli.renderers.models import (
+    _AssetSummary,
     _FailureDetails,
+    _NotebookSummary,
     _ResourceRenderState,
     _RunSummary,
     _TaskGroup,
@@ -107,6 +109,8 @@ class _CliRunRenderer:
         success: bool,
         resources: dict[str, object] | None = None,
         failure_details: list[_FailureDetails] | None = None,
+        notebooks: list[_NotebookSummary] | None = None,
+        assets: list[_AssetSummary] | None = None,
     ) -> None:
         """Print the final run summary."""
         if self._buffer.strip():
@@ -144,6 +148,10 @@ class _CliRunRenderer:
             self._console.print(self._render_failure_separator())
             self._console.print(self._render_failure_details(failure_details))
         if success:
+            if notebooks:
+                self._console.print(self._render_notebooks(notebooks))
+            if assets:
+                self._console.print(self._render_assets(assets))
             self._console.print(f"Run directory: {self._summary.run_dir}")
 
     def label_for_node(self, node_id: int) -> str | None:
@@ -344,6 +352,28 @@ class _CliRunRenderer:
             f"RSS {_format_bytes(_as_int(current.get('rss_bytes')))}   "
             f"Procs {_format_count(current.get('process_count'))}"
         )
+
+    def _render_notebooks(self, notebooks: list[_NotebookSummary]) -> Text:
+        """Render the list of notebooks materialised in this run."""
+        text = Text()
+        text.append(f"\n📓 Notebooks materialised ({len(notebooks)})\n", style="bold")
+        for nb in notebooks:
+            url = nb.html_path.as_uri()
+            text.append(f"  {nb.task_label}  ", style="bold #134e4a")
+            text.append(str(nb.html_path), style=f"link {url} #0f766e")
+            text.append("\n")
+        return text
+
+    def _render_assets(self, assets: list[_AssetSummary]) -> Text:
+        """Render the list of assets materialised in this run."""
+        text = Text()
+        text.append(f"\n📦 Assets materialised ({len(assets)})\n", style="bold")
+        for asset in assets:
+            text.append(f"  {asset.asset_key}", style="bold #134e4a")
+            if asset.artifact_path:
+                text.append(f"  {asset.artifact_path}", style="dim")
+            text.append("\n")
+        return text
 
     def _render_failure_details(self, details: list[_FailureDetails]):
         panels = [self._render_failure_panel(item) for item in details]

--- a/ginkgo/cli/renderers/run.py
+++ b/ginkgo/cli/renderers/run.py
@@ -369,10 +369,7 @@ class _CliRunRenderer:
         text = Text()
         text.append(f"\n📦 Assets materialised ({len(assets)})\n", style="bold")
         for asset in assets:
-            text.append(f"  {asset.asset_key}", style="bold #134e4a")
-            if asset.artifact_path:
-                text.append(f"  {asset.artifact_path}", style="dim")
-            text.append("\n")
+            text.append(f"  {asset.name}\n", style="bold #134e4a")
         return text
 
     def _render_failure_details(self, details: list[_FailureDetails]):

--- a/ginkgo/runtime/cache.py
+++ b/ginkgo/runtime/cache.py
@@ -164,11 +164,19 @@ class CacheStore:
         task_def: TaskDef,
         resolved_args: dict[str, Any],
         input_hashes: dict[str, Any],
+        extra_meta: dict[str, Any] | None = None,
     ) -> dict[str, str]:
         """Atomically persist a task result and metadata.
 
         File and folder outputs are copied into the artifact store, while the
         working-tree materialization is left in place as writable content.
+
+        Parameters
+        ----------
+        extra_meta : dict[str, Any] | None
+            Optional task-kind-specific metadata to persist alongside the
+            cache entry. Stored under the top-level ``"extra"`` field of
+            ``meta.json`` and retrievable via :meth:`load_extra_meta`.
 
         Returns
         -------
@@ -210,6 +218,8 @@ class CacheStore:
                     "timestamp": datetime.now(UTC).isoformat(),
                     "version": task_def.version,
                 }
+                if extra_meta is not None:
+                    meta["extra"] = extra_meta
                 (temp_dir / "meta.json").write_text(
                     json.dumps(meta, indent=2, sort_keys=True),
                     encoding="utf-8",
@@ -308,6 +318,30 @@ class CacheStore:
             return True
         self._artifact_store.restore(artifact_id=artifact_id, dest_path=path)
         return self._artifact_store.matches(artifact_id=artifact_id, path=path)
+
+    def load_extra_meta(self, *, cache_key: str) -> dict[str, Any] | None:
+        """Return task-kind-specific metadata persisted with a cache entry.
+
+        Parameters
+        ----------
+        cache_key : str
+            The content-addressed cache key.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            The dict previously passed as ``extra_meta`` to :meth:`save`,
+            or ``None`` when the entry is missing or recorded no extras.
+        """
+        meta_path = self._entry_dir(cache_key) / "meta.json"
+        if not meta_path.exists():
+            return None
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        extra = meta.get("extra")
+        return extra if isinstance(extra, dict) else None
 
     def _load_artifact_ids(self, *, cache_key: str) -> dict[str, str] | None:
         """Load output artifact mappings for one cache entry."""

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -199,6 +199,7 @@ class _TaskNode:
     driver_sentinel: Any = None
     extra_source_hash: str | None = None
     asset_versions: list[AssetVersion] = field(default_factory=list)
+    notebook_extras: dict[str, Any] | None = None
 
     @property
     def task_def(self) -> TaskDef:
@@ -896,12 +897,16 @@ class _ConcurrentEvaluator:
         """Persist and mark a task node as fully completed."""
         finalize_started = time.perf_counter()
         self._cleanup_transport(node)
+        extra_meta: dict[str, Any] | None = None
+        if node.notebook_extras is not None:
+            extra_meta = {"notebook_extras": node.notebook_extras}
         artifact_ids = self._cache_store.save(
             cache_key=node.cache_key,
             result=value,
             task_def=node.task_def,
             resolved_args=node.resolved_args,
             input_hashes=node.input_hashes,
+            extra_meta=extra_meta,
         )
 
         # Propagate output digests so downstream tasks can skip re-hashing.
@@ -2239,6 +2244,34 @@ class _ConcurrentEvaluator:
             extra["managed_kernel_name"] = managed_kernel_name
         self.provenance.update_task_extra(node_id=node.node_id, **extra)
 
+        # Stash an absolute-path version of the extras on the node so that
+        # _complete_node can persist them in the cache entry. Replaying these
+        # on a future cache hit lets us populate the new run's manifest with
+        # the rendered HTML pointer even when the task body is skipped.
+        cache_extras = dict(extra)
+        cache_extras["rendered_html"] = str(rendered_html)
+        if executed_path is not None:
+            cache_extras["executed_notebook"] = str(executed_path)
+        node.notebook_extras = cache_extras
+
+    def _replay_cached_notebook_extras(self, *, node: _TaskNode, cache_key: str) -> None:
+        """Replay notebook manifest extras stored on a previous cache save.
+
+        Notebook tasks render an HTML artifact whose path is not part of the
+        cached return value. To keep cache hits visible in the run summary
+        and downstream tooling, we persist the notebook manifest extras
+        alongside the cache entry on save and re-apply them here on hit.
+        """
+        if self.provenance is None or node.task_def.kind != "notebook":
+            return
+        cached_extra = self._cache_store.load_extra_meta(cache_key=cache_key)
+        if cached_extra is None:
+            return
+        notebook_extras = cached_extra.get("notebook_extras")
+        if not isinstance(notebook_extras, dict):
+            return
+        self.provenance.update_task_extra(node_id=node.node_id, **notebook_extras)
+
     def _render_notebook_failure_page(
         self,
         *,
@@ -2753,6 +2786,7 @@ class _ConcurrentEvaluator:
                 outputs=self._artifact_index_for(node=node, value=value),
                 assets=self._asset_index_for(value=value),
             )
+            self._replay_cached_notebook_extras(node=node, cache_key=cache_key)
         self._emit_event(
             TaskCacheHit(
                 run_id=self._run_id,

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -47,6 +47,12 @@ def notebook_ipynb_task(*, notebook_path: str, value: int) -> Path:
 
 
 @task("notebook")
+def notebook_ipynb_with_output_task(*, notebook_path: str, output_path: str) -> Path:
+    """Run an ipynb notebook that declares an output file."""
+    return notebook(notebook_path, outputs=output_path)
+
+
+@task("notebook")
 def notebook_marimo_task(*, notebook_path: str, sample_id: str) -> Path:
     """Run a marimo notebook by path."""
     return notebook(notebook_path)
@@ -459,6 +465,95 @@ class TestEvaluate:
             lambda **_: (_ for _ in ()).throw(AssertionError("cache miss")),
         )
         assert cached.evaluate(expr) == Path(recorder.run_dir / "notebooks" / "task_0000.html")
+
+    def test_cached_notebook_with_declared_output_replays_rendered_html(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cache hits on notebook tasks with declared outputs must still
+        populate ``rendered_html`` so the run summary can list the notebook.
+        """
+        nb_path = tmp_path / "report.ipynb"
+        nb_path.write_text(
+            '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}', encoding="utf-8"
+        )
+        output_path = tmp_path / "output.txt"
+        expr = notebook_ipynb_with_output_task(
+            notebook_path=str(nb_path), output_path=str(output_path)
+        )
+
+        first_recorder = RunProvenanceRecorder(
+            run_id=make_run_id(workflow_path=tmp_path / "workflow.py"),
+            workflow_path=tmp_path / "workflow.py",
+            root_dir=tmp_path / ".ginkgo" / "runs",
+            jobs=1,
+            cores=1,
+        )
+
+        def fake_run_subprocess(
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+        ) -> subprocess.CompletedProcess[str]:
+            command = " ".join(argv) if isinstance(argv, list) else str(argv)
+            if "import ipykernel" in command:
+                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+            if "ipykernel install" in command:
+                kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
+                kernel_name = command.split("--name", 1)[1].strip().split()[0]
+                kernel_dir = kernel_root / kernel_name
+                kernel_dir.mkdir(parents=True, exist_ok=True)
+                (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
+                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+            if "papermill" in command:
+                executed = first_recorder.run_dir / "notebooks" / "task_0000.ipynb"
+                executed.write_text("executed", encoding="utf-8")
+                # Honour the declared output by creating it during execution.
+                output_path.write_text("declared output", encoding="utf-8")
+                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+            if "nbconvert" in command:
+                html = first_recorder.run_dir / "notebooks" / "task_0000.html"
+                html.write_text("<html>report</html>", encoding="utf-8")
+                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+            raise AssertionError(command)
+
+        first_evaluator = _ConcurrentEvaluator(provenance=first_recorder, jobs=1, cores=1)
+        monkeypatch.setattr(first_evaluator, "_run_subprocess", fake_run_subprocess)
+        first_result = first_evaluator.evaluate(expr)
+        first_manifest = load_manifest(first_recorder.run_dir)
+        first_html = first_recorder.run_dir / "notebooks" / "task_0000.html"
+
+        assert first_result == output_path
+        assert first_manifest["tasks"]["task_0000"]["rendered_html"] == "notebooks/task_0000.html"
+
+        # Second run reuses the same cwd-scoped cache but a fresh recorder
+        # (and therefore a fresh run_dir). The notebook body must be skipped
+        # entirely yet rendered_html still has to surface in the new manifest.
+        second_recorder = RunProvenanceRecorder(
+            run_id=make_run_id(workflow_path=tmp_path / "workflow.py") + "-2",
+            workflow_path=tmp_path / "workflow.py",
+            root_dir=tmp_path / ".ginkgo" / "runs",
+            jobs=1,
+            cores=1,
+        )
+        cached_evaluator = _ConcurrentEvaluator(provenance=second_recorder, jobs=1, cores=1)
+        monkeypatch.setattr(
+            cached_evaluator,
+            "_run_subprocess",
+            lambda **_: (_ for _ in ()).throw(AssertionError("cache miss")),
+        )
+
+        cached_result = cached_evaluator.evaluate(expr)
+        second_manifest = load_manifest(second_recorder.run_dir)
+        replayed_html = second_manifest["tasks"]["task_0000"].get("rendered_html")
+
+        assert cached_result == output_path
+        assert second_manifest["tasks"]["task_0000"].get("cached") is True
+        assert isinstance(replayed_html, str)
+        # Absolute path pointing back at the original run's HTML artifact.
+        assert Path(replayed_html) == first_html
+        assert (second_recorder.run_dir / replayed_html).resolve() == first_html.resolve()
 
     def test_ipynb_notebook_task_uses_env_managed_kernel(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- After a successful `ginkgo run`, the CLI summary now lists all notebooks rendered in the run with a `📓` header, showing the task label and a clickable `file://` link to each HTML report
- Assets materialised in the run are shown with a `📦` header, listing each asset key and its artifact path
- Both sections only appear when there are items to show; failed runs are unaffected

## Test plan

- [ ] Run a workflow that includes notebook tasks — confirm the 📓 section appears with correct task labels and working clickable links
- [ ] Run a workflow that materialises assets — confirm the 📦 section lists all asset keys and paths
- [ ] Run a workflow with neither — confirm no extra output
- [ ] Confirm a failed run still shows the existing failure diagnostics without the new sections
- [ ] `pixi run pytest tests/ -q` passes (363 passed, 1 skipped)