### PR TITLE
Phase 20: profiling, explicit thread control, and fan-out concurrency caps

### DIFF
--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -18,6 +18,9 @@ import time
 from typing import Any, Iterator
 from unittest.mock import patch
 
+from rich.console import Console
+from rich.table import Table
+
 from benchmarks.bioinfo import prepare_bioinfo_benchmark_dataset
 from ginkgo.cli.commands.run import run_workflow
 from ginkgo.cli.workspace import discover_default_workflow
@@ -218,74 +221,71 @@ def _print_benchmark_summary(
 ) -> None:
     """Print a readable benchmark summary table."""
 
+    console = Console(file=stream, force_terminal=False, no_color=True, soft_wrap=True)
     if not isinstance(comparisons, list) or len(comparisons) == 0:
-        print(_render_observed_table(records=records), file=stream)
+        console.print(_render_observed_table(records=records))
         return
 
-    print(_render_comparison_table(comparisons=comparisons), file=stream)
+    console.print(_render_comparison_table(comparisons=comparisons))
 
 
-def _render_comparison_table(*, comparisons: list[dict[str, object]]) -> str:
-    """Return a fixed-width benchmark comparison table."""
+_PASS_STYLE = "green"
+_FAIL_STYLE = "red"
+_MISSING_STYLE = "yellow"
 
-    headers = [
-        "example",
-        "mode",
-        "baseline s",
-        "observed s",
-        "delta s",
-        "delta %",
-        "status",
-    ]
-    rows = [
-        [
+
+def _status_style(status: str) -> str:
+    """Return one Rich style for a comparison status."""
+    if status == "passed":
+        return _PASS_STYLE
+    if status == "failed":
+        return _FAIL_STYLE
+    return _MISSING_STYLE
+
+
+def _render_comparison_table(*, comparisons: list[dict[str, object]]) -> Table:
+    """Return a Rich benchmark comparison table."""
+
+    table = Table(title="Benchmark Comparison", show_lines=False)
+    table.add_column("example")
+    table.add_column("mode")
+    table.add_column("baseline s", justify="right")
+    table.add_column("observed s", justify="right")
+    table.add_column("delta s", justify="right")
+    table.add_column("delta %", justify="right")
+    table.add_column("status")
+
+    for item in comparisons:
+        status = str(item.get("status", "unknown"))
+        table.add_row(
             str(item.get("example", "—")),
             str(item.get("mode", "—")),
             _format_seconds(item.get("baseline_seconds")),
             _format_seconds(item.get("observed_seconds")),
             _format_delta_seconds(item.get("absolute_delta_seconds")),
             _format_percentage(item.get("percentage_delta")),
-            str(item.get("status", "unknown")),
-        ]
-        for item in comparisons
-    ]
-    return _render_table(title="Benchmark Comparison", headers=headers, rows=rows)
+            f"[{_status_style(status)}]{status}[/{_status_style(status)}]",
+        )
+    return table
 
 
-def _render_observed_table(*, records: list[BenchmarkRecord]) -> str:
-    """Return a fixed-width observed-results table."""
+def _render_observed_table(*, records: list[BenchmarkRecord]) -> Table:
+    """Return a Rich observed-results table."""
 
-    headers = ["example", "mode", "observed s", "status"]
-    rows = [
-        [
+    table = Table(title="Benchmark Results", show_lines=False)
+    table.add_column("example")
+    table.add_column("mode")
+    table.add_column("observed s", justify="right")
+    table.add_column("status")
+
+    for record in records:
+        table.add_row(
             record.example,
             record.mode,
             _format_seconds(record.wall_time_seconds),
             record.status,
-        ]
-        for record in records
-    ]
-    return _render_table(title="Benchmark Results", headers=headers, rows=rows)
-
-
-def _render_table(*, title: str, headers: list[str], rows: list[list[str]]) -> str:
-    """Return one plain-text table."""
-
-    widths = [len(header) for header in headers]
-    for row in rows:
-        for index, value in enumerate(row):
-            widths[index] = max(widths[index], len(value))
-
-    separator = "  ".join("-" * width for width in widths)
-    lines = [
-        title,
-        "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)),
-        separator,
-    ]
-    lines.extend(
-        "  ".join(value.ljust(widths[index]) for index, value in enumerate(row)) for row in rows
-    )
-    return "\n".join(lines)
+        )
+    return table
 
 
 def _raise_for_strict_regressions(*, comparisons: object, strict: bool) -> None:
@@ -519,6 +519,7 @@ def _mock_docker() -> Iterator[None]:
         use_shell: bool,
         on_stdout: Any = None,
         on_stderr: Any = None,
+        **kwargs: Any,
     ) -> subprocess.CompletedProcess[str]:
         if isinstance(argv, list) and argv and argv[0] == "docker":
             completed = subprocess.run(
@@ -568,6 +569,7 @@ def _mock_notebook_tools() -> Iterator[None]:
         use_shell: bool,
         on_stdout: Any = None,
         on_stderr: Any = None,
+        **kwargs: Any,
     ) -> subprocess.CompletedProcess[str]:
         if isinstance(argv, str) and "papermill" in argv:
             parts = shlex.split(argv)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,6 +289,33 @@ The current evaluator is concurrent and futures-based:
 
 The scheduler performs explicit cycle detection when registering expressions.
 
+**Per-task thread declaration.** A task's CPU footprint is declared on the
+decorator (`@task(threads=4)`). The scheduler uses this value as the task's
+core budget against `--cores`. When a task function's signature includes a
+`threads` parameter, the declared value is injected automatically so the task
+body can reference it. Shell tasks additionally receive `GINKGO_THREADS` in
+their subprocess environment, and `@task(threads=N, export_thread_env=True)`
+also exports `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OPENBLAS_NUM_THREADS`,
+and `NUMEXPR_NUM_THREADS` so ordinary BLAS/OpenMP tools honour the budget
+without per-workflow boilerplate.
+
+**Fan-out concurrency caps.** `.map()` and `.product_map()` accept an optional
+`max_concurrent=N` argument that caps how many branches from a single
+fan-out may run simultaneously, independent of the global `--jobs` and
+`--cores` budgets. The scheduler tracks one ephemeral concurrency group per
+fan-out and enforces the limit in the CP-SAT selection model alongside
+cores, jobs, and memory constraints.
+
+**Runtime profiling (`--profile`).** `ginkgo run --profile` enables a coarse
+phase-timer recorder that attributes wall time to CLI startup, workflow
+module import, flow construction, evaluator validation, scheduler prepare /
+dispatch / wait / consume phases, event emission, resource monitor lifecycle,
+provenance finalize, manifest load, and renderer finish. The recorder is a
+no-op when `--profile` is not set and does not run when disabled, so the
+default path is not instrumented. The phase totals are persisted under
+`timings.profile` in the run manifest, printed as a Rich summary table at
+the end of the run, and exposed by `ginkgo inspect run`.
+
 ### Remote References and Staged Access
 
 Phase 6 introduced first-class remote input support without changing the

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -55,68 +55,6 @@ architectural layers.
 
 ---
 
-### Phase 2 — Runtime Profiling and Resource Controls
-
-**Goal:** Add opt-in runtime profiling, explicit per-task thread declarations,
-and task-level concurrency limits so workflows can be diagnosed and scheduled
-with precision.
-
-**Detailed design:** [`docs/phase20-profiling-and-resource-controls-plan.md`](phase20-profiling-and-resource-controls-plan.md)
-(workstreams 1–3; workstream 4 — benchmark comparison table — is shipped)
-
-#### Deliverables
-
-**`--profile` mode (workstream 1):**
-
-- Add an opt-in `--profile` flag to `ginkgo run` that enables wider timing
-  coverage across runtime phases (CLI startup, module import, flow construction,
-  scheduler loop overhead, event emission, resource monitor lifecycle, final
-  reporting).
-- Persist the profile in run provenance and surface it in CLI output at run end.
-- `ginkgo inspect run` includes the full timing structure.
-- Profiling remains coarse-grained and cheap enough for routine diagnostic use.
-
-**First-class per-task thread control (workstream 2):**
-
-- Formalize task CPU footprint as an explicit resource declaration rather than
-  the current implicit `threads` argument convention.
-- Ensure shell tasks can access the resolved thread count through a standard
-  contract (e.g. `GINKGO_THREADS` environment variable).
-- Preserve compatibility with existing workflows that use a `threads` parameter.
-
-**Task-level concurrency limits (workstream 3):**
-
-- Add named concurrency groups with integer limits (e.g.
-  `model_training: 1`).
-- Allow tasks to declare membership in a named concurrency group.
-- Enforce concurrency-group limits in scheduler selection alongside existing
-  `jobs`, `cores`, and `memory` constraints.
-- Ensure the policy applies uniformly to ordinary tasks, `.map()` fan-out, and
-  `.product_map()` fan-out.
-- Surface concurrency-group metadata in runtime events and provenance.
-
-#### Key design points
-
-- `--profile` should not add measurable overhead or distort the runs it
-  explains.
-- Thread control must not break existing workflows that already use a `threads`
-  parameter — provide a clear migration path or backwards-compatible layering.
-- Concurrency groups are a scheduler primitive, not a `.map()` API option.
-  Fan-out already produces normal task nodes; the scheduler decides how many run
-  at once.
-- `threads` remains a declaration of CPU footprint, not a hidden mutex.
-
-#### Validation
-
-- `ginkgo run --profile` produces an attributable timing breakdown that explains
-  nearly all non-user-code runtime overhead.
-- Shell tasks can consume the scheduled thread budget through a standard
-  contract.
-- A workflow declaring `model_training` group with limit `1` enforces singleton
-  execution across mapped fan-out while unrelated tasks still run concurrently.
-- Existing workflows using the implicit `threads` convention continue to work.
-
----
 
 ### Phase 3 — UI Performance and Responsiveness
 
@@ -354,83 +292,8 @@ additional asset kinds begin to use the shared catalog.
 
 ### Phase 7 — Kubernetes / Batch Executor
 
