### PR TITLE
Phase 5: model() asset wrapper and ginkgo models CLI

### DIFF
--- a/benchmarks/baselines/github-actions-linux.json
+++ b/benchmarks/baselines/github-actions-linux.json
@@ -77,13 +77,13 @@
     {
       "example": "ml",
       "mode": "cold",
-      "baseline_seconds": 2.055,
+      "baseline_seconds": 4.929,
       "max_regression_pct": 15.0
     },
     {
       "example": "ml",
       "mode": "cached",
-      "baseline_seconds": 0.747,
+      "baseline_seconds": 0.934,
       "max_regression_pct": 20.0
     }
   ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -608,6 +608,14 @@ kind-specific metadata by wrapping them with one of four sentinel factories:
   bokeh (HTML), or a path to an existing PNG/SVG/HTML file.
 - `text(body, name=..., format=..., metadata=...)` — string, dict (stored as
   JSON), or a `Path` to a text document. Format is `{plain, markdown, json}`.
+- `model(clf, name=..., framework=..., metrics=..., metadata=...)` — trained
+  ML models. Supports scikit-learn estimators, xgboost/lightgbm sklearn
+  wrappers (all via `joblib`), PyTorch `nn.Module` (via `torch.save`), and
+  Keras/TensorFlow (via the native `.keras` archive). `metrics` is a
+  first-class `dict[str, float]` field stored on the asset version so the
+  UI and `ginkgo models` can render training metrics without walking
+  free-form metadata. Optional `ginkgo[ml]` extra pulls `joblib` and
+  `scikit-learn`; other backends stay fully optional and lazy-imported.
 
 Wrappers follow the same pattern as `shell()`/`ShellExpr`: the user calls a
 factory inside the task body, returns the sentinel, and the evaluator
@@ -626,7 +634,9 @@ Implementation is split between:
 - `ginkgo/runtime/artifacts/asset_registration.py` — extended to unwrap
   sentinels at task completion, serialising each payload, storing the bytes
   through `ArtifactStore.store_bytes`, and registering an `AssetVersion` in
-  the wrapper-specific namespace (`table` / `array` / `fig` / `text`).
+  the wrapper-specific namespace (`table` / `array` / `fig` / `text` /
+  `model`). Dict return values are walked recursively so sentinels nested
+  inside task-level result dicts register alongside list/tuple outputs.
 
 Named outputs use the asset key `<task_fn>.<name>`. Unnamed outputs are
 indexed per kind as `<task_fn>.<kind>[<index>]`. Duplicate explicit names
@@ -640,6 +650,7 @@ Kind-specific metadata stored on each `AssetVersion`:
 - `array`: `sub_kind`, `shape`, `dtype`, `chunks`, `coordinates`, `byte_size`
 - `fig`: `sub_kind`, `source_format`, `byte_size`, `dimensions`
 - `text`: `sub_kind`, `format`, `byte_size`, `line_count`
+- `model`: `sub_kind`, `framework`, `metrics`, `byte_size`
 
 `ginkgo asset show <key>` renders this metadata through the CLI without
 re-reading the stored bytes. The UI asset payload surfaces the same fields
@@ -647,9 +658,9 @@ under a `kind_metadata` key for future frontend consumers.
 
 #### Rehydration on receive
 
-Downstream tasks that declare `pd.DataFrame`, `np.ndarray`, or `str`
-parameters receive the live Python object rather than the `AssetRef`
-produced by an upstream wrapper. The evaluator rehydrates wrapped refs
+Downstream tasks that declare `pd.DataFrame`, `np.ndarray`, `str`, or a
+trained-model parameter receive the live Python object rather than the
+`AssetRef` produced by an upstream wrapper. The evaluator rehydrates wrapped refs
 in `_resolve_task_args` via `_rehydrate_wrapped_refs`, which consults a
 per-run `LivePayloadRegistry` before falling back to the on-disk
 `wrapper_loaders.load_from_ref` path.
@@ -740,6 +751,7 @@ The current CLI supports:
 - `ginkgo asset ls`
 - `ginkgo asset versions`
 - `ginkgo asset inspect`
+- `ginkgo models`
 - `ginkgo cache ls`
 - `ginkgo cache explain`
 - `ginkgo cache clear`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -614,8 +614,9 @@ kind-specific metadata by wrapping them with one of four sentinel factories:
   Keras/TensorFlow (via the native `.keras` archive). `metrics` is a
   first-class `dict[str, float]` field stored on the asset version so the
   UI and `ginkgo models` can render training metrics without walking
-  free-form metadata. Optional `ginkgo[ml]` extra pulls `joblib` and
-  `scikit-learn`; other backends stay fully optional and lazy-imported.
+  free-form metadata. All ML backends (`joblib`/`scikit-learn`,
+  `torch`, `keras`, `xgboost`, `lightgbm`) are user-managed
+  dependencies, lazy-imported at serialisation/load time.
 
 Wrappers follow the same pattern as `shell()`/`ShellExpr`: the user calls a
 factory inside the task body, returns the sentinel, and the evaluator

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -109,46 +109,33 @@ These phases extend the existing asset catalog (file-backed, with `AssetKey`,
 `AssetVersion`, alias pointers, and lineage) into richer asset kinds and
 lifecycle tooling.
 
-### Phase 5 — ML Model Training Support
+### Phase 5 — ML Model Training Support (remaining)
 
-**Goal:** Add model-aware task support so that training progress is observable
-in real time, trained models are cataloged and listable, and parameter sweeps
-are a first-class fan-out primitive.
+**Goal:** Fold out the remaining ergonomics for ML workflows: parameter
+sweeps as a first-class fan-out primitive and real-time training progress
+events. The `model()` asset wrapper, `ginkgo models` CLI, and associated
+serialisation/rehydration plumbing have already shipped.
 
-**Depends on:** the existing asset catalog and `ArtifactStore`. Benefits from
-Phase 4 for upstream dataset lineage.
+**Depends on:** the existing asset catalog, `ArtifactStore`, and the
+shipped `model()` wrapper.
 
 #### Target DSL
 
 ```python
 from ginkgo import task, flow, model, file
 
-@task(kind="model")
-def train(data: file, *, lr: float, epochs: int):
+@task()
+def train(*, data: file, lr: float, epochs: int):
     clf = fit(load(data), lr=lr, epochs=epochs)
-    return model(clf, framework="sklearn")
+    return model(clf, metrics={"final_loss": ...})
 
 @flow
 def main():
     data = prepare_data(raw=file("data/raw.csv"))
-    models = train.sweep(data=data, lr=[0.001, 0.01, 0.1], epochs=[10, 50])
-    return models
+    return train.sweep(data=data, lr=[0.001, 0.01, 0.1], epochs=[10, 50])
 ```
 
 #### Deliverables
-
-**`kind="model"` — model assets with training progress:**
-
-- Add a `ModelResult` sentinel (following the `shell()` / `ShellExpr` pattern)
-  returned from `kind="model"` task bodies via a `model()` builder function.
-  The sentinel carries the model object, framework name, and optional metrics.
-- On task completion, the evaluator serializes the model, registers an immutable
-  asset version in the catalog (namespace `"model"`), and auto-captures scalar
-  task inputs as `params` in the version metadata.
-- Expose real-time training progress through runtime events so the Rich CLI
-  renderer can display per-task training status (e.g. epoch, loss) alongside
-  the existing task progress output.
-- `ginkgo model ls` — list trained model assets with latest metrics summary.
 
 **`.sweep()` — parameter exploration:**
 
@@ -159,35 +146,34 @@ def main():
 - Support `strategy="grid"` (Cartesian product, default) and `strategy="zip"`
   (positional pairing, equal-length lists required).
 
+**Training progress events:**
+
+- Expose real-time training progress through runtime events so the Rich CLI
+  renderer can display per-task training status (e.g. epoch, loss) alongside
+  the existing task progress output. The `--agent` mode includes the same
+  events in JSONL output.
+
 #### Key design points
 
-- Model assets are registered in the existing asset catalog — this phase does
-  not build a separate model registry. Serialization, versioning, and storage
-  go through the existing `ArtifactStore` and `AssetStore`.
-- `kind="model"` uses `execution_mode = "driver"` (same as shell) — the task
-  body runs on the scheduler, produces a sentinel, and the evaluator handles
-  serialization and storage.
-- Training progress events are emitted through the existing runtime event bus.
-  The Rich renderer displays them; `--agent` mode includes them in JSONL output.
 - `.sweep()` is deliberately simple (grid/zip only) — it is not a Bayesian
   optimization framework. Complex HPO should use external tools with Ginkgo
   tasks as the execution substrate.
+- Training progress events are emitted through the existing runtime event bus.
+  Framework integration stays optional; the event contract is framework-agnostic
+  (step, metric, optional total).
 - Evaluation, model promotion, alias management, and comparison tooling are
   deferred. If needed, they can be added incrementally without changing the
   core model asset contract.
 
 #### Validation
 
-- A `kind="model"` task serializes and registers an immutable model version with
-  auto-captured params and metrics.
-- Training progress events appear in Rich CLI output during execution.
-- `ginkgo model ls` lists trained models with metrics.
 - `train.sweep(data=d, lr=[0.01, 0.1], epochs=[10, 50], strategy="grid")`
   produces 4 tasks with correct parameter combinations.
 - `strategy="zip"` with equal-length lists produces N tasks; unequal lengths
   raise a clear error.
 - Re-running with identical inputs hits the cache; changed inputs create a new
   version.
+- Training progress events appear in Rich CLI output during execution.
 
 ---
 

--- a/examples/ml/ml_model_ops/modules/delivery.py
+++ b/examples/ml/ml_model_ops/modules/delivery.py
@@ -13,7 +13,6 @@ def write_delivery_manifest(
     candidate_scorecard: file,
     champion_report: file,
     serving_checklist: file,
-    candidate_reports: list[file],
 ) -> file:
     """Write a shell-generated artifact manifest for model review.
 
@@ -27,8 +26,6 @@ def write_delivery_manifest(
         JSON report for the promoted champion.
     serving_checklist : file
         CSV deployment checklist.
-    candidate_reports : list[file]
-        JSON evaluation reports for all candidates.
 
     Returns
     -------
@@ -41,7 +38,6 @@ def write_delivery_manifest(
         candidate_scorecard,
         champion_report,
         serving_checklist,
-        *candidate_reports,
     ]
     quoted_items = " ".join(shlex.quote(str(item)) for item in manifest_items)
     return shell(

--- a/examples/ml/ml_model_ops/modules/modeling.py
+++ b/examples/ml/ml_model_ops/modules/modeling.py
@@ -1,19 +1,32 @@
-"""Candidate evaluation tasks for the ML model ops example."""
+"""Candidate training and evaluation tasks for the ML model ops example.
+
+Each candidate fits a real scikit-learn pipeline on the engineered
+feature matrix, wraps the fitted estimator with :func:`ginkgo.model`,
+and returns a dict that carries both the model asset and the scalar
+metrics downstream reporting tasks need. The model assets are
+automatically registered in the local asset catalog and listable via
+``ginkgo models``.
+"""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
-from ginkgo import file, task
+from ginkgo import file, model, task
 
 
-def _safe_slug(value: str) -> str:
-    """Return a file-safe slug for candidate names."""
-    return "".join(ch if ch.isalnum() else "_" for ch in value.lower()).strip("_")
+_FEATURE_COLUMNS = [
+    "tenure_months",
+    "segment_weight",
+    "stickiness_score",
+    "ticket_burden",
+    "expansion_readiness",
+]
 
 
 @task()
@@ -23,118 +36,158 @@ def evaluate_candidate(
     ticket_penalty: float,
     decision_threshold: float,
     feature_matrix: pd.DataFrame,
-) -> file:
-    """Evaluate one model candidate against the feature matrix.
+) -> dict[str, Any]:
+    """Fit and score one logistic-regression candidate.
 
     Parameters
     ----------
     model_name : str
-        Candidate model identifier.
+        Candidate identifier used as the model asset name.
     weight_scale : float
-        Weight applied to expansion readiness.
+        Inverse regularisation strength forwarded as scikit-learn's
+        ``C`` parameter. Higher values mean less regularisation.
     ticket_penalty : float
-        Penalty weight applied to ticket burden.
+        Additional positive-class weight, scaled so candidates that
+        tolerate more false positives train more aggressively on
+        renewals.
     decision_threshold : float
-        Probability threshold for positive predictions.
+        Probability threshold applied to ``predict_proba`` when
+        converting scores to renewal decisions.
     feature_matrix : pandas.DataFrame
-        Derived feature matrix used for candidate scoring.
+        Derived feature matrix produced by
+        :func:`build_feature_matrix`.
 
     Returns
     -------
-    file
-        JSON report with candidate metrics and decision metadata.
+    dict
+        A report carrying the wrapped model asset, the scalar metrics,
+        and confusion-matrix details used by the reporting tasks. The
+        model is rehydrated into a live pipeline when a downstream
+        task consumes this report.
     """