-<<<<<<< Updated upstream
-**Depends on:** Phase 8 (versioned DataFrame assets — profiling hooks into the DataFrame materialization path, drift detection compares version metadata).
-
-#### Deliverables
-
-**Statistical profiling at materialization time:**
-
-- When a `kind="dataframe"` task materializes a snapshot, automatically compute column-level statistics from the in-memory DataFrame before serialization:
-  - null count and null rate per column
-  - unique count / cardinality
-  - min / max / mean / std for numeric columns
-  - top-N frequent values for categorical columns
-  - approximate quantiles for numeric columns
-- Store the profile in `AssetVersion.metadata` under a `profile` key alongside the existing schema and row count fields.
-- Profiling adds negligible overhead since the DataFrame is already in memory for serialization.
-
-**Data quality gates:**
-
-- Add a `checks=` parameter to the `dataframe_asset()` builder:
-
-  ```python
-  return dataframe_asset(df, checks=[
-      check.row_count(min=1000),
-      check.no_nulls("user_id"),
-      check.unique("user_id"),
-      check.range("age", min=0, max=150),
-      check.schema_matches({"user_id": "int64", "age": "float64"}),
-      check.null_rate("email", max=0.05),
-  ])
-  ```
-
-- The evaluator runs checks after serialization. The asset version is always written (data is recorded even when quality fails), but tagged `quality: "pass" | "fail"` in metadata with individual check results.
-- Downstream tasks consuming the asset can declare `only_if_passing=True` to skip execution when upstream data quality fails, producing a clear skip reason in provenance rather than propagating bad data silently.
-- Quality check results are recorded in run provenance alongside the asset metadata.
-
-**Drift detection between versions:**
-- Add `ginkgo asset diff <key> <ver1> <ver2>` to compare profiling stats between two versions of the same asset:
-
-  ```
-  $ ginkgo asset diff dataframe/features v-a1b2c3 v-d4e5f6
-
-  COLUMN       METRIC       v-a1b2c3    v-d4e5f6    DELTA
-  row_count    -            10000       12500       +25.0%
-  age          mean         34.2        38.7        +13.2%
-  age          null_rate    0.01        0.12        +1100%  ⚠
-  category     cardinality  15          23          +53.3%
-  ```
-
-- Warning thresholds are configurable per metric. Defaults flag large relative changes in null rates, cardinality, and distribution statistics.
-- The UI data preview (from Phase 8) surfaces the profile alongside the data, and the version detail view shows drift indicators when comparing to the parent version.
-
-#### Key design points
-
-- Profiling runs synchronously during materialization while the DataFrame is in memory. This is a one-time cost at write time that avoids needing to re-read the Parquet artifact later.
-- Quality gates are advisory by default — the asset is always written. `only_if_passing` on downstream tasks is opt-in. This avoids data loss while still enabling fail-fast pipelines when desired.
-- The `check` namespace provides a small, opinionated set of common data quality assertions. This is not Great Expectations — complex validation should use external tools with Ginkgo tasks as the execution substrate.
-- Drift detection is pure metadata comparison — it never loads artifact bytes. This means it works for arbitrarily large DataFrames and is fast enough to show in the UI.
-
-#### Validation
-
-- A `kind="dataframe"` task produces a snapshot with a complete statistical profile in version metadata (null rates, cardinality, min/max for all columns).
-- A DataFrame asset with `checks=[check.no_nulls("id")]` passes quality when the column has no nulls and fails when it does. Both cases write the asset version; the failing case tags `quality: "fail"` with the check result.
-- A downstream task with `only_if_passing=True` skips execution when its upstream DataFrame asset failed quality checks, and runs normally when quality passes.
-- `ginkgo asset diff` renders correct deltas between two versions using only stored profile metadata.
-- The UI version detail view shows profile statistics and drift indicators relative to the parent version.
-
----
-
-## Tier 4 — Composition, Publishing, and Remote Execution
-
-### Phase 14 — Kubernetes / Batch Executor
-
-**Goal:** Run tasks on a remote scheduler such as Kubernetes Jobs or cloud batch services while preserving Ginkgo's dynamic DAG and cache semantics.
-=======
 **Goal:** Run tasks on a remote scheduler such as Kubernetes Jobs or cloud batch
 services while preserving Ginkgo's dynamic DAG and cache semantics.
->>>>>>> Stashed changes
 
 **Depends on:** remote-backed artifact storage for managed outputs (hard
 prerequisite; remote jobs cannot access local `.ginkgo/cache/`).
@@ -500,161 +363,6 @@ sub-workflows, enabling reuse and composition without duplicating task logic.
 
 #### Validation
 
-<<<<<<< Updated upstream
-- Define a parent workflow that calls a sub-workflow in inline mode and assert that sub-workflow tasks appear in the parent DAG, share the same run manifest, and are individually cached.
-- Define a parent workflow that calls a sub-workflow in opaque mode and assert that only the sub-workflow's result artifact appears in the parent provenance, not its internal tasks.
-- Assert that circular workflow references are detected at plan time with a clear error message.
-- Assert that parameters and secrets passed to a sub-workflow are correctly scoped and do not leak into unrelated tasks in the parent workflow.
-- Re-run the parent workflow with unchanged inputs and assert that sub-workflow tasks are served from cache at the appropriate granularity for each composition mode.
-
----
-
-## Cross-Cutting Phases
-
-These phases are not gated by a specific tier and can be worked on incrementally alongside any other work.
-
-### Phase 1 — Remaining Hardening and UI Polish
-
-**Goal:** Finish the production-readiness and local UI work that remains.
-
-Completed in this phase: sidebar shell, multi-workspace aggregation and
-workspace switching, pixi-aware workflow launch from external workspaces,
-live WebSocket event channel, structured live-state diffing, UI server package
-refactor, workspace validation from non-workspace directories, age-based
-`ginkgo cache prune`.
-
-#### Remaining Deliverables
-
-- Extend retry support with:
-  - selective retry policies
-  - retry backoff
-- Broaden cache-management policy beyond age-based pruning (size- or
-  count-based eviction).
-- Polish the UI task-graph experience:
-  - richer DAG layout (fit-to-view, failure focus, better spacing)
-- Add task priority declarations so users can express relative urgency between
-  tasks in the same DAG tier; the scheduler should respect priority when
-  multiple tasks are ready to run concurrently.
-- Tighten documentation around partial resume, dry-run behavior, and resource
-  declarations.
-
-#### Key design points
-
-- This phase is explicitly for remaining gaps in areas that already exist.
-- The goal is to reduce ambiguity and operational rough edges before the runtime surface area expands further.
-- UI work should remain local-first and should build on the current file-backed provenance model.
-
-#### Validation
-
-- Re-run `VW-4`, `VW-5`, `VW-6`, and `VW-8` through the polished CLI and UI paths and assert the richer retry, cache, and resource behavior is visible in both CLI output and persisted provenance.
-- Assert the improved diagnostics distinguish common classes of failure such as env mismatch, invalid paths, and packaging/importability errors.
-
----
-
-### Phase 16 — UI Performance and Responsiveness
-
-**Goal:** Keep the local web UI fast and predictable as run history, task counts, event volume, and artifact metadata grow.
-
-#### Problem definition
-
-The current UI is local-first and provenance-backed, which keeps the architecture simple, but that model can still become sluggish when a workspace accumulates many runs, large manifests, dense task graphs, or high-frequency live events. Notebook artifacts and richer asset metadata will increase that pressure. UI responsiveness should be treated as an explicit workstream rather than an incidental cleanup item.
-
-#### Deliverables
-
-- Profile the UI server and frontend against larger synthetic and real workspaces to identify the dominant latency and rendering costs.
-- Reduce run-list and run-detail load latency by avoiding full manifest reads when summary data is sufficient.
-- Add pagination, windowing, or incremental loading for large run collections and task lists.
-- Make live updates cheaper by sending targeted diffs and limiting unnecessary client-side recomputation.
-- Improve graph rendering performance for large DAGs through layout caching, viewport-aware rendering, or progressive expansion.
-- Ensure notebook and asset detail views remain responsive even when runs contain many artifacts.
-- Add benchmark-style regression checks for UI server payload construction and selected frontend interactions.
-
-#### Key design points
-
-- Performance work should preserve the current provenance-first architecture; optimisations should improve data access patterns rather than introduce a second source of truth.
-- The server should distinguish between summary payloads and detail payloads so the frontend does not pay full-cost reads for overview screens.
-- Frontend rendering work should favour incremental rendering and bounded DOM size over cosmetic complexity.
-- UI performance should be measured with repeatable fixtures and checked into the repository where practical, so regressions are visible.
-
-#### Risks and tradeoffs
-
-- Aggressive caching can make the UI appear fast while serving stale data if invalidation rules are weak.
-- Progressive loading improves responsiveness but can complicate navigation and empty-state handling if the UX is not deliberate.
-- Optimising graph rendering may require simplifying some visual affordances for very large workflows.
-
-#### Success criteria
-
-- Large workspaces with many historical runs remain navigable without noticeable stalls in the run list.
-- Opening a run with a large task graph or many artifacts does not block the UI for multiple seconds on routine hardware.
-- Live runs continue to update smoothly without flooding the browser with redundant state changes.
-- Notebook and artifact views remain responsive enough to be practical on real workflow runs rather than only toy examples.
-
----
-
-### Phase 20 — Task-Level Concurrency Limits
-
-**Goal:** Let workflows limit concurrency for specific classes of tasks, including `.map()` fan-out branches, without abusing `threads` or global `cores`.
-
-#### Problem definition
-
-Ginkgo already expands `.map()` and `.product_map()` into independent task
-nodes, and the evaluator already enforces global `jobs`, `cores`, and optional
-`memory` limits during dispatch. That is sufficient for broad resource control,
-but it does not express policies such as "train only one model at a time" while
-still allowing unrelated work to run concurrently. The current workaround is to
-inflate a task's `threads` requirement until it monopolizes the global core
-budget, but that conflates CPU demand with concurrency intent and can leave the
-machine underutilized.
-
-#### Deliverables
-
-- Add first-class task-level concurrency metadata so a task can declare
-  membership in a named concurrency group.
-- Add run-time configuration for integer limits per concurrency group.
-- Enforce concurrency-group limits in scheduler selection alongside existing
-  `jobs`, `cores`, and `memory` constraints.
-- Ensure the policy applies uniformly to all task dispatch, including ordinary
-  tasks, `.map()` fan-out, and `.product_map()` fan-out.
-- Surface concurrency-group metadata in runtime events and provenance where it
-  improves debuggability.
-- Document the recommended authoring pattern and the difference from
-  `threads`-based CPU budgeting.
-
-#### Key design points
-
-- This should be implemented as a scheduler primitive, not as a `.map()` API
-  option. Fan-out already produces normal task nodes; the scheduler should
-  decide how many of those nodes may run at once.
-- The initial scope should use named concurrency groups with integer limits,
-  for example `model_training: 1`.
-- Task metadata should remain explicit and static at definition time unless a
-  stronger use case emerges for per-invocation overrides.
-- Scheduler selection should account for both currently running group members
-  and newly selected ready tasks in the same dispatch cycle.
-- `threads` should remain a declaration of CPU footprint, not a hidden mutex or
-  singleton mechanism.
-
-#### Risks and tradeoffs
-
-- This adds another axis to scheduler feasibility and increases the complexity
-  of dispatch selection.
-- Tasks that belong to multiple groups may make contention harder to reason
-  about if the API is too flexible too early.
-- Exposing both `threads` and concurrency groups requires clear documentation
-  so users understand when to use each control.
-
-#### Success criteria
-
-- A workflow can declare that all `train_model` tasks belong to a
-  `model_training` group with limit `1` and have that policy enforced across
-  mapped fan-out branches.
-- Unrelated tasks that do not belong to that group can still run concurrently
-  when `jobs`, `cores`, and `memory` permit.
-- Existing workflows that rely only on `jobs`, `cores`, and `memory` continue
-  to behave as before.
-- Scheduler tests cover single-group and mixed-group contention scenarios,
-  including mapped workloads.
-=======
 - Define a parent workflow that calls a sub-workflow in inline mode and assert
   that sub-workflow tasks appear in the parent DAG, share the same run manifest,
   and are individually cached.