-    scored = feature_matrix.copy()
-
-    # Keep candidate evaluation deterministic and lightweight for CI execution.
-    logit = (
-        scored["segment_weight"] * 0.8
-        + scored["stickiness_score"] * 0.11
-        + scored["expansion_readiness"] * weight_scale * 1.4
-        + scored["tenure_months"] * 0.03
-        - scored["ticket_burden"] * ticket_penalty * 2.5
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.metrics import (
+        accuracy_score,
+        f1_score,
+        precision_score,
+        recall_score,
     )
-    centered_logit = logit - float(logit.mean())
-    scored["predicted_probability"] = 1.0 / (1.0 + np.exp(-centered_logit))
-    scored["predicted_renewal"] = scored["predicted_probability"] >= decision_threshold
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
 
-    truth = scored["renewed"]
-    predicted = scored["predicted_renewal"]
-    true_positive = int((predicted & truth).sum())
-    true_negative = int((~predicted & ~truth).sum())
-    false_positive = int((predicted & ~truth).sum())
-    false_negative = int((~predicted & truth).sum())
+    features = feature_matrix[_FEATURE_COLUMNS].to_numpy(dtype=float)
+    labels = feature_matrix["renewed"].to_numpy().astype(bool)
 
-    accuracy = round(float((predicted == truth).mean()), 3)
-    precision = round(true_positive / max(true_positive + false_positive, 1), 3)
-    recall = round(true_positive / max(true_positive + false_negative, 1), 3)
+    pipeline = Pipeline(
+        [
+            ("scale", StandardScaler()),
+            (
+                "clf",
+                LogisticRegression(
+                    C=weight_scale,
+                    class_weight={False: 1.0, True: 1.0 + ticket_penalty},
+                    solver="liblinear",
+                    random_state=0,
+                ),
+            ),
+        ]
+    )
+    pipeline.fit(features, labels)
+
+    # Resubstitution metrics keep the example self-contained for CI;
+    # real pipelines should evaluate on a held-out fold.
+    positive_proba = pipeline.predict_proba(features)[:, 1]
+    predictions = positive_proba >= decision_threshold
+
+    true_positive = int(np.sum(predictions & labels))
+    true_negative = int(np.sum(~predictions & ~labels))
+    false_positive = int(np.sum(predictions & ~labels))
+    false_negative = int(np.sum(~predictions & labels))
+
+    metrics = {
+        "accuracy": round(float(accuracy_score(labels, predictions)), 3),
+        "precision": round(
+            float(precision_score(labels, predictions, zero_division=0)), 3
+        ),
+        "recall": round(float(recall_score(labels, predictions, zero_division=0)), 3),
+        "f1": round(float(f1_score(labels, predictions, zero_division=0)), 3),
+        "decision_threshold": float(decision_threshold),
+    }
     business_score = round(
-        accuracy * 45.0
-        + recall * 35.0
-        + float(scored["predicted_probability"].mean()) * 10.0
+        metrics["accuracy"] * 45.0
+        + metrics["recall"] * 35.0
+        + float(positive_proba.mean()) * 10.0
         - false_positive * 1.5,
         3,
     )
+    metrics["business_score"] = business_score
 
-    payload = {
+    top_segments = (
+        feature_matrix.assign(predicted_probability=positive_proba)
+        .groupby("segment", as_index=False)["predicted_probability"]
+        .mean()
+        .sort_values("predicted_probability", ascending=False)
+        .round({"predicted_probability": 3})
+        .to_dict(orient="records")
+    )
+
+    return {
+        "model": model(
+            pipeline,
+            name=model_name,
+            metrics=metrics,
+            metadata={"feature_columns": _FEATURE_COLUMNS},
+        ),
         "model_name": model_name,
-        "weight_scale": weight_scale,
-        "ticket_penalty": ticket_penalty,
-        "decision_threshold": decision_threshold,
-        "accounts": len(scored),
-        "accuracy": accuracy,
-        "precision": precision,
-        "recall": recall,
-        "business_score": business_score,
+        "weight_scale": float(weight_scale),
+        "ticket_penalty": float(ticket_penalty),
+        "decision_threshold": float(decision_threshold),
+        "accounts": int(len(feature_matrix)),
+        "metrics": metrics,
         "confusion_matrix": {
             "true_positive": true_positive,
             "true_negative": true_negative,
             "false_positive": false_positive,
             "false_negative": false_negative,
         },
-        "top_segments": (
-            scored.groupby("segment", as_index=False)["predicted_probability"]
-            .mean()
-            .sort_values("predicted_probability", ascending=False)
-            .round({"predicted_probability": 3})
-            .to_dict(orient="records")
-        ),
+        "top_segments": top_segments,
     }
-
-    output = Path(f"results/candidates/{_safe_slug(model_name)}.json")
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    return file(str(output))
 
 
 @task()
-def write_candidate_scorecard(candidate_reports: list[file], feature_profile: file) -> file:
-    """Aggregate candidate metrics into a scorecard.
+def write_candidate_scorecard(
+    candidate_reports: list[dict[str, Any]],
+    feature_profile: file,
+) -> file:
+    """Aggregate candidate metrics into a single scorecard CSV.
 
     Parameters
     ----------
-    candidate_reports : list[file]
-        Candidate JSON evaluation reports.
+    candidate_reports : list[dict]
+        One report per trained candidate, as produced by
+        :func:`evaluate_candidate`.
     feature_profile : file
-        Dataset-level feature summary.
+        Dataset-level feature summary from the inputs stage.
 
     Returns
     -------
     file
-        CSV scorecard across all model candidates.
+        CSV scorecard across all trained candidates, ranked by
+        business score.
     """
     feature_rows = int(pd.read_csv(feature_profile).loc[0, "accounts"])
     rows = []
-    for report_path in candidate_reports:
-        payload = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    for report in candidate_reports:
+        metrics = report["metrics"]
         rows.append(
             {
-                "model_name": payload["model_name"],
-                "accuracy": payload["accuracy"],
-                "precision": payload["precision"],
-                "recall": payload["recall"],
-                "business_score": payload["business_score"],
-                "decision_threshold": payload["decision_threshold"],
+                "model_name": report["model_name"],
+                "accuracy": metrics["accuracy"],
+                "precision": metrics["precision"],
+                "recall": metrics["recall"],
+                "f1": metrics["f1"],
+                "business_score": metrics["business_score"],
+                "decision_threshold": metrics["decision_threshold"],
                 "dataset_accounts": feature_rows,
             }
         )
@@ -149,25 +202,36 @@ def write_candidate_scorecard(candidate_reports: list[file], feature_profile: fi
 
 
 @task()
-def select_champion(candidate_reports: list[file]) -> file:
-    """Select the highest-scoring model candidate.
+def select_champion(candidate_reports: list[dict[str, Any]]) -> file:
+    """Select the highest-scoring candidate and freeze a JSON summary.
 
     Parameters
     ----------
-    candidate_reports : list[file]
-        Candidate JSON evaluation reports.
+    candidate_reports : list[dict]
+        One report per trained candidate.
 
     Returns
     -------
     file
         JSON report for the promoted champion candidate.
     """
-    payloads = [
-        json.loads(Path(report_path).read_text(encoding="utf-8")) for report_path in candidate_reports
-    ]
-    champion = max(payloads, key=lambda item: (float(item["business_score"]), str(item["model_name"])))
+    champion = max(
+        candidate_reports,
+        key=lambda item: (
+            float(item["metrics"]["business_score"]),
+            str(item["model_name"]),
+        ),
+    )
+    summary = {
+        "model_name": champion["model_name"],
+        "decision_threshold": champion["decision_threshold"],
+        "metrics": champion["metrics"],
+        "confusion_matrix": champion["confusion_matrix"],
+        "top_segments": champion["top_segments"],
+        "accounts": champion["accounts"],
+    }
 
     output = Path("results/champion_model.json")
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(champion, indent=2), encoding="utf-8")
+    output.write_text(json.dumps(summary, indent=2), encoding="utf-8")
     return file(str(output))

--- a/examples/ml/ml_model_ops/modules/reporting.py
+++ b/examples/ml/ml_model_ops/modules/reporting.py
@@ -40,12 +40,13 @@ def write_model_card(
     profile = pd.read_csv(feature_profile)
     holdout = pd.read_csv(holdout_summary)
     runner_up = scorecard.iloc[1]
+    champion_metrics = champion["metrics"]
 
     lines = [
         "# Champion Model Card",
         "",
         f"Champion: **{champion['model_name']}**",
-        f"Business score: **{champion['business_score']}**",
+        f"Business score: **{champion_metrics['business_score']}**",
         f"Decision threshold: **{champion['decision_threshold']}**",
         "",
         "## Dataset Profile",

--- a/examples/ml/ml_model_ops/workflow.py
+++ b/examples/ml/ml_model_ops/workflow.py
@@ -67,5 +67,4 @@ def main() -> file:
         candidate_scorecard=candidate_scorecard,
         champion_report=champion_report,
         serving_checklist=serving_checklist,
-        candidate_reports=candidate_reports,
     )

--- a/ginkgo/__init__.py
+++ b/ginkgo/__init__.py
@@ -25,6 +25,7 @@ _EXPORTS = {
     "array": ("ginkgo.core.wrappers", "array"),
     "asset": ("ginkgo.core.asset", "asset"),
     "fig": ("ginkgo.core.wrappers", "fig"),
+    "model": ("ginkgo.core.wrappers", "model"),
     "table": ("ginkgo.core.wrappers", "table"),
     "text": ("ginkgo.core.wrappers", "text"),
     "evaluate": ("ginkgo.runtime.evaluator", "evaluate"),

--- a/ginkgo/cli/app.py
+++ b/ginkgo/cli/app.py
@@ -15,6 +15,7 @@ from ginkgo.cli.commands.doctor import command_doctor
 from ginkgo.cli.commands.env import command_env
 from ginkgo.cli.commands.init import command_init
 from ginkgo.cli.commands.inspect import command_inspect
+from ginkgo.cli.commands.models import command_models
 from ginkgo.cli.commands.notebooks import command_notebooks
 from ginkgo.cli.commands.run import command_run
 from ginkgo.cli.commands.secrets import command_secrets
@@ -47,6 +48,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return command_init(args)
         if args.command == "inspect":
             return command_inspect(args)
+        if args.command == "models":
+            return command_models(args)
         if args.command == "notebooks":
             return command_notebooks(args)
         if args.command == "secrets":
@@ -140,6 +143,9 @@ def _build_parser() -> argparse.ArgumentParser:
     inspect_workflow_parser.add_argument("--config", action="append", default=[])
     inspect_run_parser = inspect_subparsers.add_parser("run")
     inspect_run_parser.add_argument("run_id")
+
+    models_parser = subparsers.add_parser("models")
+    models_parser.add_argument("run_id", nargs="?")
 
     subparsers.add_parser("notebooks")
 

--- a/ginkgo/cli/commands/asset.py
+++ b/ginkgo/cli/commands/asset.py
@@ -187,6 +187,8 @@ def render_asset_show(*, console, version) -> int:
         _render_fig_metadata(console=console, metadata=metadata)
     elif namespace == "text":
         _render_text_metadata(console=console, metadata=metadata)
+    elif namespace == "model":
+        _render_model_metadata(console=console, metadata=metadata)
     else:
         console.print(Panel.fit(repr(metadata), title="metadata"))
 
@@ -240,3 +242,31 @@ def _render_text_metadata(*, console, metadata: dict) -> None:
     console.print(f"Format: {metadata.get('format')}")
     console.print(f"Byte size: {metadata.get('byte_size', '-')}")
     console.print(f"Lines: {metadata.get('line_count', '-')}")
+
+
+def _render_model_metadata(*, console, metadata: dict) -> None:
+    """Print framework, byte size, and metrics for a model asset."""
+    console.print(f"Framework: {metadata.get('framework', '-')}")
+    console.print(f"Byte size: {metadata.get('byte_size', '-')}")
+    metrics = metadata.get("metrics") or {}
+    if not metrics:
+        console.print("Metrics: -")
+        return
+    metrics_table = Table(
+        box=box.SQUARE,
+        border_style="#0f766e",
+        header_style="bold #134e4a",
+        expand=False,
+    )
+    metrics_table.add_column("Metric", style="bold")
+    metrics_table.add_column("Value", justify="right")
+    for name in sorted(metrics):
+        metrics_table.add_row(str(name), _format_metric(metrics[name]))
+    console.print(metrics_table)
+
+
+def _format_metric(value: object) -> str:
+    """Format a metric value for CLI display."""
+    if isinstance(value, float):
+        return f"{value:.4g}"
+    return str(value)

--- a/ginkgo/cli/commands/models.py
+++ b/ginkgo/cli/commands/models.py
@@ -1,0 +1,109 @@
+"""``ginkgo models`` — list model assets produced by the latest run."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from rich import box
+from rich.table import Table
+
+from ginkgo.cli.common import console, resolve_run_dir
+from ginkgo.runtime.run_summary import RunSummary
+
+
+@dataclass(frozen=True, kw_only=True)
+class ModelRow:
+    """One display row for ``ginkgo models``."""
+
+    task: str
+    name: str
+    framework: str
+    metrics: str
+    version_id: str
+
+
+def command_models(args) -> int:
+    """Handle ``ginkgo models`` — list models produced by a run."""
+    is_tty = getattr(sys.stdout, "isatty", lambda: False)()
+    rich_console = console(sys.stdout, width=None if is_tty else 160)
+
+    run_id = getattr(args, "run_id", None)
+    try:
+        run_dir = resolve_run_dir(run_id)
+    except FileNotFoundError as exc:
+        rich_console.print(f"[red]{exc}[/]")
+        return 1
+
+    summary = RunSummary.load(run_dir)
+    rows = collect_model_rows(run_summary=summary)
+
+    rich_console.print(f"[bold green]🌿 ginkgo models[/] [dim]run={summary.run_id}[/]\n")
+    if not rows:
+        rich_console.print("[dim]No model assets in this run.[/]")
+        return 0
+
+    table = Table(
+        box=box.SQUARE,
+        border_style="#0f766e",
+        header_style="bold #134e4a",
+        expand=False,
+    )
+    table.add_column("Task", style="bold", overflow="fold")
+    table.add_column("Name", overflow="fold")
+    table.add_column("Framework")
+    table.add_column("Metrics", overflow="fold")
+    table.add_column("Version", overflow="fold")
+    for row in rows:
+        table.add_row(row.task, row.name, row.framework, row.metrics, row.version_id)
+    rich_console.print(table)
+    return 0
+
+
+def collect_model_rows(*, run_summary: RunSummary) -> list[ModelRow]:
+    """Return one row per model asset materialised in the run.
+
+    Parameters
+    ----------
+    run_summary : RunSummary
+        Parsed run summary whose task entries carry rendered asset refs.
+
+    Returns
+    -------
+    list[ModelRow]
+        Rows ordered by task node id, matching the run's task ordering.
+    """
+    rows: list[ModelRow] = []
+    for task in run_summary.tasks:
+        for asset in task.assets:
+            if asset.get("namespace") != "model":
+                continue
+            metadata = asset.get("metadata") or {}
+            rows.append(
+                ModelRow(
+                    task=task.base_name,
+                    name=str(asset.get("name", "-")),
+                    framework=str(metadata.get("framework", "-")),
+                    metrics=_format_metrics(metadata.get("metrics") or {}),
+                    version_id=str(asset.get("version_id", "-")),
+                )
+            )
+    return rows
+
+
+def _format_metrics(metrics: dict[str, Any]) -> str:
+    """Format a metrics dict as a compact ``name=value`` list."""
+    if not metrics:
+        return "-"
+    parts: list[str] = []
+    for name in sorted(metrics):
+        value = metrics[name]
+        if isinstance(value, float):
+            parts.append(f"{name}={value:.4g}")
+        else:
+            parts.append(f"{name}={value}")
+    return ", ".join(parts)
+
+
+__all__ = ["ModelRow", "collect_model_rows", "command_models"]

--- a/ginkgo/core/wrappers.py
+++ b/ginkgo/core/wrappers.py
@@ -104,7 +104,29 @@ class TextResult(_WrappedResult):
     text_format: Literal["plain", "markdown", "json"] = "plain"
 
 
-WrappedResult = TableResult | ArrayResult | FigureResult | TextResult
+@dataclass(frozen=True, kw_only=True)
+class ModelResult(_WrappedResult):
+    """Sentinel for trained-model asset outputs.
+
+    Produced by :func:`ginkgo.model`. The kind name is ``"model"``. The
+    ``sub_kind`` field carries the detected framework
+    (``"sklearn"`` / ``"xgboost"`` / ``"lightgbm"`` / ``"pytorch"`` /
+    ``"keras"``).
+
+    Parameters
+    ----------
+    metrics : dict[str, float]
+        Optional training or validation metrics captured at return time.
+        Stored as a first-class field so downstream tooling (``ginkgo
+        models``, the UI) can render them without walking free-form
+        metadata.
+    """
+
+    kind: str = "model"
+    metrics: dict[str, float] = field(default_factory=dict)
+
+
+WrappedResult = TableResult | ArrayResult | FigureResult | TextResult | ModelResult
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +211,35 @@ def _detect_fig_sub_kind(payload: Any) -> str:
         f"fig() does not support payload of type "
         f"{type(payload).__module__}.{type(payload).__name__}"
     )
+
+
+_MODEL_MODULE_ROOTS: dict[str, str] = {
+    "sklearn": "sklearn",
+    "xgboost": "xgboost",
+    "lightgbm": "lightgbm",
+    "torch": "pytorch",
+    "keras": "keras",
+    "tensorflow": "keras",
+}
+
+
+def _detect_model_sub_kind(payload: Any) -> str:
+    """Detect the framework sub-kind for a model payload.
+
+    Uses the top-level module of the payload's class. Scikit-learn-style
+    wrappers in other libraries (``xgboost.sklearn.XGBClassifier``,
+    ``lightgbm.sklearn.LGBMClassifier``) resolve to their owning package
+    rather than ``sklearn``, which keeps serialisation consistent with
+    the library that produced them.
+    """
+    root = _module_root(payload)
+    try:
+        return _MODEL_MODULE_ROOTS[root]
+    except KeyError as exc:
+        raise TypeError(
+            f"model() does not support payload of type "
+            f"{type(payload).__module__}.{type(payload).__name__}"
+        ) from exc
 
 
 def _detect_text_sub_kind(
@@ -324,6 +375,58 @@ def fig(
         payload=payload,
         name=name,
         sub_kind=sub_kind,
+        metadata=dict(metadata or {}),
+    )
+
+
+def model(
+    payload: Any,
+    *,
+    name: str | None = None,
+    framework: str | None = None,
+    metrics: dict[str, float] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> ModelResult:
+    """Wrap a trained model as an asset return.
+
+    Parameters
+    ----------
+    payload : Any
+        The trained model object. Supports scikit-learn estimators,
+        XGBoost and LightGBM sklearn-wrapped models, PyTorch ``nn.Module``
+        instances, and Keras/TensorFlow models.
+    name : str | None
+        Optional explicit local asset name.
+    framework : str | None
+        Optional explicit framework override, bypassing module-based
+        detection. Must be one of ``"sklearn"``, ``"xgboost"``,
+        ``"lightgbm"``, ``"pytorch"``, ``"keras"``.
+    metrics : dict[str, float] | None
+        Optional scalar metrics captured at training time. Stored as a
+        first-class field on the asset version for ``ginkgo models`` and
+        UI rendering.
+    metadata : dict[str, Any] | None
+        Optional free-form metadata stored on the asset version.
+
+    Returns
+    -------
+    ModelResult
+    """
+    if framework is not None:
+        if framework not in set(_MODEL_MODULE_ROOTS.values()):
+            raise ValueError(
+                f"model() framework must be one of "
+                f"{sorted(set(_MODEL_MODULE_ROOTS.values()))}, got {framework!r}"
+            )
+        sub_kind = framework
+    else:
+        sub_kind = _detect_model_sub_kind(payload)
+
+    return ModelResult(
+        payload=payload,
+        name=name,
+        sub_kind=sub_kind,
+        metrics=dict(metrics or {}),
         metadata=dict(metadata or {}),
     )
 

--- a/ginkgo/runtime/artifacts/asset_registration.py
+++ b/ginkgo/runtime/artifacts/asset_registration.py
@@ -32,7 +32,7 @@ from ginkgo.runtime.artifacts.wrapper_serialization import (
 from ginkgo.runtime.caching.cache import CacheStore
 
 
-_WRAPPER_NAMESPACES = {"table", "array", "fig", "text"}
+_WRAPPER_NAMESPACES = {"table", "array", "fig", "text", "model"}
 
 
 def asset_key_for_result(*, name: str, kind: str) -> AssetKey:
@@ -44,7 +44,7 @@ def asset_key_for_result(*, name: str, kind: str) -> AssetKey:
         Local asset name.
     kind : str
         Asset kind. Supports ``"file"`` plus the wrapped kinds
-        (``"table"`` / ``"array"`` / ``"fig"`` / ``"text"``).
+        (``"table"`` / ``"array"`` / ``"fig"`` / ``"text"`` / ``"model"``).
 
     Returns
     -------
@@ -214,6 +214,17 @@ class AssetRegistrar:
                 )
                 for item in value
             )
+
+        if isinstance(value, dict):
+            return {
+                key: self._replace_asset_results(
+                    node=node,
+                    value=item,
+                    parent_refs=parent_refs,
+                    wrapper_state=wrapper_state,
+                )
+                for key, item in value.items()
+            }
 
         return value
 

--- a/ginkgo/runtime/artifacts/wrapper_loaders.py
+++ b/ginkgo/runtime/artifacts/wrapper_loaders.py
@@ -209,8 +209,7 @@ def _load_model_bytes(
             import joblib  # type: ignore[import-not-found]
         except ImportError as exc:
             raise ImportError(
-                f"Loading a model asset with framework={sub_kind!r} requires the "
-                "'joblib' package. Install with: pip install joblib scikit-learn"
+                f"Loading a model asset with framework={sub_kind!r} requires the 'joblib' package."
             ) from exc
 
         return joblib.load(io.BytesIO(data))
@@ -220,8 +219,7 @@ def _load_model_bytes(
             import torch  # type: ignore[import-not-found]
         except ImportError as exc:
             raise ImportError(
-                "Loading a model asset with framework='pytorch' requires the "
-                "'torch' package. Install with: pip install torch"
+                "Loading a model asset with framework='pytorch' requires the 'torch' package."
             ) from exc
 
         # ``weights_only=False`` is required for full-object reloads, which
@@ -236,8 +234,7 @@ def _load_model_bytes(
             import keras  # type: ignore[import-not-found]
         except ImportError as exc:
             raise ImportError(
-                "Loading a model asset with framework='keras' requires the "
-                "'keras' package. Install with: pip install keras"
+                "Loading a model asset with framework='keras' requires the 'keras' package."
             ) from exc
 
         with tempfile.NamedTemporaryFile(suffix=".keras", delete=False) as handle:

--- a/ginkgo/runtime/artifacts/wrapper_loaders.py
+++ b/ginkgo/runtime/artifacts/wrapper_loaders.py
@@ -96,6 +96,12 @@ def _dispatch(
         )
     if namespace == "text":
         return _load_text_bytes(artifact_store=artifact_store, artifact_id=artifact_id)
+    if namespace == "model":
+        return _load_model_bytes(
+            artifact_store=artifact_store,
+            artifact_id=artifact_id,
+            metadata=metadata,
+        )
     raise ValueError(f"no loader registered for asset namespace {namespace!r}")
 
 
@@ -130,6 +136,15 @@ def load_fig(*, artifact_store: ArtifactStore, version: AssetVersion) -> tuple[b
 def load_text(*, artifact_store: ArtifactStore, version: AssetVersion) -> str:
     """Load a ``text`` asset version as a decoded UTF-8 string."""
     return _load_text_bytes(artifact_store=artifact_store, artifact_id=version.artifact_id)
+
+
+def load_model(*, artifact_store: ArtifactStore, version: AssetVersion) -> Any:
+    """Load a ``model`` asset version as the original trained-model object."""
+    return _load_model_bytes(
+        artifact_store=artifact_store,
+        artifact_id=version.artifact_id,
+        metadata=dict(version.metadata),
+    )
 
 
 def _load_table_bytes(*, artifact_store: ArtifactStore, artifact_id: str) -> Any:
@@ -178,6 +193,44 @@ def _load_fig_bytes(
 def _load_text_bytes(*, artifact_store: ArtifactStore, artifact_id: str) -> str:
     data = artifact_store.read_bytes(artifact_id=artifact_id)
     return data.decode("utf-8")
+
+
+def _load_model_bytes(
+    *,
+    artifact_store: ArtifactStore,
+    artifact_id: str,
+    metadata: dict[str, Any],
+) -> Any:
+    sub_kind = metadata.get("sub_kind")
+    data = artifact_store.read_bytes(artifact_id=artifact_id)
+
+    if sub_kind in {"sklearn", "xgboost", "lightgbm"}:
+        import joblib  # type: ignore[import-not-found]
+
+        return joblib.load(io.BytesIO(data))
+
+    if sub_kind == "pytorch":
+        import torch  # type: ignore[import-not-found]
+
+        # ``weights_only=False`` is required for full-object reloads, which
+        # is the symmetry we chose with sklearn/keras. The user accepts the
+        # pickle contract at save time.
+        return torch.load(io.BytesIO(data), weights_only=False)
+
+    if sub_kind == "keras":
+        import tempfile
+
+        import keras  # type: ignore[import-not-found]
+
+        with tempfile.NamedTemporaryFile(suffix=".keras", delete=False) as handle:
+            handle.write(data)
+            tmp_path = Path(handle.name)
+        try:
+            return keras.models.load_model(str(tmp_path))
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    raise ValueError(f"unknown model sub_kind {sub_kind!r}")
 
 
 def _looks_like_npy(data: bytes) -> bool:

--- a/ginkgo/runtime/artifacts/wrapper_loaders.py
+++ b/ginkgo/runtime/artifacts/wrapper_loaders.py
@@ -205,12 +205,24 @@ def _load_model_bytes(
     data = artifact_store.read_bytes(artifact_id=artifact_id)
 
     if sub_kind in {"sklearn", "xgboost", "lightgbm"}:
-        import joblib  # type: ignore[import-not-found]
+        try:
+            import joblib  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                f"Loading a model asset with framework={sub_kind!r} requires the "
+                "'joblib' package. Install with: pip install joblib scikit-learn"
+            ) from exc
 
         return joblib.load(io.BytesIO(data))
 
     if sub_kind == "pytorch":
-        import torch  # type: ignore[import-not-found]
+        try:
+            import torch  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "Loading a model asset with framework='pytorch' requires the "
+                "'torch' package. Install with: pip install torch"
+            ) from exc
 
         # ``weights_only=False`` is required for full-object reloads, which
         # is the symmetry we chose with sklearn/keras. The user accepts the
@@ -220,7 +232,13 @@ def _load_model_bytes(
     if sub_kind == "keras":
         import tempfile
 
-        import keras  # type: ignore[import-not-found]
+        try:
+            import keras  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "Loading a model asset with framework='keras' requires the "
+                "'keras' package. Install with: pip install keras"
+            ) from exc
 
         with tempfile.NamedTemporaryFile(suffix=".keras", delete=False) as handle:
             handle.write(data)

--- a/ginkgo/runtime/artifacts/wrapper_serialization.py
+++ b/ginkgo/runtime/artifacts/wrapper_serialization.py
@@ -514,8 +514,7 @@ def _serialize_model(wrapper: ModelResult) -> SerializedWrapper:
             import joblib  # type: ignore[import-not-found]
         except ImportError as exc:
             raise ImportError(
-                f"model() with framework={sub_kind!r} requires the 'joblib' package. "
-                "Install with: pip install joblib scikit-learn"
+                f"model() with framework={sub_kind!r} requires the 'joblib' package."
             ) from exc
 
         buffer = io.BytesIO()
@@ -526,8 +525,7 @@ def _serialize_model(wrapper: ModelResult) -> SerializedWrapper:
             import torch  # type: ignore[import-not-found]
         except ImportError as exc:
             raise ImportError(
-                "model() with framework='pytorch' requires the 'torch' package. "
-                "Install with: pip install torch"
+                "model() with framework='pytorch' requires the 'torch' package."
             ) from exc
 
         buffer = io.BytesIO()

--- a/ginkgo/runtime/artifacts/wrapper_serialization.py
+++ b/ginkgo/runtime/artifacts/wrapper_serialization.py
@@ -510,13 +510,25 @@ def _serialize_model(wrapper: ModelResult) -> SerializedWrapper:
     payload = wrapper.payload
 
     if sub_kind in {"sklearn", "xgboost", "lightgbm"}:
-        import joblib  # type: ignore[import-not-found]
+        try:
+            import joblib  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                f"model() with framework={sub_kind!r} requires the 'joblib' package. "
+                "Install with: pip install joblib scikit-learn"
+            ) from exc
 
         buffer = io.BytesIO()
         joblib.dump(payload, buffer)
         data = buffer.getvalue()
     elif sub_kind == "pytorch":
-        import torch  # type: ignore[import-not-found]
+        try:
+            import torch  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "model() with framework='pytorch' requires the 'torch' package. "
+                "Install with: pip install torch"
+            ) from exc
 
         buffer = io.BytesIO()
         torch.save(payload, buffer)

--- a/ginkgo/runtime/artifacts/wrapper_serialization.py
+++ b/ginkgo/runtime/artifacts/wrapper_serialization.py
@@ -19,6 +19,7 @@ from typing import Any
 from ginkgo.core.wrappers import (
     ArrayResult,
     FigureResult,
+    ModelResult,
     TableResult,
     TextResult,
     WrappedResult,
@@ -106,6 +107,8 @@ def serialize_wrapper(
             return _serialize_fig(wrapper)
         if isinstance(wrapper, TextResult):
             return _serialize_text(wrapper)
+        if isinstance(wrapper, ModelResult):
+            return _serialize_model(wrapper)
     except WrapperSerializationError:
         raise
     except Exception as exc:
@@ -476,6 +479,66 @@ def _serialize_text(wrapper: TextResult) -> SerializedWrapper:
     return SerializedWrapper(
         data=data,
         extension=_TEXT_EXTENSION_BY_FORMAT[wrapper.text_format],
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+_MODEL_EXTENSION_BY_SUB_KIND = {
+    "sklearn": "joblib",
+    "xgboost": "joblib",
+    "lightgbm": "joblib",
+    "pytorch": "pt",
+    "keras": "keras",
+}
+
+
+def _serialize_model(wrapper: ModelResult) -> SerializedWrapper:
+    """Serialise a trained-model payload as a full-object blob.
+
+    Joblib covers the sklearn family (sklearn itself plus the sklearn
+    wrappers in xgboost/lightgbm); PyTorch uses ``torch.save`` with the
+    full model object so reloading does not require the original class
+    to be re-defined in the same import path; Keras writes the native
+    ``.keras`` archive via a temporary file.
+    """
+    sub_kind = wrapper.sub_kind
+    payload = wrapper.payload
+
+    if sub_kind in {"sklearn", "xgboost", "lightgbm"}:
+        import joblib  # type: ignore[import-not-found]
+
+        buffer = io.BytesIO()
+        joblib.dump(payload, buffer)
+        data = buffer.getvalue()
+    elif sub_kind == "pytorch":
+        import torch  # type: ignore[import-not-found]
+
+        buffer = io.BytesIO()
+        torch.save(payload, buffer)
+        data = buffer.getvalue()
+    elif sub_kind == "keras":
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "model.keras"
+            payload.save(str(target))
+            data = target.read_bytes()
+    else:
+        raise ValueError(f"unknown model sub_kind {sub_kind!r}")
+
+    metadata: dict[str, Any] = {
+        "sub_kind": sub_kind,
+        "framework": sub_kind,
+        "metrics": dict(wrapper.metrics),
+        "byte_size": len(data),
+    }
+    metadata.update(wrapper.metadata)
+    return SerializedWrapper(
+        data=data,
+        extension=_MODEL_EXTENSION_BY_SUB_KIND[sub_kind],
         metadata=metadata,
     )
 

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -985,15 +985,15 @@ class _ConcurrentEvaluator:
         """Replace wrapped ``AssetRef`` values with live Python payloads.
 
         Recurses into lists, tuples, and dicts. ``AssetRef`` entries with a
-        wrapper kind (``table`` / ``array`` / ``text``) are rehydrated
-        either from the in-process live-payload cache (zero-copy handoff)
-        or from the on-disk loader as a fallback. ``file`` and ``fig``
-        refs are left as-is: the former flow through the existing file
-        coercion path, and the latter carry binary payloads that users
-        rarely consume as live Python objects.
+        wrapper kind (``table`` / ``array`` / ``text`` / ``model``) are
+        rehydrated either from the in-process live-payload cache
+        (zero-copy handoff) or from the on-disk loader as a fallback.
+        ``file`` and ``fig`` refs are left as-is: the former flow through
+        the existing file coercion path, and the latter carry binary
+        payloads that users rarely consume as live Python objects.
         """
         if isinstance(value, AssetRef):
-            if value.kind in {"table", "array", "text"}:
+            if value.kind in {"table", "array", "text", "model"}:
                 cached = self._live_payloads.get(artifact_id=value.artifact_id)
                 if cached is not None:
                     return cached

--- a/pixi.lock
+++ b/pixi.lock
@@ -47,9 +47,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
@@ -59,15 +59,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
@@ -76,7 +76,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl
@@ -92,13 +92,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/da51f2bcad81ca3733bc21e83f3b6752446436b565b90f5c350ad227ad01/loro-1.10.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c8/82/69a545901f1c33fa8c1541a0ef1e4238adeb262ce77993ae892692fe967b/marimo-0.21.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/b4/53ca91d287b52ae1806ce947659a4357472cd4ab1f54ae5638cff8cc8a25/marimo-0.23.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -106,17 +107,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b8/8e/6b17e43f6eb9369d9858ee32c97959fcd515628a1df376af96c11606cf70/msgspec-0.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0d/4b/8d5f796a792f8a25f6925a96032f098789f448571eb92011df1ae59e8ea8/nbconvert-7.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -124,7 +125,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/95/9f/f9fd57a727dcc89c54e84455d8317bff7db05ef21bb6d05b03705111f7c0/papermill-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -137,15 +138,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
@@ -161,15 +164,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cc/f4/f3f61c203bc980dd9bba0ba7ed3c6e81ddfd36b286330f9487c2c7d041aa/ty-0.0.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/c3/f89a9a42b47da108ed758ae9d065d10bf2acc2ea88e3d200b95511096b7b/ty-0.0.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -209,9 +213,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
@@ -222,15 +226,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
@@ -239,7 +243,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl
@@ -255,13 +259,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/93/5164e93a77e365a92def77c1258386daef233516a29fb674a3b9d973b8b8/loro-1.10.3-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/c8/82/69a545901f1c33fa8c1541a0ef1e4238adeb262ce77993ae892692fe967b/marimo-0.21.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/b4/53ca91d287b52ae1806ce947659a4357472cd4ab1f54ae5638cff8cc8a25/marimo-0.23.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl
@@ -269,17 +274,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/dd/1d/b9949e4ad6953e9f9a142c7997b2f7390c81e03e93570c7c33caf65d27e1/msgspec-0.20.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0d/4b/8d5f796a792f8a25f6925a96032f098789f448571eb92011df1ae59e8ea8/nbconvert-7.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl
@@ -287,7 +292,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/95/9f/f9fd57a727dcc89c54e84455d8317bff7db05ef21bb6d05b03705111f7c0/papermill-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
@@ -300,15 +305,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
@@ -324,15 +331,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/71/25/37081461e13d38a190e5646948d7bc42084f7bd1c6b44f12550be3923e7e/ty-0.0.26-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/d2/a2649eb6841ebf946ac827e778b7e78b5ef63c3758bf2b9da13d927a53da/ty-0.0.30-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl
@@ -374,14 +382,14 @@ packages:
   - hypothesis ; extra == 'tests'
   - pytest ; extra == 'tests'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
   name: aiobotocore
-  version: 3.3.0
-  sha256: 9125ab2b63740dfe3b66b8d5a90d13aed9587b850aa53225ef214a04a1aa7fdc
+  version: 3.4.0
+  sha256: 26290eb6830ea92d8a6f5f90b56e9f5cedd6d126074d5db63b195e281d982465
   requires_dist:
   - aiohttp>=3.12.0,<4.0.0
   - aioitertools>=0.5.1,<1.0.0
-  - botocore>=1.42.62,<1.42.71
+  - botocore>=1.42.79,<1.42.85
   - python-dateutil>=2.1,<3.0.0
   - jmespath>=0.7.1,<2.0.0
   - multidict>=6.0.0,<7.0.0
@@ -394,10 +402,10 @@ packages:
   version: 2.6.1
   sha256: f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl
   name: aiohttp
-  version: 3.13.4
-  sha256: 0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed
+  version: 3.13.5
+  sha256: 756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25
   requires_dist:
   - aiohappyeyeballs>=2.5.0
   - aiosignal>=1.4.0
@@ -412,10 +420,10 @@ packages:
   - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
   - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and extra == 'speedups'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: aiohttp
-  version: 3.13.4
-  sha256: 351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7
+  version: 3.13.5
+  sha256: 241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b
   requires_dist:
   - aiohappyeyeballs>=2.5.0
   - aiosignal>=1.4.0
@@ -549,10 +557,10 @@ packages:
   - webencodings
   - tinycss2>=1.1.0,<1.5 ; extra == 'css'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
   name: botocore
-  version: 1.42.70
-  sha256: 54ed9d25f05f810efd22b0dfda0bb9178df3ad8952b2e4359e05156c9321bd3c
+  version: 1.42.84
+  sha256: 15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3
   requires_dist:
   - jmespath>=0.7.1,<2.0.0
   - python-dateutil>=2.1,<3.0.0
@@ -614,24 +622,24 @@ packages:
   version: 3.5.0
   sha256: a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.6
-  sha256: 9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8
+  version: 3.4.7
+  sha256: bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
   name: charset-normalizer
-  version: 3.4.6
-  sha256: 7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db
+  version: 3.4.7
+  sha256: c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0
   requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
   name: circuitbreaker
   version: 2.1.3
   sha256: 87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1
-- pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl
   name: click
-  version: 8.3.1
-  sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+  version: 8.3.2
+  sha256: 1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
   requires_dist:
   - colorama ; sys_platform == 'win32'
   requires_python: '>=3.10'
@@ -653,17 +661,17 @@ packages:
   requires_dist:
   - pytest ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl
   name: cryptography
-  version: 46.0.6
-  sha256: 22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97
+  version: 46.0.7
+  sha256: ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4
   requires_dist:
   - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
   - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
   - nox[uv]>=2024.4.15 ; extra == 'nox'
-  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - cryptography-vectors==46.0.7 ; extra == 'test'
   - pytest>=7.4.0 ; extra == 'test'
   - pytest-benchmark>=4.0 ; extra == 'test'
   - pytest-cov>=2.10.1 ; extra == 'test'
@@ -683,17 +691,17 @@ packages:
   - check-sdist ; extra == 'pep8test'
   - click>=8.0.1 ; extra == 'pep8test'
   requires_python: '>=3.8,!=3.9.0,!=3.9.1'
-- pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl
   name: cryptography
-  version: 46.0.6
-  sha256: 64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8
+  version: 46.0.7
+  sha256: 420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef
   requires_dist:
   - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
   - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
   - nox[uv]>=2024.4.15 ; extra == 'nox'
-  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - cryptography-vectors==46.0.7 ; extra == 'test'
   - pytest>=7.4.0 ; extra == 'test'
   - pytest-benchmark>=4.0 ; extra == 'test'
   - pytest-cov>=2.10.1 ; extra == 'test'
@@ -779,10 +787,10 @@ packages:
   - pytest-benchmark ; extra == 'devel'
   - pytest-cache ; extra == 'devel'
   - validictory ; extra == 'devel'
-- pypi: https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl
   name: filelock
-  version: 3.25.2
-  sha256: ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70
+  version: 3.28.0
+  sha256: de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: frozenlist
@@ -916,7 +924,7 @@ packages:
 - pypi: ./
   name: ginkgo
   version: 0.1.0
-  sha256: e8d0c5d48b88ceb00cf5ec322b48b1d71acd3a8de28f5d3e2857dc7437dd2975
+  sha256: d6aadc4934283d2ab90ecdaa5444ee56eb42938b64d5bd4d8e5e0041d61add51
   requires_dist:
   - blake3>=1.0.0
   - fsspec>=2024.10.0
@@ -932,6 +940,8 @@ packages:
   - ipykernel>=6.29 ; extra == 'notebooks'
   - marimo>=0.11 ; extra == 'notebooks'
   - nbconvert>=7.16 ; extra == 'notebooks'
+  - joblib>=1.3 ; extra == 'ml'
+  - scikit-learn>=1.3 ; extra == 'ml'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
@@ -1148,6 +1158,11 @@ packages:
   name: jmespath
   version: 1.1.0
   sha256: a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
+  name: joblib
+  version: 1.5.3
+  sha256: 5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
   name: jsonschema
@@ -1444,10 +1459,10 @@ packages:
   version: 1.10.3
   sha256: 91d3b2e187ccfe2b14118a6e5617266fedcdf3435f6fa0a3db7b4afce8afa687
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/c8/82/69a545901f1c33fa8c1541a0ef1e4238adeb262ce77993ae892692fe967b/marimo-0.21.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/db/b4/53ca91d287b52ae1806ce947659a4357472cd4ab1f54ae5638cff8cc8a25/marimo-0.23.1-py3-none-any.whl
   name: marimo
-  version: 0.21.1
-  sha256: ad184f2ef297a5206bc3219ebbae3ea33e0ba9902ddb68c171bd2c44724db35a
+  version: 0.23.1
+  sha256: fb2546fdd669fcba5cf3b1aaaa8fd84196c292935bc2dce457cf8077ae2e8608
   requires_dist:
   - click>=8.0,<9
   - jedi>=0.18.0
@@ -1467,6 +1482,7 @@ packages:
   - narwhals>=2.0.0
   - packaging
   - msgspec>=0.20.0
+  - pyzmq>=27.1.0 ; python_full_version < '3.15'
   - python-lsp-server>=1.13.0 ; extra == 'lsp'
   - python-lsp-ruff>=2.0.0 ; extra == 'lsp'
   - mcp>=1.0.0 ; extra == 'mcp'
@@ -1474,7 +1490,7 @@ packages:
   - marimo[sql] ; extra == 'recommended'
   - marimo[sandbox] ; extra == 'recommended'
   - altair>=5.4.0 ; extra == 'recommended'
-  - pydantic-ai-slim[openai]>=1.39.0 ; extra == 'recommended'
+  - pydantic-ai-slim[openai]>=1.52.0 ; extra == 'recommended'
   - ruff ; extra == 'recommended'
   - nbformat>=5.7.0 ; extra == 'recommended'
   - pyzmq>=27.1.0 ; extra == 'sandbox'
@@ -1579,24 +1595,24 @@ packages:
   requires_dist:
   - typing-extensions ; python_full_version < '3.11'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/b8/8e/6b17e43f6eb9369d9858ee32c97959fcd515628a1df376af96c11606cf70/msgspec-0.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: msgspec
-  version: 0.20.0
-  sha256: 27d35044dd8818ac1bd0fedb2feb4fbdff4e3508dd7c5d14316a12a2d96a0de0
+  version: 0.21.1
+  sha256: 3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb
   requires_dist:
   - tomli ; python_full_version < '3.11' and extra == 'toml'
   - tomli-w ; extra == 'toml'
   - pyyaml ; extra == 'yaml'
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/dd/1d/b9949e4ad6953e9f9a142c7997b2f7390c81e03e93570c7c33caf65d27e1/msgspec-0.20.0-cp314-cp314-macosx_11_0_arm64.whl
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl
   name: msgspec
-  version: 0.20.0
-  sha256: 703c3bb47bf47801627fb1438f106adbfa2998fe586696d1324586a375fca238
+  version: 0.21.1
+  sha256: 3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a
   requires_dist:
   - tomli ; python_full_version < '3.11' and extra == 'toml'
   - tomli-w ; extra == 'toml'
   - pyyaml ; extra == 'yaml'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
   name: multidict
   version: 6.7.1
@@ -1648,10 +1664,10 @@ packages:
   - pytest>=9,<10 ; extra == 'testing-docutils'
   - pytest-param-files~=0.6.0 ; extra == 'testing-docutils'
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
   name: narwhals
-  version: 2.18.1
-  sha256: a0a8bb80205323851338888ba3a12b4f65d352362c8a94be591244faf36504ad
+  version: 2.19.0
+  sha256: 1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b
   requires_dist:
   - cudf-cu12>=24.10.0 ; extra == 'cudf'
   - dask[dataframe]>=2024.8 ; extra == 'dask'
@@ -1708,10 +1724,10 @@ packages:
   - testpath ; extra == 'test'
   - xmltodict ; extra == 'test'
   requires_python: '>=3.10.0'
-- pypi: https://files.pythonhosted.org/packages/0d/4b/8d5f796a792f8a25f6925a96032f098789f448571eb92011df1ae59e8ea8/nbconvert-7.17.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl
   name: nbconvert
-  version: 7.17.0
-  sha256: 4f99a63b337b9a23504347afdab24a11faa7d86b405e5c8f9881cd313336d518
+  version: 7.17.1
+  sha256: aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8
   requires_dist:
   - beautifulsoup4
   - bleach[css]!=5.0.0
@@ -1817,10 +1833,10 @@ packages:
   version: 2.4.4
   sha256: 27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
   name: oci
-  version: 2.169.0
-  sha256: c71bb5143f307791082b3e33cc1545c2490a518cfed85ab1948ef5107c36d30b
+  version: 2.171.0
+  sha256: 235e7aa8891c02869ea9d0418ef8ffc7af18b36509bc0b95d74c449569bf894c
   requires_dist:
   - certifi
   - cryptography>=3.2.1,<47.0.0
@@ -1828,7 +1844,7 @@ packages:
   - python-dateutil>=2.5.3,<3.0.0
   - pytz>=2016.10
   - configparser==4.0.2 ; python_full_version < '3'
-  - urllib3==1.26.2 ; python_full_version < '3.10'
+  - urllib3==1.26.20 ; python_full_version < '3.10'
   - circuitbreaker>=1.3.1,<2.0.0 ; python_full_version < '3.7'
   - urllib3>=2.6.3 ; python_full_version >= '3.10'
   - circuitbreaker>=1.3.1,<3.0.0 ; python_full_version >= '3.7'
@@ -2215,10 +2231,10 @@ packages:
   sha256: 7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523
   requires_dist:
   - ptyprocess>=0.5
-- pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
   name: platformdirs
-  version: 4.9.4
-  sha256: 68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868
+  version: 4.9.6
+  sha256: e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
   sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
@@ -2497,10 +2513,10 @@ packages:
   requires_dist:
   - six>=1.5
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- pypi: https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl
   name: python-discovery
-  version: 1.2.1
-  sha256: b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502
+  version: 1.2.2
+  sha256: e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a
   requires_dist:
   - filelock>=3.15.4
   - platformdirs>=4.3.6,<5
@@ -2617,15 +2633,15 @@ packages:
   - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
   - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
   name: rich
-  version: 14.3.3
-  sha256: 793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d
+  version: 15.0.0
+  sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
   requires_dist:
   - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
   - markdown-it-py>=2.2.0
   - pygments>=2.13.0,<3.0.0
-  requires_python: '>=3.8.0'
+  requires_python: '>=3.9.0'
 - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
   name: roman-numerals
   version: 4.1.0
@@ -2681,6 +2697,212 @@ packages:
   - fsspec==2026.3.0
   - aiohttp>=3.9.0,!=4.0.0a0,!=4.0.0a1
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl
+  name: scikit-learn
+  version: 1.8.0
+  sha256: 6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7
+  requires_dist:
+  - numpy>=1.24.1
+  - scipy>=1.10.0
+  - joblib>=1.3.0
+  - threadpoolctl>=3.2.0
+  - numpy>=1.24.1 ; extra == 'build'
+  - scipy>=1.10.0 ; extra == 'build'
+  - cython>=3.1.2 ; extra == 'build'
+  - meson-python>=0.17.1 ; extra == 'build'
+  - numpy>=1.24.1 ; extra == 'install'
+  - scipy>=1.10.0 ; extra == 'install'
+  - joblib>=1.3.0 ; extra == 'install'
+  - threadpoolctl>=3.2.0 ; extra == 'install'
+  - matplotlib>=3.6.1 ; extra == 'benchmark'
+  - pandas>=1.5.0 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.6.1 ; extra == 'docs'
+  - scikit-image>=0.22.0 ; extra == 'docs'
+  - pandas>=1.5.0 ; extra == 'docs'
+  - seaborn>=0.13.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=7.3.7 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.17.1 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=10.1.0 ; extra == 'docs'
+  - pooch>=1.8.0 ; extra == 'docs'
+  - sphinx-prompt>=1.4.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.9.1 ; extra == 'docs'
+  - plotly>=5.18.0 ; extra == 'docs'
+  - polars>=0.20.30 ; extra == 'docs'
+  - sphinx-design>=0.6.0 ; extra == 'docs'
+  - sphinxcontrib-sass>=0.3.4 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.15.3 ; extra == 'docs'
+  - sphinx-remove-toctrees>=1.0.0.post1 ; extra == 'docs'
+  - towncrier>=24.8.0 ; extra == 'docs'
+  - matplotlib>=3.6.1 ; extra == 'examples'
+  - scikit-image>=0.22.0 ; extra == 'examples'
+  - pandas>=1.5.0 ; extra == 'examples'
+  - seaborn>=0.13.0 ; extra == 'examples'
+  - pooch>=1.8.0 ; extra == 'examples'
+  - plotly>=5.18.0 ; extra == 'examples'
+  - matplotlib>=3.6.1 ; extra == 'tests'
+  - pandas>=1.5.0 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.11.7 ; extra == 'tests'
+  - mypy>=1.15 ; extra == 'tests'
+  - pyamg>=5.0.0 ; extra == 'tests'
+  - polars>=0.20.30 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.8.0 ; extra == 'tests'
+  - conda-lock==3.0.1 ; extra == 'maintenance'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: scikit-learn
+  version: 1.8.0
+  sha256: fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4
+  requires_dist:
+  - numpy>=1.24.1
+  - scipy>=1.10.0
+  - joblib>=1.3.0
+  - threadpoolctl>=3.2.0
+  - numpy>=1.24.1 ; extra == 'build'
+  - scipy>=1.10.0 ; extra == 'build'
+  - cython>=3.1.2 ; extra == 'build'
+  - meson-python>=0.17.1 ; extra == 'build'
+  - numpy>=1.24.1 ; extra == 'install'
+  - scipy>=1.10.0 ; extra == 'install'
+  - joblib>=1.3.0 ; extra == 'install'
+  - threadpoolctl>=3.2.0 ; extra == 'install'
+  - matplotlib>=3.6.1 ; extra == 'benchmark'
+  - pandas>=1.5.0 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.6.1 ; extra == 'docs'
+  - scikit-image>=0.22.0 ; extra == 'docs'
+  - pandas>=1.5.0 ; extra == 'docs'
+  - seaborn>=0.13.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=7.3.7 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.17.1 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=10.1.0 ; extra == 'docs'
+  - pooch>=1.8.0 ; extra == 'docs'
+  - sphinx-prompt>=1.4.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.9.1 ; extra == 'docs'
+  - plotly>=5.18.0 ; extra == 'docs'
+  - polars>=0.20.30 ; extra == 'docs'
+  - sphinx-design>=0.6.0 ; extra == 'docs'
+  - sphinxcontrib-sass>=0.3.4 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.15.3 ; extra == 'docs'
+  - sphinx-remove-toctrees>=1.0.0.post1 ; extra == 'docs'
+  - towncrier>=24.8.0 ; extra == 'docs'
+  - matplotlib>=3.6.1 ; extra == 'examples'
+  - scikit-image>=0.22.0 ; extra == 'examples'
+  - pandas>=1.5.0 ; extra == 'examples'
+  - seaborn>=0.13.0 ; extra == 'examples'
+  - pooch>=1.8.0 ; extra == 'examples'
+  - plotly>=5.18.0 ; extra == 'examples'
+  - matplotlib>=3.6.1 ; extra == 'tests'
+  - pandas>=1.5.0 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.11.7 ; extra == 'tests'
+  - mypy>=1.15 ; extra == 'tests'
+  - pyamg>=5.0.0 ; extra == 'tests'
+  - polars>=0.20.30 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.8.0 ; extra == 'tests'
+  - conda-lock==3.0.1 ; extra == 'maintenance'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: scipy
+  version: 1.17.1
+  sha256: eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl
+  name: scipy
+  version: 1.17.1
+  sha256: 45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
   name: six
   version: 1.17.0
@@ -2847,6 +3069,11 @@ packages:
   - tornado>=4.5 ; extra == 'test'
   - typeguard ; extra == 'test'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+  name: threadpoolctl
+  version: 3.6.0
+  sha256: 43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
   name: tinycss2
   version: 1.4.0
@@ -2942,15 +3169,15 @@ packages:
   - pytest-mypy-testing ; extra == 'test'
   - pytest>=7.0,<8.2 ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/71/25/37081461e13d38a190e5646948d7bc42084f7bd1c6b44f12550be3923e7e/ty-0.0.26-py3-none-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/d9/c3/f89a9a42b47da108ed758ae9d065d10bf2acc2ea88e3d200b95511096b7b/ty-0.0.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ty
-  version: 0.0.26
-  sha256: a01b7de5693379646d423b68f119719a1338a20017ba48a93eefaff1ee56f97b
+  version: 0.0.30
+  sha256: a4b328ee332ec6276afc863ea7cf6d8167d9dd8d9f3d1c2e738ef39932511ac4
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/cc/f4/f3f61c203bc980dd9bba0ba7ed3c6e81ddfd36b286330f9487c2c7d041aa/ty-0.0.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/e3/d2/a2649eb6841ebf946ac827e778b7e78b5ef63c3758bf2b9da13d927a53da/ty-0.0.30-py3-none-macosx_11_0_arm64.whl
   name: ty
-  version: 0.0.26
-  sha256: 8a2c766a94d79b4f82995d41229702caf2d76e5c440ec7e543d05c70e98bf8ab
+  version: 0.0.30
+  sha256: fe3012af4d0714e7353fd3cf6d2d02d5b0f0fe6f1cb8beb2366ed9f621c2c349
   requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
@@ -2982,10 +3209,10 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
   name: uvicorn
-  version: 0.42.0
-  sha256: 96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359
+  version: 0.44.0
+  sha256: ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89
   requires_dist:
   - click>=7.0
   - h11>=0.8
@@ -2998,17 +3225,17 @@ packages:
   - watchfiles>=0.20 ; extra == 'standard'
   - websockets>=10.4 ; extra == 'standard'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl
   name: virtualenv
-  version: 21.2.0
-  sha256: 1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f
+  version: 21.2.4
+  sha256: 29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac
   requires_dist:
   - distlib>=0.3.7,<1
   - filelock>=3.24.2,<4 ; python_full_version >= '3.10'
   - filelock>=3.16.1,<=3.19.1 ; python_full_version < '3.10'
   - importlib-metadata>=6.6 ; python_full_version < '3.8'
   - platformdirs>=3.9.1,<5
-  - python-discovery>=1
+  - python-discovery>=1.2.2
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl

--- a/pixi.lock
+++ b/pixi.lock
@@ -170,7 +170,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d9/c3/f89a9a42b47da108ed758ae9d065d10bf2acc2ea88e3d200b95511096b7b/ty-0.0.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl
@@ -337,7 +337,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e3/d2/a2649eb6841ebf946ac827e778b7e78b5ef63c3758bf2b9da13d927a53da/ty-0.0.30-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl
@@ -924,7 +924,7 @@ packages:
 - pypi: ./
   name: ginkgo
   version: 0.1.0
-  sha256: d6aadc4934283d2ab90ecdaa5444ee56eb42938b64d5bd4d8e5e0041d61add51
+  sha256: 775fa3abf91c6d1f6ffa517d3d604a3220f6afa49990d01831e8cbb129578ed6
   requires_dist:
   - blake3>=1.0.0
   - fsspec>=2024.10.0
@@ -940,8 +940,6 @@ packages:
   - ipykernel>=6.29 ; extra == 'notebooks'
   - marimo>=0.11 ; extra == 'notebooks'
   - nbconvert>=7.16 ; extra == 'notebooks'
-  - joblib>=1.3 ; extra == 'ml'
-  - scikit-learn>=1.3 ; extra == 'ml'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
@@ -3169,15 +3167,15 @@ packages:
   - pytest-mypy-testing ; extra == 'test'
   - pytest>=7.0,<8.2 ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/d9/c3/f89a9a42b47da108ed758ae9d065d10bf2acc2ea88e3d200b95511096b7b/ty-0.0.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl
   name: ty
-  version: 0.0.30
-  sha256: a4b328ee332ec6276afc863ea7cf6d8167d9dd8d9f3d1c2e738ef39932511ac4
+  version: 0.0.31
+  sha256: 5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/e3/d2/a2649eb6841ebf946ac827e778b7e78b5ef63c3758bf2b9da13d927a53da/ty-0.0.30-py3-none-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ty
-  version: 0.0.30
-  sha256: fe3012af4d0714e7353fd3cf6d2d02d5b0f0fe6f1cb8beb2366ed9f621c2c349
+  version: 0.0.31
+  sha256: c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e
   requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ notebooks = [
     "marimo>=0.11",
     "nbconvert>=7.16",
 ]
-ml = [
-    "joblib>=1.3",
-    "scikit-learn>=1.3",
-]
 
 [project.scripts]
 ginkgo = "ginkgo.cli:main"
@@ -47,7 +43,7 @@ channels = ["conda-forge"]
 platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.pypi-dependencies]
-ginkgo = { path = ".", editable = true, extras = ["notebooks", "ml"] }
+ginkgo = { path = ".", editable = true, extras = ["notebooks"] }
 fsspec = ">=2024.10.0"
 numpy = ">=2.0"
 ocifs = ">=1.3.2"
@@ -74,6 +70,8 @@ sphinx = ">=8.0"
 myst-parser = ">=4.0"
 furo = ">=2024.8.6"
 sphinx-copybutton = ">=0.5.2"
+joblib = ">=1.3"
+scikit-learn = ">=1.3"
 
 [tool.pixi.environments]
 default = { features = ["dev"], solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ notebooks = [
     "marimo>=0.11",
     "nbconvert>=7.16",
 ]
+ml = [
+    "joblib>=1.3",
+    "scikit-learn>=1.3",
+]
 
 [project.scripts]
 ginkgo = "ginkgo.cli:main"
@@ -43,7 +47,7 @@ channels = ["conda-forge"]
 platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.pypi-dependencies]
-ginkgo = { path = ".", editable = true, extras = ["notebooks"] }
+ginkgo = { path = ".", editable = true, extras = ["notebooks", "ml"] }
 fsspec = ">=2024.10.0"
 numpy = ">=2.0"
 ocifs = ">=1.3.2"

--- a/tests/envs/test_env/pixi.lock
+++ b/tests/envs/test_env/pixi.lock
@@ -42,19 +42,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/73/9058a1a457dd20491d1b37de53d6876eff125e1520d9b2dd7d0acbc88de2/blake3-1.0.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
@@ -64,7 +64,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -77,7 +77,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -118,19 +118,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e5/fe/ee6298e8e586096fb6f5eddd31393d8544f33ae0792c71ecbb4c2bef98ac/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fa/b913eb9cc4af708c03e01e6b88a8bb3a74833ba4ae4b16b87e2829198e06/blake3-1.0.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
@@ -140,7 +140,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/e0/ac57dd43eaadd73748bb542b30912e16c7dbf3a75f393f69efb8a1a2f032/ortools-9.15.6755-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
@@ -153,7 +153,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -188,19 +188,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/8e/8458c4285fbc5de76414f243e4e0fcab795d71a8b75324e14959aee699da/blake3-1.0.8-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
@@ -210,7 +210,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl
@@ -223,7 +223,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -263,14 +263,14 @@ packages:
   version: 2.4.0
   sha256: 88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/16/54/a295bd8d7ac900c339b2c7024ed0ff9538afb60e92eb0979b8bb49deb20e/aiobotocore-3.3.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
   name: aiobotocore
-  version: 3.3.0
-  sha256: 9125ab2b63740dfe3b66b8d5a90d13aed9587b850aa53225ef214a04a1aa7fdc
+  version: 3.4.0
+  sha256: 26290eb6830ea92d8a6f5f90b56e9f5cedd6d126074d5db63b195e281d982465
   requires_dist:
   - aiohttp>=3.12.0,<4.0.0
   - aioitertools>=0.5.1,<1.0.0
-  - botocore>=1.42.62,<1.42.71
+  - botocore>=1.42.79,<1.42.85
   - python-dateutil>=2.1,<3.0.0
   - jmespath>=0.7.1,<2.0.0
   - multidict>=6.0.0,<7.0.0
@@ -283,10 +283,10 @@ packages:
   version: 2.6.1
   sha256: f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: aiohttp
-  version: 3.13.4
-  sha256: 0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed
+  version: 3.13.5
+  sha256: ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56
   requires_dist:
   - aiohappyeyeballs>=2.5.0
   - aiosignal>=1.4.0
@@ -301,10 +301,10 @@ packages:
   - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
   - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and extra == 'speedups'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl
   name: aiohttp
-  version: 3.13.4
-  sha256: 351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7
+  version: 3.13.5
+  sha256: 756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25
   requires_dist:
   - aiohappyeyeballs>=2.5.0
   - aiosignal>=1.4.0
@@ -319,10 +319,10 @@ packages:
   - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
   - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and extra == 'speedups'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/e5/fe/ee6298e8e586096fb6f5eddd31393d8544f33ae0792c71ecbb4c2bef98ac/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: aiohttp
-  version: 3.13.4
-  sha256: f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c
+  version: 3.13.5
+  sha256: 241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b
   requires_dist:
   - aiohappyeyeballs>=2.5.0
   - aiosignal>=1.4.0
@@ -378,10 +378,10 @@ packages:
   requires_dist:
   - typing-extensions>=4.6.0 ; python_full_version < '3.12'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/fb/51/08f32aea872253173f513ba68122f4300966290677c8e59887b4ffd5d957/botocore-1.42.70-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
   name: botocore
-  version: 1.42.70
-  sha256: 54ed9d25f05f810efd22b0dfda0bb9178df3ad8952b2e4359e05156c9321bd3c
+  version: 1.42.84
+  sha256: 15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3
   requires_dist:
   - jmespath>=0.7.1,<2.0.0
   - python-dateutil>=2.1,<3.0.0
@@ -455,20 +455,20 @@ packages:
   requires_dist:
   - pycparser ; implementation_name != 'PyPy'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.6
-  sha256: 9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8
+  version: 3.4.7
+  sha256: bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
   name: charset-normalizer
-  version: 3.4.6
-  sha256: ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421
+  version: 3.4.7
+  sha256: c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: charset-normalizer
-  version: 3.4.6
-  sha256: 7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db
+  version: 3.4.7
+  sha256: 1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a
   requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
   name: circuitbreaker
@@ -485,17 +485,17 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
-- pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl
   name: cryptography
-  version: 46.0.6
-  sha256: 22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97
+  version: 46.0.7
+  sha256: ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4
   requires_dist:
   - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
   - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
   - nox[uv]>=2024.4.15 ; extra == 'nox'
-  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - cryptography-vectors==46.0.7 ; extra == 'test'
   - pytest>=7.4.0 ; extra == 'test'
   - pytest-benchmark>=4.0 ; extra == 'test'
   - pytest-cov>=2.10.1 ; extra == 'test'
@@ -515,17 +515,17 @@ packages:
   - check-sdist ; extra == 'pep8test'
   - click>=8.0.1 ; extra == 'pep8test'
   requires_python: '>=3.8,!=3.9.0,!=3.9.1'
-- pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl
   name: cryptography
-  version: 46.0.6
-  sha256: 64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8
+  version: 46.0.7
+  sha256: 420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef
   requires_dist:
   - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
   - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
   - nox[uv]>=2024.4.15 ; extra == 'nox'
-  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - cryptography-vectors==46.0.7 ; extra == 'test'
   - pytest>=7.4.0 ; extra == 'test'
   - pytest-benchmark>=4.0 ; extra == 'test'
   - pytest-cov>=2.10.1 ; extra == 'test'
@@ -545,17 +545,17 @@ packages:
   - check-sdist ; extra == 'pep8test'
   - click>=8.0.1 ; extra == 'pep8test'
   requires_python: '>=3.8,!=3.9.0,!=3.9.1'
-- pypi: https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl
   name: cryptography
-  version: 46.0.6
-  sha256: 67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175
+  version: 46.0.7
+  sha256: 73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77
   requires_dist:
   - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
   - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
   - nox[uv]>=2024.4.15 ; extra == 'nox'
-  - cryptography-vectors==46.0.6 ; extra == 'test'
+  - cryptography-vectors==46.0.7 ; extra == 'test'
   - pytest>=7.4.0 ; extra == 'test'
   - pytest-benchmark>=4.0 ; extra == 'test'
   - pytest-cov>=2.10.1 ; extra == 'test'
@@ -712,7 +712,7 @@ packages:
 - pypi: ../../..
   name: ginkgo
   version: 0.1.0
-  sha256: e8d0c5d48b88ceb00cf5ec322b48b1d71acd3a8de28f5d3e2857dc7437dd2975
+  sha256: d6aadc4934283d2ab90ecdaa5444ee56eb42938b64d5bd4d8e5e0041d61add51
   requires_dist:
   - blake3>=1.0.0
   - fsspec>=2024.10.0
@@ -728,6 +728,8 @@ packages:
   - ipykernel>=6.29 ; extra == 'notebooks'
   - marimo>=0.11 ; extra == 'notebooks'
   - nbconvert>=7.16 ; extra == 'notebooks'
+  - joblib>=1.3 ; extra == 'ml'
+  - scikit-learn>=1.3 ; extra == 'ml'
   requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
   sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
@@ -1215,10 +1217,10 @@ packages:
   version: 2.4.4
   sha256: 27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/e4/bf/19643bd939ab595193779ee25c2c12aef8e9a54e0a68de5ed79f209702e3/oci-2.169.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9c/2f/4925fcf29e771c62a6892a49d5e35efed2fb0d1ee3aaa1535435cf2e2b87/oci-2.171.0-py3-none-any.whl
   name: oci
-  version: 2.169.0
-  sha256: c71bb5143f307791082b3e33cc1545c2490a518cfed85ab1948ef5107c36d30b
+  version: 2.171.0
+  sha256: 235e7aa8891c02869ea9d0418ef8ffc7af18b36509bc0b95d74c449569bf894c
   requires_dist:
   - certifi
   - cryptography>=3.2.1,<47.0.0
@@ -1226,7 +1228,7 @@ packages:
   - python-dateutil>=2.5.3,<3.0.0
   - pytz>=2016.10
   - configparser==4.0.2 ; python_full_version < '3'
-  - urllib3==1.26.2 ; python_full_version < '3.10'
+  - urllib3==1.26.20 ; python_full_version < '3.10'
   - circuitbreaker>=1.3.1,<2.0.0 ; python_full_version < '3.7'
   - urllib3>=2.6.3 ; python_full_version >= '3.10'
   - circuitbreaker>=1.3.1,<3.0.0 ; python_full_version >= '3.7'
@@ -1865,15 +1867,15 @@ packages:
   - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
   - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
   name: rich
-  version: 14.3.3
-  sha256: 793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d
+  version: 15.0.0
+  sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
   requires_dist:
   - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
   - markdown-it-py>=2.2.0
   - pygments>=2.13.0,<3.0.0
-  requires_python: '>=3.8.0'
+  requires_python: '>=3.9.0'
 - pypi: https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl
   name: s3fs
   version: 2026.3.0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -404,12 +404,20 @@ class TestExamples:
         monkeypatch.chdir(example_dir)
 
         _, first_manifest = _run_example(example_dir=example_dir)
-        candidate_outputs = sorted((example_dir / "results" / "candidates").glob("*.json"))
         scorecard = pd.read_csv(example_dir / "results" / "candidate_scorecard.csv")
 
         assert first_manifest["status"] == "succeeded"
         assert len(first_manifest["tasks"]) == 13
-        assert len(candidate_outputs) == 4
+
+        # Candidates now return model() assets instead of JSON files.
+        model_assets = [
+            asset
+            for task in first_manifest["tasks"].values()
+            for asset in (task.get("assets") or [])
+            if asset.get("namespace") == "model"
+        ]
+        assert len(model_assets) == 4
+
         assert sorted(scorecard["model_name"].tolist()) == [
             "baseline_logit",
             "expansion_focus",

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -11,11 +11,12 @@ import pandas as pd
 import pytest
 
 import ginkgo
-from ginkgo import array, fig, table, task, text
+from ginkgo import array, fig, model, table, task, text
 from ginkgo.core.asset import AssetRef
 from ginkgo.core.wrappers import (
     ArrayResult,
     FigureResult,
+    ModelResult,
     TableResult,
     TextResult,
 )
@@ -38,6 +39,7 @@ class TestFactories:
         assert ginkgo.array is array
         assert ginkgo.fig is fig
         assert ginkgo.text is text
+        assert ginkgo.model is model
 
     def test_table_pandas_detection(self) -> None:
         wrapper = table(pd.DataFrame({"a": [1, 2]}))
@@ -97,6 +99,31 @@ class TestFactories:
     def test_text_dict_rejects_non_json_format(self) -> None:
         with pytest.raises(ValueError):
             text({"a": 1}, format="markdown")
+
+    def test_model_sklearn_detection(self) -> None:
+        sklearn = pytest.importorskip("sklearn.linear_model")
+        clf = sklearn.LogisticRegression()
+        wrapper = model(clf, name="classifier", metrics={"auc": 0.91})
+        assert isinstance(wrapper, ModelResult)
+        assert wrapper.sub_kind == "sklearn"
+        assert wrapper.metrics == {"auc": 0.91}
+        assert wrapper.name == "classifier"
+
+    def test_model_framework_override(self) -> None:
+        sklearn = pytest.importorskip("sklearn.dummy")
+        clf = sklearn.DummyClassifier()
+        wrapper = model(clf, framework="sklearn")
+        assert wrapper.sub_kind == "sklearn"
+
+    def test_model_framework_override_rejects_unknown(self) -> None:
+        sklearn = pytest.importorskip("sklearn.dummy")
+        clf = sklearn.DummyClassifier()
+        with pytest.raises(ValueError):
+            model(clf, framework="onnx")
+
+    def test_model_rejects_unsupported_type(self) -> None:
+        with pytest.raises(TypeError):
+            model(object())
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +226,26 @@ class TestSerializers:
         import json as _json
 
         assert _json.loads(result.data.decode("utf-8")) == {"a": 1, "b": [1, 2]}
+
+    def test_serialize_sklearn_model_roundtrip(self) -> None:
+        sklearn_lm = pytest.importorskip("sklearn.linear_model")
+        pytest.importorskip("joblib")
+        clf = sklearn_lm.LogisticRegression()
+        clf.fit(np.array([[0.0], [1.0], [2.0], [3.0]]), np.array([0, 0, 1, 1]))
+
+        wrapper = model(clf, name="clf", metrics={"score": 0.875})
+        result = serialize_wrapper(wrapper=wrapper, wrapper_index=0)
+        assert result.extension == "joblib"
+        assert result.metadata["framework"] == "sklearn"
+        assert result.metadata["sub_kind"] == "sklearn"
+        assert result.metadata["metrics"] == {"score": 0.875}
+        assert result.metadata["byte_size"] == len(result.data)
+
+        # Round-trip via joblib so we know the bytes are a real joblib blob.
+        import joblib  # type: ignore[import-not-found]
+
+        restored = joblib.load(io.BytesIO(result.data))
+        assert list(restored.predict([[0.5], [2.5]])) == [0, 1]
 
     def test_serialization_error_wraps_underlying_failure(self) -> None:
         class Exploding:
@@ -411,6 +458,91 @@ class TestAssetShow:
 
 
 # ---------------------------------------------------------------------------
+# ginkgo models CLI
+# ---------------------------------------------------------------------------
+
+
+class TestModelsCommand:
+    def test_empty_state_when_no_runs(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        from ginkgo.cli.app import main
+
+        rc = main(["models"])
+        assert rc == 1
+        output = capsys.readouterr().out
+        assert "No runs found" in output
+
+    def test_lists_models_from_latest_run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        pytest.importorskip("sklearn.linear_model")
+        pytest.importorskip("joblib")
+        monkeypatch.chdir(tmp_path)
+
+        _run_with_provenance(tmp_path, produce_sklearn_model())
+
+        from ginkgo.cli.app import main
+
+        rc = main(["models"])
+        assert rc == 0
+        output = capsys.readouterr().out
+        assert "🌿 ginkgo models" in output
+        assert "produce_sklearn_model" in output
+        assert "sklearn" in output
+        assert "classifier" in output
+        assert "score=1" in output
+
+    def test_empty_state_when_run_has_no_models(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _run_with_provenance(tmp_path, make_table_task())
+
+        from ginkgo.cli.app import main
+
+        rc = main(["models"])
+        assert rc == 0
+        output = capsys.readouterr().out
+        assert "No model assets in this run." in output
+
+
+def _run_with_provenance(tmp_path: Path, expr: object) -> None:
+    """Evaluate an expression under a real provenance recorder.
+
+    Writes a manifest under ``.ginkgo/runs/<run_id>/`` so the ``ginkgo
+    models`` command path can discover the run and its asset entries.
+    """
+    from ginkgo.runtime.caching.provenance import RunProvenanceRecorder, make_run_id
+
+    workflow_path = tmp_path / "workflow.py"
+    workflow_path.write_text("# placeholder\n", encoding="utf-8")
+    recorder = RunProvenanceRecorder(
+        run_id=make_run_id(workflow_path=workflow_path),
+        workflow_path=workflow_path,
+        root_dir=tmp_path / ".ginkgo" / "runs",
+        jobs=1,
+        cores=1,
+    )
+    try:
+        ginkgo.evaluate(expr, provenance=recorder, jobs=1, cores=1)
+        recorder.finalize(status="succeeded")
+    except Exception:
+        recorder.finalize(status="failed")
+        raise
+
+
+# ---------------------------------------------------------------------------
 # Phase 4.5 — rehydration-on-receive
 # ---------------------------------------------------------------------------
 
@@ -457,6 +589,22 @@ def consume_text_length(upstream: object) -> int:
 @task()
 def consume_scalar_expecting_int(upstream: int) -> int:
     return upstream + 1
+
+
+@task()
+def produce_sklearn_model() -> object:
+    from sklearn.linear_model import LogisticRegression
+
+    clf = LogisticRegression()
+    clf.fit(np.array([[0.0], [1.0], [2.0], [3.0]]), np.array([0, 0, 1, 1]))
+    return model(clf, name="classifier", metrics={"score": 1.0})
+
+
+@task()
+def consume_model_predict(trained: object) -> list[int]:
+    # Rehydration should hand us back the trained sklearn estimator.
+    predictions = trained.predict(np.array([[0.5], [2.5]]))
+    return [int(value) for value in predictions]
 
 
 class TestRehydration:
@@ -542,6 +690,16 @@ class TestRehydration:
             ginkgo.evaluate(
                 consume_scalar_expecting_int(upstream=produce_table()),
             )
+
+    def test_model_ref_rehydrated_to_estimator(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A downstream consumer observes the live sklearn estimator."""
+        pytest.importorskip("sklearn.linear_model")
+        pytest.importorskip("joblib")
+        monkeypatch.chdir(tmp_path)
+        result = ginkgo.evaluate(consume_model_predict(trained=produce_sklearn_model()))
+        assert result == [0, 1]
 
     def test_live_registry_capacity_eviction(self) -> None:
         """The registry is bounded — oldest entries evict when full."""


### PR DESCRIPTION
## Summary

- Add `model()` wrapper sentinel following the Phase 4 `table`/`array`/`fig`/`text` pattern. Detects sklearn, xgboost/lightgbm (sklearn wrappers), pytorch, and keras/tensorflow from the payload's module root. Serialisation uses joblib for the sklearn family, `torch.save` for torch, and the native `.keras` archive for keras. Metrics are a first-class `dict[str, float]` field persisted on the asset version.
- Rehydrate `model` refs on receive so downstream tasks get the live trained estimator rather than an `AssetRef` (extends the existing `table`/`array`/`text` path).
- Add `ginkgo models [run_id]` — lists model assets produced by a run with task, name, framework, metrics, and version id. Extends `ginkgo asset show` to render model metadata.
- Fix latent gap in `AssetRegistrar._replace_asset_results` where wrapped sentinels nested inside dict return values were skipped; the validation walker already handled dicts, so this aligns the two passes and lets tasks return `{"model": model(...), ...}`.
- Adapt `examples/ml/ml_model_ops` to train real scikit-learn pipelines, register them as model assets via `model()`, and feed a dict-shaped report through the scorecard/champion tasks.
- Add `ginkgo[ml]` optional extra (`joblib`, `scikit-learn`); torch/keras/xgboost/lightgbm remain fully optional and lazy-imported.

Phase 5's `.sweep()` primitive and the real-time training-progress event contract remain in `docs/implementation-plan.md` as the follow-up; the model-asset work is marked as shipped in `docs/architecture.md`.

## Test plan

- [x] `pixi run pytest tests/ -q --ignore=tests/test_examples.py` — 484 passed, 4 skipped
- [x] `pixi run lint`, `pixi run format-check`, `pixi run typecheck` — clean
- [x] `examples/ml` runs end-to-end: 13 tasks, 4 model assets registered
- [x] `ginkgo models` in the ml example lists all four sklearn candidates with framework, metrics, and version ids
- [x] Unit + integration tests for `model()` factory, serializer round-trip, rehydration-to-live-estimator, and three CLI states (no runs / no models in run / populated)