@@ -668,4 +376,72 @@ machine underutilized.
 - Re-run the parent workflow with unchanged inputs and assert that sub-workflow
   tasks are served from cache at the appropriate granularity for each
   composition mode.
->>>>>>> Stashed changes
+
+---
+
+### Phase 9 — Remote Input Streaming (FUSE)
+
+**Goal:** Add a FUSE-style streaming layer for remote inputs so that tasks
+running on remote workers can read from object stores without first staging
+the full file to local disk.
+
+**Depends on:** Phase 7. The staging contract (`waiting -> staging -> running`)
+and the worker-local staging root are the substrate this phase replaces; the
+remote executor must already exist so the streaming layer has a real consumer.
+
+#### Deliverables
+
+- Add a worker-local FUSE mount that exposes configured remote prefixes as
+  ordinary local paths, so tasks continue to receive plain `file` and
+  `folder` arguments.
+- Integrate the mount with the existing staging layer as an alternative
+  hydration strategy: tasks declare or inherit a streaming policy, and the
+  staging phase either downloads (current behavior) or mounts (new behavior)
+  on a per-input basis.
+- Support read-through caching with bounded local disk so repeated reads do
+  not incur repeated network round-trips, while keeping the cache footprint
+  predictable on small pod disks.
+- Surface streaming metrics (bytes read, cache hit rate, fault count) in
+  runtime events and per-task provenance so the cost of streaming is visible
+  alongside existing CPU and memory metrics.
+- Provide a fallback to staged downloads when streaming is unavailable or
+  unsuitable (no FUSE support, tools that mmap or seek pathologically), with
+  the choice recorded in provenance.
+- Extend `ginkgo doctor` to validate FUSE availability, kernel module
+  presence, and required pod security context for the configured executor.
+
+#### Key design points
+
+- Streaming is an input-side optimization. Output publishing continues to go
+  through the remote-backed artifact store from Phase 7 — the asymmetry is
+  deliberate, since outputs must be immutable and content-addressed.
+- The FUSE layer lives behind the existing staging contract rather than
+  beside it. Tasks, the scheduler, and the cache should not gain a separate
+  "streamed input" code path; the only difference is whether the bytes
+  behind a path are present locally or fetched on demand.
+- Streaming policy is per-input, not global. Some tools (random-access BAM
+  indexing, SQLite) require local files; others (sequential FASTQ scans,
+  CSV reads) stream cleanly. The default should be staged for correctness,
+  with streaming opted in per task or per input pattern.
+- POSIX semantics over object stores are incomplete. The streaming layer
+  must document and enforce its supported subset (no atomic rename, no
+  random writes, bounded `stat` accuracy) rather than pretending the mount
+  is a full filesystem.
+- Cache identity is unaffected: streamed inputs hash by the same remote
+  reference identity already used for staged inputs.
+
+#### Validation
+
+- A bioinformatics workflow that consumes large FASTQ inputs runs end to end
+  on the remote executor with streaming enabled, and the pod's local disk
+  high-water mark stays well below the total input size.
+- Re-running the same workflow with streaming disabled produces identical
+  outputs and identical cache identity, confirming the streaming layer is a
+  pure performance optimization.
+- A task that requires random-access reads (e.g. indexed BAM) is correctly
+  served from the staged-download fallback when declared incompatible with
+  streaming, and provenance records the fallback.
+- Streaming metrics appear in run provenance and are inspectable via
+  `ginkgo inspect run`.
+- `ginkgo doctor` reports a clear error on a cluster or host where FUSE is
+  unavailable, rather than failing opaquely at task execution time.

--- a/ginkgo/cli/app.py
+++ b/ginkgo/cli/app.py
@@ -80,6 +80,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip content hashing; use stat-based checks only (faster warm runs)",
     )
+    run_parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Record a coarse runtime phase profile and print it at run end",
+    )
 
     cache_parser = subparsers.add_parser("cache")
     cache_subparsers = cache_parser.add_subparsers(dest="cache_command", required=True)

--- a/ginkgo/cli/commands/run.py
+++ b/ginkgo/cli/commands/run.py
@@ -38,6 +38,7 @@ from ginkgo.runtime.caching.provenance import (
 from ginkgo.runtime.environment.secrets import build_secret_resolver
 from ginkgo.runtime.events import EventBus, RunCompleted, RunStarted, RunValidated
 from ginkgo.runtime.notifications.notifications import build_notification_service
+from ginkgo.runtime.profiling import ProfileRecorder
 from ginkgo.runtime.run_summary import RunSummary, TaskSummary
 
 
@@ -56,6 +57,7 @@ def command_run(args, *, output_mode: RunMode) -> int:
         dry_run=args.dry_run,
         output_mode=output_mode,
         trust_workspace=getattr(args, "trust_workspace", False),
+        profile=getattr(args, "profile", False),
     )
 
 
@@ -69,7 +71,11 @@ def run_workflow(
     dry_run: bool,
     output_mode: RunMode = "default",
     trust_workspace: bool = False,
+    profile: bool = False,
 ) -> int:
+    profiler = ProfileRecorder(enabled=profile)
+    cli_startup_started = time.perf_counter()
+
     run_id = make_run_id(workflow_path=workflow_path)
     rich_console = console(sys.stdout)
     if dry_run and output_mode not in {"agent", "agent_verbose"}:
@@ -81,13 +87,18 @@ def run_workflow(
             f"[bold green]🌿 ginkgo run[/] [bold]{workflow_path.name}[/] [dim]({run_id})[/]\n"
         )
 
+    profiler.record(phase="cli_startup", seconds=time.perf_counter() - cli_startup_started)
+
     load_started = time.perf_counter()
     with _config_session(override_paths=config_paths) as session:
-        module = load_module_from_path(workflow_path)
-        flow = _discover_flow(module)
-        expr = flow()
+        with profiler.timed("workflow_module_import"):
+            module = load_module_from_path(workflow_path)
+        with profiler.timed("flow_construction"):
+            flow = _discover_flow(module)
+            expr = flow()
         params = session.merged_loaded_values()
-    runtime_config = load_runtime_config(project_root=Path.cwd(), override_paths=config_paths)
+    with profiler.timed("runtime_config_load"):
+        runtime_config = load_runtime_config(project_root=Path.cwd(), override_paths=config_paths)
     runtime_params = dict(runtime_config)
     runtime_params.update(params)
     load_elapsed = time.perf_counter() - load_started
@@ -111,9 +122,11 @@ def run_workflow(
         memory=memory,
         backend=backend,
         secret_resolver=secret_resolver,
+        profiler=profiler,
     )
     validate_started = time.perf_counter()
-    evaluator.validate(expr)
+    with profiler.timed("evaluator_validate"):
+        evaluator.validate(expr)
     validate_elapsed = time.perf_counter() - validate_started
     task_count = len(evaluator._nodes)
     edge_count = sum(len(node.dependency_ids) for node in evaluator._nodes.values())
@@ -181,7 +194,8 @@ def run_workflow(
         root_pid=os.getpid(),
         sink=recorder.update_resources,
     )
-    resource_monitor.start()
+    with profiler.timed("resource_monitor_startup"):
+        resource_monitor.start()
     warning_console = console(sys.stderr)
     notification_service = build_notification_service(
         config=runtime_params,
@@ -227,6 +241,7 @@ def run_workflow(
                 secret_resolver=secret_resolver,
                 event_bus=bus,
                 trust_workspace=trust_workspace,
+                profiler=profiler,
             )
             if renderer is not None:
                 renderer.start(planned_tasks=planned_tasks)
@@ -247,9 +262,12 @@ def run_workflow(
                     phase="workflow_execute_seconds",
                     seconds=time.perf_counter() - run_started,
                 )
-                resource_summary = resource_monitor.stop()
-                recorder.finalize(status="failed", error=str(exc), resources=resource_summary)
-                run_summary = RunSummary.load(recorder.run_dir)
+                with profiler.timed("resource_monitor_shutdown"):
+                    resource_summary = resource_monitor.stop()
+                with profiler.timed("provenance_finalize"):
+                    recorder.finalize(status="failed", error=str(exc), resources=resource_summary)
+                with profiler.timed("manifest_load"):
+                    run_summary = RunSummary.load(recorder.run_dir)
                 bus.emit(
                     RunCompleted(
                         run_id=run_id,
@@ -265,22 +283,29 @@ def run_workflow(
                         renderer=renderer,
                         verbose=output_mode == "verbose",
                     )
-                    renderer.finish(
-                        elapsed=time.perf_counter() - run_started,
-                        success=False,
-                        resources=resource_summary,
-                        failure_details=failure_details,
-                    )
+                    with profiler.timed("renderer_finish"):
+                        renderer.finish(
+                            elapsed=time.perf_counter() - run_started,
+                            success=False,
+                            resources=resource_summary,
+                            failure_details=failure_details,
+                        )
                     print(f"Run directory: {recorder.run_dir}", file=sys.stderr)
+                if profiler.enabled:
+                    recorder.set_profile(profile=profiler.snapshot())
+                    _print_profile_table(console=rich_console, profile=profiler.snapshot())
                 raise
 
-            resource_summary = resource_monitor.stop()
+            with profiler.timed("resource_monitor_shutdown"):
+                resource_summary = resource_monitor.stop()
             recorder.add_run_timing(
                 phase="workflow_execute_seconds",
                 seconds=time.perf_counter() - run_started,
             )
-            recorder.finalize(status="succeeded", resources=resource_summary)
-            run_summary = RunSummary.load(recorder.run_dir)
+            with profiler.timed("provenance_finalize"):
+                recorder.finalize(status="succeeded", resources=resource_summary)
+            with profiler.timed("manifest_load"):
+                run_summary = RunSummary.load(recorder.run_dir)
             bus.emit(
                 RunCompleted(
                     run_id=run_id,
@@ -289,16 +314,20 @@ def run_workflow(
                 )
             )
             if renderer is not None:
-                renderer.finish(
-                    elapsed=time.perf_counter() - run_started,
-                    success=True,
-                    resources=resource_summary,
-                    notebooks=_render_notebooks(
-                        run_summary=run_summary,
-                        renderer=renderer,
-                    ),
-                    assets=_render_assets(run_summary=run_summary),
-                )
+                with profiler.timed("renderer_finish"):
+                    renderer.finish(
+                        elapsed=time.perf_counter() - run_started,
+                        success=True,
+                        resources=resource_summary,
+                        notebooks=_render_notebooks(
+                            run_summary=run_summary,
+                            renderer=renderer,
+                        ),
+                        assets=_render_assets(run_summary=run_summary),
+                    )
+            if profiler.enabled:
+                recorder.set_profile(profile=profiler.snapshot())
+                _print_profile_table(console=rich_console, profile=profiler.snapshot())
     finally:
         if notification_service is not None:
             notification_service.close()
@@ -340,6 +369,34 @@ def _combined_log_tail(*, run_dir: Path, task: TaskSummary, lines: int) -> list[
     if isinstance(task.stderr_log, str):
         combined.extend(tail_text(run_dir / task.stderr_log, lines=lines))
     return combined[-lines:]
+
+
+def _print_profile_table(
+    *,
+    console,
+    profile: dict[str, dict[str, float | int]],
+) -> None:
+    """Print a Rich profile table summarising recorded phase timings."""
+    from rich.table import Table
+
+    table = Table(title="Runtime Profile", show_lines=False)
+    table.add_column("phase")
+    table.add_column("seconds", justify="right")
+    table.add_column("count", justify="right")
+
+    rows = sorted(
+        profile.items(),
+        key=lambda item: float(item[1].get("seconds", 0.0)),
+        reverse=True,
+    )
+    for phase, values in rows:
+        table.add_row(
+            phase,
+            f"{float(values.get('seconds', 0.0)):.4f}",
+            str(int(values.get("count", 0))),
+        )
+    console.print("")
+    console.print(table)
 
 
 def _discover_flow(module: ModuleType) -> FlowDef:

--- a/ginkgo/core/expr.py
+++ b/ginkgo/core/expr.py
@@ -33,6 +33,8 @@ class Expr(Generic[T]):
     args: dict[str, object] = field(default_factory=dict)
     mapped: bool = False
     display_label_parts: tuple[str, ...] = field(default_factory=tuple, repr=False)
+    concurrency_group: str | None = field(default=None, repr=False)
+    concurrency_group_limit: int | None = field(default=None, repr=False)
 
     @property
     def output(self) -> _OutputProxy:
@@ -141,14 +143,43 @@ class ExprList(Generic[T]):
     def __iter__(self):
         return iter(self.exprs)
 
-    def map(self, **varying: Any) -> ExprList[T]:
-        """Extend each existing branch by zipping new varying arguments."""
+    def map(self, *, max_concurrent: int | None = None, **varying: Any) -> ExprList[T]:
+        """Extend each existing branch by zipping new varying arguments.
+
+        Parameters
+        ----------
+        max_concurrent : int | None
+            When set, the scheduler will run at most this many of the
+            generated branches concurrently. Independent of the global
+            ``--jobs`` and ``--cores`` budgets.
+        **varying
+            Per-branch keyword arguments.
+        """
         from ginkgo.core.task import _fan_out_expr_list
 
-        return _fan_out_expr_list(expr_list=self, varying=varying, mode="zip")
+        return _fan_out_expr_list(
+            expr_list=self,
+            varying=varying,
+            mode="zip",
+            max_concurrent=max_concurrent,
+        )
 
-    def product_map(self, **varying: Any) -> ExprList[T]:
-        """Extend each existing branch across Cartesian varying arguments."""
+    def product_map(self, *, max_concurrent: int | None = None, **varying: Any) -> ExprList[T]:
+        """Extend each existing branch across Cartesian varying arguments.
+
+        Parameters
+        ----------
+        max_concurrent : int | None
+            When set, the scheduler will run at most this many of the
+            generated branches concurrently.
+        **varying
+            Per-branch keyword arguments.
+        """
         from ginkgo.core.task import _fan_out_expr_list
 
-        return _fan_out_expr_list(expr_list=self, varying=varying, mode="product")
+        return _fan_out_expr_list(
+            expr_list=self,
+            varying=varying,
+            mode="product",
+            max_concurrent=max_concurrent,
+        )

--- a/ginkgo/core/task.py
+++ b/ginkgo/core/task.py
@@ -36,6 +36,16 @@ class TaskDef:
         Additional retry attempts after the initial execution.
     kind : str
         Execution contract for the task body.
+    threads : int
+        Static CPU footprint for the scheduler. Used as the task's core
+        budget against ``--cores`` and made available to the task body when
+        the function signature declares a ``threads`` parameter. Shell tasks
+        also receive ``GINKGO_THREADS=<n>`` in the subprocess environment.
+    export_thread_env : bool
+        When ``True``, shell tasks additionally receive ``OMP_NUM_THREADS``,
+        ``MKL_NUM_THREADS``, ``OPENBLAS_NUM_THREADS``, and
+        ``NUMEXPR_NUM_THREADS`` set to the declared thread count. Default is
+        ``False`` so existing tool configuration is not silently overridden.
     """
 
     fn: Callable[..., Any]
@@ -43,6 +53,8 @@ class TaskDef:
     version: int = 1
     retries: int = 0
     kind: str = "python"
+    threads: int = 1
+    export_thread_env: bool = False
     _signature: inspect.Signature = field(init=False, repr=False)
     _type_hints: dict[str, Any] = field(init=False, repr=False)
     _required_params: frozenset[str] = field(init=False, repr=False)
@@ -54,6 +66,8 @@ class TaskDef:
         if self.kind not in _TASK_KINDS:
             supported = ", ".join(sorted(_TASK_KINDS))
             raise ValueError(f"kind must be one of {{{supported}}}, got {self.kind!r}")
+        if self.threads < 1:
+            raise ValueError(f"threads must be at least 1, got {self.threads}")
 
         sig = inspect.signature(self.fn)
         hints = get_type_hints(self.fn)
@@ -130,6 +144,16 @@ class TaskDef:
         """
         supplied = set(kwargs.keys())
 
+        if "threads" in supplied:
+            import warnings
+
+            warnings.warn(
+                f"{self.fn.__name__}(): passing 'threads' as a function argument has no "
+                "scheduler effect. Declare the static thread count on the decorator "
+                "instead, e.g. @task(threads=N).",
+                stacklevel=2,
+            )
+
         # Validate that all supplied args are valid parameter names
         valid_params = set(self.all_params.keys())
         unknown = supplied - valid_params
@@ -174,13 +198,18 @@ class PartialCall:
     task_def: TaskDef
     fixed_args: dict[str, object] = field(default_factory=dict)
 
-    def map(self, **varying: Any) -> ExprList:
+    def map(self, *, max_concurrent: int | None = None, **varying: Any) -> ExprList:
         """Fan-out: produce one ``Expr`` per element by zipping varying columns.
 
         All varying argument columns must be the same length.
 
         Parameters
         ----------
+        max_concurrent : int | None
+            When set, the scheduler will run at most this many generated
+            branches concurrently, independently of ``--jobs`` and
+            ``--cores`` limits. Use this to throttle classes of work that
+            should not run in parallel (e.g. model training).
         **varying
             Keyword arguments where each value is an iterable (list, Series,
             or ``ExprList``) of per-element values.
@@ -197,11 +226,41 @@ class PartialCall:
         TypeError
             If a varying argument name is not a valid parameter.
         """
-        return _fan_out_partial_call(partial_call=self, varying=varying, mode="zip")
+        return _fan_out_partial_call(
+            partial_call=self,
+            varying=varying,
+            mode="zip",
+            max_concurrent=max_concurrent,
+        )
 
-    def product_map(self, **varying: Any) -> ExprList:
+    def product_map(self, *, max_concurrent: int | None = None, **varying: Any) -> ExprList:
         """Fan-out: produce one ``Expr`` per Cartesian combination."""
-        return _fan_out_partial_call(partial_call=self, varying=varying, mode="product")
+        return _fan_out_partial_call(
+            partial_call=self,
+            varying=varying,
+            mode="product",
+            max_concurrent=max_concurrent,
+        )
+
+
+def _next_concurrency_group_id(task_def: TaskDef) -> str:
+    """Return one process-unique concurrency group identifier."""
+    global _concurrency_group_counter
+    _concurrency_group_counter += 1
+    return f"map:{task_def.name}:{_concurrency_group_counter}"
+
+
+def _validate_max_concurrent(*, max_concurrent: int | None, function_name: str) -> None:
+    """Reject non-positive ``max_concurrent`` values."""
+    if max_concurrent is None:
+        return
+    if not isinstance(max_concurrent, int) or isinstance(max_concurrent, bool):
+        raise TypeError(
+            f"{function_name}() max_concurrent must be an integer, got "
+            f"{type(max_concurrent).__name__}"
+        )
+    if max_concurrent < 1:
+        raise ValueError(f"{function_name}() max_concurrent must be at least 1")
 
 
 def _fan_out_partial_call(
@@ -209,17 +268,21 @@ def _fan_out_partial_call(
     partial_call: PartialCall,
     varying: dict[str, Any],
     mode: _FanOutMode,
+    max_concurrent: int | None = None,
 ) -> ExprList:
     """Build an ``ExprList`` from one partially-applied task."""
+    function_name = _fan_out_function_name(mode=mode)
+    _validate_max_concurrent(max_concurrent=max_concurrent, function_name=function_name)
     columns = _materialize_varying_columns(
         task_def=partial_call.task_def,
         varying=varying,
-        function_name=_fan_out_function_name(mode=mode),
+        function_name=function_name,
     )
-    rows = _build_varying_rows(
-        columns=columns, mode=mode, function_name=_fan_out_function_name(mode=mode)
-    )
+    rows = _build_varying_rows(columns=columns, mode=mode, function_name=function_name)
     varying_keys = tuple(columns.keys())
+    group_id = (
+        _next_concurrency_group_id(partial_call.task_def) if max_concurrent is not None else None
+    )
     exprs = [
         Expr(
             task_def=partial_call.task_def,
@@ -231,6 +294,8 @@ def _fan_out_partial_call(
                 mode=mode,
                 varying_keys=varying_keys,
             ),
+            concurrency_group=group_id,
+            concurrency_group_limit=max_concurrent,
         )
         for row in rows
     ]
@@ -242,20 +307,20 @@ def _fan_out_expr_list(
     expr_list: ExprList,
     varying: dict[str, Any],
     mode: _FanOutMode,
+    max_concurrent: int | None = None,
 ) -> ExprList:
     """Extend each existing branch with additional fan-out rows."""
-    task_def = _expr_list_task_def(
-        expr_list=expr_list, function_name=_fan_out_function_name(mode=mode)
-    )
+    function_name = _fan_out_function_name(mode=mode)
+    _validate_max_concurrent(max_concurrent=max_concurrent, function_name=function_name)
+    task_def = _expr_list_task_def(expr_list=expr_list, function_name=function_name)
     columns = _materialize_varying_columns(
         task_def=task_def,
         varying=varying,
-        function_name=_fan_out_function_name(mode=mode),
+        function_name=function_name,
     )
-    rows = _build_varying_rows(
-        columns=columns, mode=mode, function_name=_fan_out_function_name(mode=mode)
-    )
+    rows = _build_varying_rows(columns=columns, mode=mode, function_name=function_name)
     varying_keys = tuple(columns.keys())
+    group_id = _next_concurrency_group_id(task_def) if max_concurrent is not None else None
     exprs = [
         Expr(
             task_def=task_def,
@@ -270,11 +335,20 @@ def _fan_out_expr_list(
                     varying_keys=varying_keys,
                 ),
             ),
+            concurrency_group=(
+                group_id if max_concurrent is not None else base_expr.concurrency_group
+            ),
+            concurrency_group_limit=(
+                max_concurrent if max_concurrent is not None else base_expr.concurrency_group_limit
+            ),
         )
         for base_expr in expr_list
         for row in rows
     ]
     return ExprList(exprs=exprs, task_def=task_def)
+
+
+_concurrency_group_counter: int = 0
 
 
 def _expr_list_task_def(*, expr_list: ExprList, function_name: str) -> TaskDef:
@@ -316,6 +390,16 @@ def _materialize_varying_columns(
         raise TypeError(
             f"{task_def.fn.__name__}() arguments are auto-managed by ginkgo: "
             f"{', '.join(sorted(supplied_managed))}"
+        )
+
+    if "threads" in varying:
+        import warnings
+
+        warnings.warn(
+            f"{task_def.fn.__name__}(): passing 'threads' as a fan-out argument has no "
+            "scheduler effect. Declare the static thread count on the decorator instead, "
+            "e.g. @task(threads=N).",
+            stacklevel=3,
         )
 
     return {key: list(column) for key, column in varying.items()}
@@ -405,6 +489,8 @@ def task(
     version: int = 1,
     retries: int = 0,
     kind: str = "python",
+    threads: int = 1,
+    export_thread_env: bool = False,
 ) -> Callable[[Callable[..., Any]], TaskDef]:
     """Decorator that turns a function into a lazy task definition.
 
@@ -426,6 +512,16 @@ def task(
         Additional retry attempts after the initial execution.
     kind : str
         Execution contract for the task body. Ignored when ``_kind`` is given.
+    threads : int
+        Static CPU footprint for the scheduler. The task body receives the
+        same value when its function signature declares a ``threads``
+        parameter; shell tasks also see ``GINKGO_THREADS=<n>`` in the
+        subprocess environment.
+    export_thread_env : bool
+        Export common BLAS/OpenMP thread environment variables
+        (``OMP_NUM_THREADS``, ``MKL_NUM_THREADS``, ``OPENBLAS_NUM_THREADS``,
+        ``NUMEXPR_NUM_THREADS``) to shell-task subprocesses. Default
+        ``False``.
 
     Returns
     -------
@@ -443,7 +539,15 @@ def task(
         raise ValueError(f"task kind specified twice: positional {_kind!r} and keyword {kind!r}")
 
     def decorator(fn: Callable[..., Any]) -> TaskDef:
-        return TaskDef(fn=fn, env=env, version=version, retries=retries, kind=resolved_kind)
+        return TaskDef(
+            fn=fn,
+            env=env,
+            version=version,
+            retries=retries,
+            kind=resolved_kind,
+            threads=threads,
+            export_thread_env=export_thread_env,
+        )
 
     return decorator
 

--- a/ginkgo/runtime/caching/provenance.py
+++ b/ginkgo/runtime/caching/provenance.py
@@ -155,6 +155,31 @@ class RunProvenanceRecorder:
                 }
             )
 
+    def set_profile(self, *, profile: dict[str, dict[str, float | int]]) -> None:
+        """Replace the recorded profile snapshot with one provided by the caller.
+
+        Parameters
+        ----------
+        profile : dict
+            Mapping of phase name to ``{"seconds", "count"}`` records.
+        """
+        with self._lock:
+            timings = self._manifest.setdefault("timings", _empty_timings())
+            timings["profile"] = {
+                str(phase): {
+                    "seconds": _rounded_seconds(values.get("seconds", 0.0)),
+                    "count": int(values.get("count", 0)),
+                }
+                for phase, values in profile.items()
+            }
+            self._append_event(
+                {
+                    "event": "provenance_profile_set",
+                    "run_id": self.run_id,
+                    "profile": timings["profile"],
+                }
+            )
+
     def add_task_timing(self, *, node_id: int, phase: str, seconds: float) -> None:
         """Accumulate one task timing bucket without writing immediately."""
         if seconds <= 0:
@@ -594,6 +619,7 @@ def _empty_timings() -> dict[str, Any]:
     return {
         "run": {},
         "task_phase_totals": {},
+        "profile": {},
     }
 
 
@@ -665,6 +691,12 @@ def _replay_provenance_events(
             seconds = event.get("seconds")
             if isinstance(phase, str) and isinstance(seconds, int | float):
                 run_timings[phase] = _rounded_seconds(run_timings.get(phase, 0.0) + seconds)
+            continue
+
+        if event_name == "provenance_profile_set":
+            profile = event.get("profile")
+            if isinstance(profile, dict):
+                timings["profile"] = dict(profile)
             continue
 
         if event_name == "provenance_task_timing":

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -56,6 +56,7 @@ from ginkgo.runtime.events import (
 )
 from ginkgo.runtime.module_loader import resolve_module_file
 from ginkgo.runtime.caching.provenance import RunProvenanceRecorder
+from ginkgo.runtime.profiling import ProfileRecorder
 from ginkgo.runtime.scheduler import SchedulableTask, select_dispatch_subset
 from ginkgo.runtime.environment.secrets import (
     SecretResolver,
@@ -166,6 +167,8 @@ class _TaskNode:
     input_hashes: dict[str, Any] | None = None
     threads: int = 1
     memory_gb: int = 0
+    concurrency_group: str | None = None
+    concurrency_group_limit: int | None = None
     result: Any = MISSING
     tmp_paths: list[Path] = field(default_factory=list)
     transport_path: Path | None = None
@@ -199,6 +202,7 @@ class _ConcurrentEvaluator:
     secret_resolver: SecretResolver | None = None
     event_bus: EventBus | None = None
     trust_workspace: bool = False
+    profiler: ProfileRecorder | None = None
     _cache_store: CacheStore = field(init=False, repr=False)
     _asset_store: AssetStore = field(init=False, repr=False)
     _nodes: dict[int, _TaskNode] = field(default_factory=dict, init=False, repr=False)
@@ -231,6 +235,8 @@ class _ConcurrentEvaluator:
     _known_digests: dict[str, str] = field(default_factory=dict, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        if self.profiler is None:
+            self.profiler = ProfileRecorder(enabled=False)
         default_jobs = os.cpu_count() or 1
         self.jobs = default_jobs if self.jobs is None else self.jobs
         self.cores = self.jobs if self.cores is None else self.cores
@@ -322,12 +328,14 @@ class _ConcurrentEvaluator:
                         self._interrupt_running_work()
 
                     if self._failure is None:
-                        self._prepare_pending_nodes()
-                        self._finalize_dynamic_nodes()
-                        self._dispatch_ready_nodes(
-                            python_executor=python_executor,
-                            shell_executor=shell_executor,
-                        )
+                        with self.profiler.timed("scheduler_prepare"):
+                            self._prepare_pending_nodes()
+                            self._finalize_dynamic_nodes()
+                        with self.profiler.timed("scheduler_dispatch"):
+                            self._dispatch_ready_nodes(
+                                python_executor=python_executor,
+                                shell_executor=shell_executor,
+                            )
 
                         if self._is_root_resolved() and not self._running_futures:
                             return self._materialize(self._root_template)
@@ -335,11 +343,13 @@ class _ConcurrentEvaluator:
                         break
 
                     if self._running_futures:
-                        done, _ = wait(
-                            tuple(self._running_futures.keys()),
-                            return_when=FIRST_COMPLETED,
-                        )
-                        self._consume_completed_futures(done)
+                        with self.profiler.timed("scheduler_wait"):
+                            done, _ = wait(
+                                tuple(self._running_futures.keys()),
+                                return_when=FIRST_COMPLETED,
+                            )
+                        with self.profiler.timed("scheduler_consume_completed"):
+                            self._consume_completed_futures(done)
                         continue
 
                     if self._failure is not None:
@@ -457,6 +467,8 @@ class _ConcurrentEvaluator:
             node_id=node_id,
             expr=expr,
             dependency_ids=dependency_ids,
+            concurrency_group=expr.concurrency_group,
+            concurrency_group_limit=expr.concurrency_group_limit,
         )
         self._expr_nodes[expr_id] = node_id
         self._emit_event(
@@ -537,7 +549,7 @@ class _ConcurrentEvaluator:
         self._prepare_task_environment(node=node)
         self._record_task_metadata(node=node)
 
-        node.threads = self._task_threads(resolved_args)
+        node.threads = self._task_threads(node.task_def)
         node.memory_gb = self._task_memory_gb(resolved_args)
         if node.threads > self.cores:
             raise ValueError(
@@ -606,18 +618,21 @@ class _ConcurrentEvaluator:
         available_jobs = self.jobs - len(self._running_futures)
         available_cores = self.cores - self._running_cores()
         available_memory = None if self.memory is None else self.memory - self._running_memory_gb()
+        available_group_slots = self._available_group_slots(ready_nodes=ready_nodes)
         selected = select_dispatch_subset(
             ready_tasks=[
                 SchedulableTask(
                     node_id=node.node_id,
                     threads=node.threads,
                     memory_gb=node.memory_gb,
+                    concurrency_group=node.concurrency_group,
                 )
                 for node in ready_nodes
             ],
             jobs=available_jobs,
             cores=available_cores,
             memory=available_memory,
+            available_group_slots=available_group_slots,
         )
 
         for node_id in selected:
@@ -905,6 +920,12 @@ class _ConcurrentEvaluator:
                 resolved_args[name] = self._materialize(expr.args[name])
                 continue
 
+            if name == "threads":
+                # Inject the decorator-declared thread count so user code can
+                # use it for shell command interpolation or in-process work.
+                resolved_args[name] = task_def.threads
+                continue
+
             if parameter.default is not parameter.empty:
                 resolved_args[name] = parameter.default
                 continue
@@ -1102,6 +1123,36 @@ class _ConcurrentEvaluator:
         """Return the core footprint of currently running tasks."""
         return sum(self._nodes[node_id].threads for node_id, _ in self._running_futures.values())
 
+    def _available_group_slots(self, *, ready_nodes: list[_TaskNode]) -> dict[str, int]:
+        """Return the remaining concurrency budget per active group.
+
+        For each named concurrency group represented in the ready set, the
+        result contains the group's declared limit minus the number of tasks
+        from that group currently in flight.
+        """
+        active_groups: dict[str, int] = {}
+        for node in ready_nodes:
+            if node.concurrency_group is None or node.concurrency_group_limit is None:
+                continue
+            active_groups[node.concurrency_group] = node.concurrency_group_limit
+
+        if not active_groups:
+            return {}
+
+        running_per_group: dict[str, int] = {}
+        for node_id, _ in self._running_futures.values():
+            running_node = self._nodes[node_id]
+            if running_node.concurrency_group is None:
+                continue
+            running_per_group[running_node.concurrency_group] = (
+                running_per_group.get(running_node.concurrency_group, 0) + 1
+            )
+
+        return {
+            group_id: max(0, limit - running_per_group.get(group_id, 0))
+            for group_id, limit in active_groups.items()
+        }
+
     def _running_memory_gb(self) -> int:
         """Return the declared memory footprint of currently running tasks."""
         return sum(self._nodes[node_id].memory_gb for node_id, _ in self._running_futures.values())
@@ -1183,18 +1234,9 @@ class _ConcurrentEvaluator:
         future = python_executor.submit(run_task, payload)
         self._running_futures[future] = (node.node_id, "python")
 
-    def _task_threads(self, resolved_args: dict[str, Any]) -> int:
+    def _task_threads(self, task_def: TaskDef) -> int:
         """Return the scheduler core footprint for a task."""
-        raw_threads = resolved_args.get("threads", 1)
-        try:
-            threads = int(raw_threads)
-        except (TypeError, ValueError) as exc:
-            raise TypeError(f"threads must be an integer, got {raw_threads!r}") from exc
-
-        if threads < 1:
-            raise ValueError(f"threads must be at least 1, got {threads}")
-
-        return threads
+        return task_def.threads
 
     def _task_memory_gb(self, resolved_args: dict[str, Any]) -> int:
         """Return the scheduler memory footprint for a task in GiB."""
@@ -1606,7 +1648,8 @@ class _ConcurrentEvaluator:
     def _emit_event(self, event: object) -> None:
         """Emit a runtime event to the attached event bus, if any."""
         if self.event_bus is not None:
-            self.event_bus.emit(event)
+            with self.profiler.timed("event_emit"):
+                self.event_bus.emit(event)
 
     def _task_log_emitter(self, *, node: _TaskNode, stream: str) -> Any:
         """Return a task-log callback bound to one task node and stream."""

--- a/ginkgo/runtime/profiling.py
+++ b/ginkgo/runtime/profiling.py
@@ -1,0 +1,86 @@
+"""Coarse phase-timer aggregation for the ``--profile`` runtime mode.
+
+The :class:`ProfileRecorder` is a single object that accumulates wall-time
+samples for named phases. When the recorder is disabled (the default), every
+public method short-circuits to a no-op so the default ``ginkgo run`` path
+incurs no measurable overhead.
+
+The recorder is intentionally coarse: it aggregates per-phase totals and call
+counts, not function-level traces. Detailed function-level profiling is
+deliberately out of scope to keep the recording cost negligible and to prevent
+the act of measurement from distorting what is being measured.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator
+
+
+@dataclass(kw_only=True)
+class ProfileRecorder:
+    """Accumulate wall time and call counts for named runtime phases.
+
+    Parameters
+    ----------
+    enabled : bool
+        When ``False``, all recording methods are no-ops. The default value is
+        ``False`` so the recorder can be created unconditionally without cost.
+    """
+
+    enabled: bool = False
+    _seconds: dict[str, float] = field(default_factory=dict, init=False, repr=False)
+    _counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+
+    def record(self, *, phase: str, seconds: float) -> None:
+        """Add one observation of ``seconds`` to ``phase``."""
+        if not self.enabled or seconds <= 0:
+            return
+        self._seconds[phase] = self._seconds.get(phase, 0.0) + float(seconds)
+        self._counts[phase] = self._counts.get(phase, 0) + 1
+
+    @contextmanager
+    def timed(self, phase: str) -> Iterator[None]:
+        """Time the wrapped block and record it under ``phase``.
+
+        When the recorder is disabled this yields immediately and performs no
+        measurement.
+        """
+        if not self.enabled:
+            yield
+            return
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.record(phase=phase, seconds=time.perf_counter() - started)
+
+    def snapshot(self) -> dict[str, dict[str, float | int]]:
+        """Return the current per-phase totals as a JSON-serializable mapping.
+
+        Returns
+        -------
+        dict
+            Mapping of ``phase`` to ``{"seconds": float, "count": int}``.
+        """
+        return {
+            phase: {
+                "seconds": round(self._seconds[phase], 6),
+                "count": self._counts[phase],
+            }
+            for phase in self._seconds
+        }
+
+    def merge_into(self, other: "ProfileRecorder") -> None:
+        """Add this recorder's totals into ``other``.
+
+        Used to flush a pre-recorder buffer into the canonical recorder once it
+        becomes available later in the run.
+        """
+        if not other.enabled:
+            return
+        for phase, seconds in self._seconds.items():
+            other._seconds[phase] = other._seconds.get(phase, 0.0) + seconds
+            other._counts[phase] = other._counts.get(phase, 0) + self._counts[phase]

--- a/ginkgo/runtime/scheduler.py
+++ b/ginkgo/runtime/scheduler.py
@@ -20,11 +20,16 @@ class SchedulableTask:
         Core footprint for the task.
     memory_gb : int
         Declared memory footprint for the task in GiB.
+    concurrency_group : str | None
+        Optional named concurrency group. When set, the scheduler will
+        respect the corresponding entry in ``available_group_slots`` when
+        selecting tasks to dispatch.
     """
 
     node_id: int
     threads: int
     memory_gb: int
+    concurrency_group: str | None = None
 
 
 def select_dispatch_subset(
@@ -33,6 +38,7 @@ def select_dispatch_subset(
     jobs: int,
     cores: int,
     memory: int | None = None,
+    available_group_slots: dict[str, int] | None = None,
 ) -> list[int]:
     """Select a feasible subset of ready tasks to dispatch.
 
@@ -47,6 +53,10 @@ def select_dispatch_subset(
     memory : int | None
         Available memory budget in GiB for this cycle, or ``None`` when
         memory-aware scheduling is disabled.
+    available_group_slots : dict[str, int] | None
+        Remaining concurrency-group budgets after accounting for in-flight
+        tasks. The scheduler enforces ``sum(selected in group) <= slot``
+        for each group present in this mapping.
 
     Returns
     -------
@@ -57,7 +67,13 @@ def select_dispatch_subset(
     if jobs <= 0 or cores <= 0 or (memory is not None and memory < 0) or not tasks:
         return []
 
-    return _select_with_cp_sat(tasks=tasks, jobs=jobs, cores=cores, memory=memory)
+    return _select_with_cp_sat(
+        tasks=tasks,
+        jobs=jobs,
+        cores=cores,
+        memory=memory,
+        available_group_slots=available_group_slots or {},
+    )
 
 
 def _select_with_cp_sat(
@@ -66,6 +82,7 @@ def _select_with_cp_sat(
     jobs: int,
     cores: int,
     memory: int | None,
+    available_group_slots: dict[str, int],
 ) -> list[int]:
     """Select tasks using OR-Tools CP-SAT when available."""
     model = cp_model.CpModel()
@@ -75,6 +92,20 @@ def _select_with_cp_sat(
     model.Add(sum(task.threads * selected[task.node_id] for task in tasks) <= cores)
     if memory is not None:
         model.Add(sum(task.memory_gb * selected[task.node_id] for task in tasks) <= memory)
+
+    # Per-group concurrency limits — each named group consumes one slot per
+    # selected task; tasks already in flight have already been deducted from
+    # the caller-provided remaining budget.
+    grouped: dict[str, list[SchedulableTask]] = {}
+    for task in tasks:
+        if task.concurrency_group is None:
+            continue
+        grouped.setdefault(task.concurrency_group, []).append(task)
+    for group_id, group_tasks in grouped.items():
+        slot = available_group_slots.get(group_id)
+        if slot is None:
+            continue
+        model.Add(sum(selected[task.node_id] for task in group_tasks) <= max(0, int(slot)))
 
     total_selected = sum(selected.values())
     total_cores = sum(task.threads * selected[task.node_id] for task in tasks)

--- a/ginkgo/runtime/task_runners/shell.py
+++ b/ginkgo/runtime/task_runners/shell.py
@@ -55,6 +55,31 @@ class ShellTaskError(RuntimeError):
 # ----- Helpers --------------------------------------------------------------
 
 
+_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+
+def build_shell_subprocess_env(*, task_def: Any) -> dict[str, str]:
+    """Return the environment for a shell-task subprocess.
+
+    Always exports ``GINKGO_THREADS`` carrying the task's declared thread
+    count. When ``task_def.export_thread_env`` is ``True``, also exports the
+    common BLAS/OpenMP thread variables so off-the-shelf tools pick up the
+    declared budget without per-workflow boilerplate.
+    """
+    env = dict(os.environ)
+    threads = int(getattr(task_def, "threads", 1))
+    env["GINKGO_THREADS"] = str(threads)
+    if getattr(task_def, "export_thread_env", False):
+        for name in _THREAD_ENV_VARS:
+            env[name] = str(threads)
+    return env
+
+
 def remove_declared_output(path: Path) -> None:
     """Remove one pre-existing declared output before task execution."""
     if path.is_symlink() or path.is_file():
@@ -265,6 +290,7 @@ class ShellRunner:
         use_shell: bool,
         on_stdout: Any = None,
         on_stderr: Any = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         """Run a subprocess while tracking it for interrupt-time termination."""
         popen_kwargs: dict[str, Any] = {
@@ -275,6 +301,8 @@ class ShellRunner:
         }
         if os.name == "posix":
             popen_kwargs["start_new_session"] = True
+        if env is not None:
+            popen_kwargs["env"] = env
 
         process = subprocess.Popen(argv, **popen_kwargs)
         self.register(process=process)
@@ -352,6 +380,8 @@ class ShellRunner:
             argv = cmd
             use_shell = True
 
+        subprocess_env = build_shell_subprocess_env(task_def=node.task_def)
+
         stdout_handle = node.stdout_path.open("a", encoding="utf-8") if node.stdout_path else None
         stderr_handle = node.stderr_path.open("a", encoding="utf-8") if node.stderr_path else None
         user_log_handle = user_log_path.open("a", encoding="utf-8") if user_log_path else None
@@ -374,6 +404,7 @@ class ShellRunner:
                 use_shell=use_shell,
                 on_stdout=lambda chunk: emit_chunk(stream="stdout", chunk=chunk),
                 on_stderr=lambda chunk: emit_chunk(stream="stderr", chunk=chunk),
+                env=subprocess_env,
             )
         finally:
             if stdout_handle is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1293,3 +1293,69 @@ def main():
             "cache_key_changed",
             "source_hash_changed",
         }
+
+
+class TestCliRunProfile:
+    def test_run_profile_emits_table_and_persists_snapshot(self) -> None:
+        from ginkgo.runtime.caching.provenance import load_manifest
+
+        Path("workflow.py").write_text(
+            """
+from ginkgo import flow, task
+
+@task()
+def hello() -> str:
+    return "ok"
+
+@flow
+def main():
+    return hello()
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "workflow.py", "--profile", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "Runtime Profile" in result.stdout
+        assert "scheduler_dispatch" in result.stdout
+        assert "evaluator_validate" in result.stdout
+
+        run_dir = _extract_run_dir(result.stdout)
+        manifest = load_manifest(run_dir)
+        profile = manifest["timings"]["profile"]
+        assert "scheduler_dispatch" in profile
+        assert profile["scheduler_dispatch"]["seconds"] > 0
+        assert profile["scheduler_dispatch"]["count"] >= 1
+
+        inspect = _run_cli("inspect", "run", run_dir.name, cwd=Path.cwd())
+        assert inspect.returncode == 0, inspect.stderr
+        inspect_payload = json.loads(inspect.stdout)
+        assert "scheduler_dispatch" in inspect_payload["timings"]["profile"]
+
+    def test_run_without_profile_does_not_emit_table_or_snapshot(self) -> None:
+        from ginkgo.runtime.caching.provenance import load_manifest
+
+        Path("workflow.py").write_text(
+            """
+from ginkgo import flow, task
+
+@task()
+def hello() -> str:
+    return "ok"
+
+@flow
+def main():
+    return hello()
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "workflow.py", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "Runtime Profile" not in result.stdout
+
+        run_dir = _extract_run_dir(result.stdout)
+        manifest = load_manifest(run_dir)
+        assert manifest["timings"]["profile"] == {}

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -377,7 +377,9 @@ class TestContainerShellE2E:
         output_file = tmp_path / "result.txt"
         captured_argv: list[Any] = []
 
-        def mock_run_subprocess(self_runner, *, argv, use_shell, on_stdout=None, on_stderr=None):
+        def mock_run_subprocess(
+            self_runner, *, argv, use_shell, on_stdout=None, on_stderr=None, **kwargs
+        ):
             captured_argv.append(argv)
             output_file.write_text("ok\n")
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
@@ -434,7 +436,9 @@ class TestContainerShellE2E:
 
         from ginkgo.runtime.task_runners.shell import ShellRunner
 
-        def mock_run_subprocess(self_runner, *, argv, use_shell, on_stdout=None, on_stderr=None):
+        def mock_run_subprocess(
+            self_runner, *, argv, use_shell, on_stdout=None, on_stderr=None, **kwargs
+        ):
             output_file.write_text("ok\n")
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -400,7 +400,12 @@ class TestEvaluate:
         calls: list[str] = []
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
             calls.append(command)
@@ -483,6 +488,7 @@ class TestEvaluate:
             use_shell: bool,
             on_stdout: Any = None,
             on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
             if "import ipykernel" in command:
@@ -577,7 +583,12 @@ class TestEvaluate:
         calls: list[str] = []
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
             calls.append(command)
@@ -637,7 +648,12 @@ class TestEvaluate:
         bus.subscribe(events.append)
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
             if "import ipykernel" in command:
@@ -680,7 +696,12 @@ class TestEvaluate:
         evaluator = _ConcurrentEvaluator(jobs=1, cores=1)
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
             if "import ipykernel" in command:
@@ -730,7 +751,12 @@ class TestEvaluate:
         install_calls = 0
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             nonlocal install_calls
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
@@ -794,7 +820,12 @@ class TestEvaluate:
         )
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = str(argv)
             if "export html" in command:
@@ -823,7 +854,12 @@ class TestEvaluate:
         expr = python_script_task(script_path=str(script_path), output_path=str(output_path))
 
         def fake_run_subprocess(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             # Simulate the script creating its declared output.
             output_path.write_text("done\n", encoding="utf-8")
@@ -843,7 +879,12 @@ class TestEvaluate:
         expr_v1 = notebook_ipynb_task(notebook_path=str(nb_path), value=1)
 
         def fake_subprocess_ok(
-            *, argv: str | list[str], use_shell: bool, on_stdout: Any = None, on_stderr: Any = None
+            *,
+            argv: str | list[str],
+            use_shell: bool,
+            on_stdout: Any = None,
+            on_stderr: Any = None,
+            **kwargs: Any,
         ) -> subprocess.CompletedProcess[str]:
             command = " ".join(argv) if isinstance(argv, list) else str(argv)
             if "import ipykernel" in command:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -79,6 +79,7 @@ def _mock_docker() -> Iterator[None]:
         use_shell: bool,
         on_stdout: Any = None,
         on_stderr: Any = None,
+        **kwargs: Any,
     ) -> subprocess.CompletedProcess[str]:
         # Docker argv: ["docker", "run", ..., "bash", "-c", "<cmd>"]
         if isinstance(argv, list) and argv and argv[0] == "docker":
@@ -130,6 +131,7 @@ def _mock_notebook_tools() -> Iterator[None]:
         use_shell: bool,
         on_stdout: Any = None,
         on_stderr: Any = None,
+        **kwargs: Any,
     ) -> subprocess.CompletedProcess[str]:
         if isinstance(argv, str) and "papermill" in argv:
             parts = shlex.split(argv)

--- a/tests/test_max_concurrent.py
+++ b/tests/test_max_concurrent.py
@@ -1,0 +1,119 @@
+"""Phase 20 — ``.map(max_concurrent=N)`` scheduler tests."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from ginkgo import evaluate, flow, task
+from ginkgo.runtime.scheduler import SchedulableTask, select_dispatch_subset
+
+
+class TestSchedulerGroupConstraint:
+    def test_group_limit_caps_selected_count(self) -> None:
+        ready = [
+            SchedulableTask(node_id=i, threads=1, memory_gb=0, concurrency_group="g")
+            for i in range(5)
+        ]
+
+        selected = select_dispatch_subset(
+            ready_tasks=ready,
+            jobs=10,
+            cores=10,
+            available_group_slots={"g": 2},
+        )
+
+        assert len(selected) == 2
+
+    def test_zero_remaining_slot_blocks_dispatch(self) -> None:
+        ready = [
+            SchedulableTask(node_id=1, threads=1, memory_gb=0, concurrency_group="g"),
+            SchedulableTask(node_id=2, threads=1, memory_gb=0, concurrency_group="g"),
+        ]
+        selected = select_dispatch_subset(
+            ready_tasks=ready,
+            jobs=4,
+            cores=4,
+            available_group_slots={"g": 0},
+        )
+        assert selected == []
+
+    def test_unrelated_tasks_unaffected_by_group_limit(self) -> None:
+        ready = [
+            SchedulableTask(node_id=1, threads=1, memory_gb=0, concurrency_group="g"),
+            SchedulableTask(node_id=2, threads=1, memory_gb=0, concurrency_group="g"),
+            SchedulableTask(node_id=3, threads=1, memory_gb=0),
+            SchedulableTask(node_id=4, threads=1, memory_gb=0),
+        ]
+        selected = select_dispatch_subset(
+            ready_tasks=ready,
+            jobs=10,
+            cores=10,
+            available_group_slots={"g": 1},
+        )
+        # 1 from group g, plus both ungrouped tasks
+        in_group = [n for n in selected if n in {1, 2}]
+        ungrouped = [n for n in selected if n in {3, 4}]
+        assert len(in_group) == 1
+        assert sorted(ungrouped) == [3, 4]
+
+
+# ----- End-to-end fan-out test -----------------------------------------------
+
+
+_intervals_dir: dict[str, Path] = {}
+
+
+@task()
+def _record_interval(item: str) -> dict[str, float]:
+    started = time.perf_counter()
+    time.sleep(0.1)
+    ended = time.perf_counter()
+    return {"item": float(hash(item) % 1000), "start": started, "end": ended}
+
+
+@flow
+def _capped_flow(items: list[str]):
+    return _record_interval().map(item=items, max_concurrent=1)
+
+
+@flow
+def _uncapped_flow(items: list[str]):
+    return _record_interval().map(item=items)
+
+
+def _peak_overlap(records: list[dict[str, float]]) -> int:
+    points: list[tuple[float, int]] = []
+    for record in records:
+        points.append((record["start"], 1))
+        points.append((record["end"], -1))
+    points.sort(key=lambda item: (item[0], item[1]))
+    active = 0
+    peak = 0
+    for _, delta in points:
+        active += delta
+        peak = max(peak, active)
+    return peak
+
+
+class TestMapMaxConcurrent:
+    def test_max_concurrent_one_serializes_branches(self) -> None:
+        items = [f"item_{i}" for i in range(4)]
+        records = evaluate(_capped_flow(items=items), jobs=4, cores=4)
+        assert len(records) == 4
+        assert _peak_overlap(records) == 1
+
+    def test_uncapped_runs_concurrently(self) -> None:
+        items = [f"item_{i}" for i in range(4)]
+        records = evaluate(_uncapped_flow(items=items), jobs=4, cores=4)
+        assert _peak_overlap(records) >= 2
+
+    def test_max_concurrent_must_be_positive(self) -> None:
+        @task()
+        def step(x: int) -> int:
+            return x
+
+        with pytest.raises(ValueError, match="max_concurrent must be at least 1"):
+            step().map(x=[1, 2], max_concurrent=0)

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,44 @@
+"""Tests for the runtime profile recorder."""
+
+from __future__ import annotations
+
+import time
+
+from ginkgo.runtime.profiling import ProfileRecorder
+
+
+def test_disabled_recorder_records_nothing() -> None:
+    recorder = ProfileRecorder(enabled=False)
+    with recorder.timed("phase_a"):
+        time.sleep(0.001)
+    recorder.record(phase="phase_b", seconds=0.5)
+    assert recorder.snapshot() == {}
+
+
+def test_enabled_recorder_accumulates_seconds_and_counts() -> None:
+    recorder = ProfileRecorder(enabled=True)
+    recorder.record(phase="phase_a", seconds=0.1)
+    recorder.record(phase="phase_a", seconds=0.2)
+    recorder.record(phase="phase_b", seconds=0.05)
+
+    snapshot = recorder.snapshot()
+    assert snapshot["phase_a"]["count"] == 2
+    assert snapshot["phase_a"]["seconds"] == 0.3
+    assert snapshot["phase_b"]["count"] == 1
+    assert snapshot["phase_b"]["seconds"] == 0.05
+
+
+def test_timed_context_records_elapsed() -> None:
+    recorder = ProfileRecorder(enabled=True)
+    with recorder.timed("phase"):
+        time.sleep(0.005)
+    snapshot = recorder.snapshot()
+    assert snapshot["phase"]["count"] == 1
+    assert snapshot["phase"]["seconds"] >= 0.005
+
+
+def test_negative_seconds_are_ignored() -> None:
+    recorder = ProfileRecorder(enabled=True)
+    recorder.record(phase="phase", seconds=0.0)
+    recorder.record(phase="phase", seconds=-1.0)
+    assert recorder.snapshot() == {}

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -370,3 +370,43 @@ class TestPartialCallMap:
 
         result = process().map(sample=["s1"]).product_map(lr=[0.01], epochs=[10])
         assert result[0].display_label_parts == ("s1", "lr=0.01", "epochs=10")
+
+
+class TestTaskThreadsContract:
+    def test_threads_default_is_one(self):
+        @task()
+        def f() -> int:
+            return 0
+
+        assert f.threads == 1
+        assert f.export_thread_env is False
+
+    def test_threads_decorator_value(self):
+        @task(threads=4)
+        def f() -> int:
+            return 0
+
+        assert f.threads == 4
+
+    def test_threads_must_be_at_least_one(self):
+        with pytest.raises(ValueError, match="threads must be at least 1"):
+
+            @task(threads=0)
+            def f() -> int:
+                return 0
+
+    def test_threads_kwarg_at_call_warns(self):
+        @task(threads=2)
+        def f(x: int = 1, threads: int = 1) -> int:
+            return x
+
+        with pytest.warns(UserWarning, match="passing 'threads' as a function argument"):
+            f(threads=4)
+
+    def test_threads_in_map_warns(self):
+        @task(threads=2)
+        def f(x: int, threads: int = 1) -> int:
+            return x
+
+        with pytest.warns(UserWarning, match="passing 'threads' as a fan-out argument"):
+            f().map(x=[1, 2], threads=[1, 2])

--- a/tests/test_task_threads.py
+++ b/tests/test_task_threads.py
@@ -1,0 +1,94 @@
+"""Phase 20 — explicit per-task thread declaration tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ginkgo import evaluate, flow, shell, task
+from ginkgo.runtime.task_runners.shell import build_shell_subprocess_env
+
+
+@task(threads=4)
+def _big_task() -> str:
+    return "ok"
+
+
+@flow
+def _big_flow():
+    return _big_task()
+
+
+@task(threads=3)
+def _report_threads(threads: int = 1) -> int:
+    return threads
+
+
+@flow
+def _report_flow():
+    return _report_threads()
+
+
+@task("shell", threads=5)
+def _shell_step_default() -> str:
+    return shell(cmd="true", output="out.txt")
+
+
+@task("shell", threads=6, export_thread_env=True)
+def _shell_step_export() -> str:
+    return shell(cmd="true", output="out.txt")
+
+
+@task("shell", threads=2)
+def _shell_step_inherit() -> str:
+    return shell(cmd="true", output="out.txt")
+
+
+@task("shell", threads=7)
+def _write_threads(out_path: str) -> str:
+    return shell(
+        cmd=f'sh -c "echo $GINKGO_THREADS > {out_path}"',
+        output=out_path,
+    )
+
+
+@flow
+def _write_threads_flow(out_path: str):
+    return _write_threads(out_path=out_path)
+
+
+class TestSchedulerReadsDecoratorThreads:
+    def test_oversize_threads_rejected_against_cores_budget(self) -> None:
+        with pytest.raises(ValueError, match="requires 4 cores but only 1 are available"):
+            evaluate(_big_flow(), jobs=1, cores=1)
+
+    def test_decorator_threads_value_injected_into_function(self) -> None:
+        result = evaluate(_report_flow(), jobs=1, cores=4)
+        assert result == 3
+
+
+class TestShellSubprocessEnv:
+    def test_ginkgo_threads_always_set(self) -> None:
+        env = build_shell_subprocess_env(task_def=_shell_step_default)
+        assert env["GINKGO_THREADS"] == "5"
+        assert env.get("OMP_NUM_THREADS", "") != "5"
+
+    def test_export_thread_env_sets_blas_vars(self) -> None:
+        env = build_shell_subprocess_env(task_def=_shell_step_export)
+        assert env["GINKGO_THREADS"] == "6"
+        assert env["OMP_NUM_THREADS"] == "6"
+        assert env["MKL_NUM_THREADS"] == "6"
+        assert env["OPENBLAS_NUM_THREADS"] == "6"
+        assert env["NUMEXPR_NUM_THREADS"] == "6"
+
+    def test_inherits_existing_environment(self) -> None:
+        env = build_shell_subprocess_env(task_def=_shell_step_inherit)
+        assert "PATH" in env or "HOME" in env
+
+
+class TestShellTaskPropagatesThreads:
+    def test_shell_subprocess_sees_ginkgo_threads(self, tmp_path: Path) -> None:
+        out_path = tmp_path / "threads.txt"
+        evaluate(_write_threads_flow(out_path=str(out_path)), jobs=1, cores=8)
+        assert out_path.read_text(encoding="utf-8").strip() == "7"

--- a/tests/test_vw7_resources.py
+++ b/tests/test_vw7_resources.py
@@ -63,7 +63,7 @@ def _compute_peaks(intervals: list[dict[str, object]]) -> tuple[int, int, int]:
     return peak_tasks, peak_cores, peak_heavy
 
 
-@task()
+@task(threads=8)
 def heavy(item: str, events_dir: str, threads: int = 8) -> str:
     started_at = time.time()
     time.sleep(0.15)

--- a/tests/test_vw8_memory.py
+++ b/tests/test_vw8_memory.py
@@ -74,7 +74,7 @@ def _compute_peaks(intervals: list[dict[str, object]]) -> tuple[int, int, int, i
     return peak_tasks, peak_cores, peak_memory, peak_high_memory
 
 
-@task()
+@task(threads=2)
 def high_mem(item: str, events_dir: str, threads: int = 2, memory_gb: int = 16) -> str:
     started_at = time.time()
     time.sleep(0.15)


### PR DESCRIPTION
## Summary

- **\`--profile\` runtime timing** — opt-in \`ginkgo run --profile\` records a coarse phase-timer breakdown (CLI startup, module import, flow construction, validation, scheduler prepare/dispatch/wait/consume, event emission, resource monitor lifecycle, provenance finalize, manifest load, renderer finish). Printed as a Rich table at run end, persisted under \`timings.profile\` in the manifest, surfaced by \`ginkgo inspect run\`. Default path is a no-op — the recorder does nothing when the flag is not set.
- **\`@task(threads=N)\` as the canonical thread contract** — task CPU footprint is now declared on the decorator instead of via an implicit \`threads\` function argument. The declared value is auto-injected into the task body when the function signature has a \`threads\` parameter, so shell f-strings and Python code can still reference it. Passing \`threads=\` at a call site or \`.map()\` now emits a migration warning.
- **Shell subprocess env propagation** — shell tasks always receive \`GINKGO_THREADS=<n>\` in their subprocess env. \`@task(threads=N, export_thread_env=True)\` also exports \`OMP_NUM_THREADS\`, \`MKL_NUM_THREADS\`, \`OPENBLAS_NUM_THREADS\`, and \`NUMEXPR_NUM_THREADS\` so off-the-shelf BLAS/OpenMP tools honour the budget without per-workflow boilerplate.
- **\`.map(max_concurrent=N)\`** — new kwarg on \`.map()\` and \`.product_map()\` caps how many branches from a single fan-out may run simultaneously, independent of \`--jobs\`/\`--cores\`. Implemented as a scheduler primitive: each fan-out gets an ephemeral concurrency group, and the CP-SAT model enforces \`sum(selected in group) <= limit\` alongside the existing cores/jobs/memory constraints. Lets \`model_training\` or single-license workloads serialise cleanly without abusing \`threads\`.
- **Rich benchmark comparison table** — \`benchmarks/harness.py\` now renders baseline-vs-observed comparisons as a coloured Rich table; JSON output and strict-mode failures are unchanged.

## Breaking change

The implicit "\`threads\` as a function argument sets the scheduler footprint" convention is removed. Workflows that declared \`def my_task(..., threads: int = 4)\` and relied on the scheduler reading that value must move the declaration to the decorator: \`@task(threads=4)\`. A warning fires at call sites that still pass \`threads=\` as a kwarg.

## Test plan

- [x] \`pytest tests/test_profiling.py\` — \`ProfileRecorder\` no-op and enabled-mode unit tests
- [x] \`pytest tests/test_cli.py::TestCliRunProfile\` — end-to-end \`--profile\` flag, manifest persistence, \`inspect run\` surfacing
- [x] \`pytest tests/test_task.py::TestTaskThreadsContract\` — decorator validation and call-site warnings
- [x] \`pytest tests/test_task_threads.py\` — scheduler enforcement, auto-injection, shell env propagation end-to-end
- [x] \`pytest tests/test_max_concurrent.py\` — scheduler-level group constraints and fan-out serialisation via timestamp overlap
- [x] \`pytest tests/test_benchmarks.py\` — Rich comparison table rendering
- [x] Full sweep: \`pytest tests/ --ignore=tests/envs\` — 442 passed (one pre-existing UI flake unrelated to this work, passes in isolation)
- [x] \`pixi run lint\` / ruff / ty — clean