### PR TITLE
retries, task priority, cache prune on size, failures, docs 

### DIFF
--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -46,3 +46,18 @@ working-tree output already matches the cached artifact, it is left untouched.
 `ginkgo cache prune` and related cache cleanup paths are artifact-aware:
 read-only artifacts have permissions restored before deletion so cache
 maintenance can safely remove unreferenced stored outputs.
+
+`ginkgo cache prune` supports three orthogonal policies, which may be
+combined:
+
+- `--older-than <duration>` — remove every entry older than the cutoff
+  (`45m`, `12h`, `30d`).
+- `--max-size <size>` — remove oldest entries until total cache size is at
+  or below the target (`500MB`, `2GB`, `10GB`).
+- `--max-entries <N>` — remove oldest entries until the total entry count
+  is at or below the target.
+
+At least one policy is required. When multiple are given, they are applied
+together: `--older-than` selects unconditionally, and `--max-size` /
+`--max-entries` then pick additional oldest-first entries until their
+budgets are met. Orphan artifacts are garbage-collected once at the end.

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -25,3 +25,17 @@ Implemented CLI features include dry-run validation, merged config overrides,
 human-readable run summaries, structured inspection and diagnostics, secret
 discovery and validation, cache inspection and eviction, failed-task
 debugging, and asset catalog inspection for local workspaces.
+
+`ginkgo cache prune` accepts `--older-than <duration>`, `--max-size <size>`,
+and `--max-entries <N>`. At least one of the three is required; multiple
+may be combined, and eviction always proceeds oldest-first with orphan
+artifact garbage collection at the end. `--dry-run` previews what would be
+removed without touching disk.
+
+Run-time failure diagnostics classify each task failure into one of a small
+set of categories — `env_mismatch`, `import_error`, `invalid_path`,
+`missing_input`, `shell_command_error`, `serialization_error`,
+`user_code_error`, `output_validation_error`, `cache_error`,
+`cycle_detected`, and `scheduler_error` — and the end-of-run renderer
+groups failures by category so that common root causes stand out without
+digging through individual panels.

--- a/docs/architecture/execution-model.md
+++ b/docs/architecture/execution-model.md
@@ -60,6 +60,29 @@ fan-out may run simultaneously, independent of the global `--jobs` and
 fan-out and enforces the limit in the CP-SAT selection model alongside
 cores, jobs, and memory constraints.
 
+**Task priority.** `@task(priority=N)` declares a relative dispatch priority
+(range `[-1000, 1000]`, default `0`). When several tasks are ready
+simultaneously and contend for the same resources, the CP-SAT selection
+model prefers higher-priority tasks. Priority is a strict tiebreaker: it
+never overrides the scheduler's primary objective of dispatching as many
+ready tasks as possible, nor its secondary objective of filling the core
+budget. Workloads that do not set `priority` are unaffected.
+
+**Selective retries and backoff.** `@task(retries=N)` enables retries; the
+retry policy is narrowed by:
+
+- `retry_on=IOError` (or a tuple of exception classes) to retry only
+  specific failure modes;
+- `retry_on_exit_codes=(137,)` for shell tasks to retry only specific
+  exit codes;
+- `retry_backoff=<seconds>` with `retry_backoff_multiplier` and
+  `retry_backoff_max` to apply exponential delay between attempts.
+
+Retry-delayed tasks transition through a `waiting_retry` scheduler state
+with a ready-at deadline; the scheduler wakes on the earliest deadline
+without busy-looping. `TaskRetrying` events carry the scheduled
+`delay_seconds`.
+
 **Runtime profiling (`--profile`).** `ginkgo run --profile` enables a coarse
 phase-timer recorder that attributes wall time to CLI startup, workflow
 module import, flow construction, evaluator validation, scheduler prepare /

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -36,6 +36,9 @@ The repository currently implements:
   scaffolded project initialization
 - An example-driven benchmark harness with generated benchmark inputs, checked-
   in baselines, and a separate CI lane for slowdown detection
+- Selective retry policies with exponential backoff, size- and count-based
+  cache eviction, task-level scheduling priority as a strict tiebreaker, and
+  end-of-run failure classification that groups diagnostics by category
 
 ## Topic Map
 

--- a/docs/site/guide/caching-and-provenance.md
+++ b/docs/site/guide/caching-and-provenance.md
@@ -55,6 +55,48 @@ ginkgo cache prune --older-than 30d --dry-run
 These commands are useful when you want to understand reuse behavior without
 manually navigating hidden directories.
 
+## Bounding Cache Size
+
+`ginkgo cache prune` supports three eviction policies, which can be combined
+in one invocation:
+
+```bash
+# Time-based: remove anything older than 30 days
+ginkgo cache prune --older-than 30d
+
+# Size-based: bring total cache size down to 5 GB
+ginkgo cache prune --max-size 5GB
+
+# Count-based: keep only the newest 500 entries
+ginkgo cache prune --max-entries 500
+
+# Combined: also remove anything older than 90 days
+ginkgo cache prune --older-than 90d --max-size 5GB
+```
+
+Eviction is oldest-first, and orphaned artifacts are garbage-collected at the
+end of the operation. Use `--dry-run` to preview what would be removed.
+
+## Partial Resume
+
+When a run fails partway through, Ginkgo preserves every successfully cached
+task. Rerunning the same workflow picks up where the previous run left off:
+tasks whose inputs are unchanged serve from cache, and only the tasks that
+failed or were never reached are re-executed. The `cache_key` column in
+`ginkgo cache ls` and the cache-hit markers in `ginkgo run` output make this
+reuse visible. There is no separate resume command — the cache itself is the
+resume mechanism.
+
+## Dry-Run Mode
+
+`ginkgo run workflow.py --dry-run` validates the workflow without executing
+any task body. Ginkgo resolves the expression tree, checks environments and
+secrets, computes cache keys for every task, and reports which tasks would
+run, which would serve from cache, and which resources they declare. Dry-run
+is the fastest way to confirm that a workflow is correctly wired, that every
+declared environment exists, and that planned caching aligns with intent
+before committing to a real run.
+
 ## Why This Matters In Practice
 
 Caching is only useful if users can trust it. Provenance is only useful if users

--- a/docs/site/guide/tasks-and-flows.md
+++ b/docs/site/guide/tasks-and-flows.md
@@ -116,6 +116,56 @@ Tasks can return:
 That gives you controlled dynamic graph expansion while keeping the authoring
 model small.
 
+## Declaring Resource Requirements
+
+Every `@task` can declare the resources it needs. The scheduler respects
+these declarations against the `--jobs`, `--cores`, and `--memory` budgets.
+
+```python
+@task(threads=4, memory="8Gi")
+def align_reads(sample_id: str, reads: file) -> file:
+    ...
+
+@task(kind="shell", gpu=1, remote=True, memory="16Gi")
+def train_model(dataset: folder) -> file:
+    ...
+```
+
+- `threads=N` declares the CPU footprint. Tasks that read `threads` as a
+  function parameter receive it automatically; shell tasks also see
+  `GINKGO_THREADS` in their subprocess environment. Set
+  `export_thread_env=True` to additionally export `OMP_NUM_THREADS` and
+  related BLAS/OpenMP variables.
+- `memory="8Gi"` declares the memory footprint. Format is Kubernetes-style
+  (`512Mi`, `4Gi`, `16Gi`). Remote executors map this to pod resource
+  requests.
+- `gpu=N` and `remote=True` dispatch the task to the configured remote
+  executor. Tasks with `gpu > 0` are implicitly remote.
+
+## Priority And Retry Policies
+
+Two optional decorator parameters control scheduling and resilience:
+
+```python
+# Highest-priority tasks run first when multiple are ready at once.
+@task(priority=10)
+def critical_path_step(...): ...
+
+# Retry up to 3 times, only on IOError, with exponential backoff.
+@task(retries=3, retry_on=IOError, retry_backoff=1.0)
+def network_fetch(...): ...
+
+# Retry only specific exit codes on shell tasks.
+@task(kind="shell", retries=2, retry_on_exit_codes=(137,))  # OOM kills
+def memory_intensive_step(...): ...
+```
+
+`priority` is a strict tiebreaker: it never lets a higher-priority task
+block a larger set of lower-priority tasks from running. Retries with a
+non-zero `retry_backoff` pause the task in a `waiting_retry` state for the
+computed delay (capped at `retry_backoff_max`) before the scheduler picks
+it up again.
+
 ## When To Split A Task
 
 Split tasks when you need:

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -18,42 +18,6 @@ Each phase is independently testable and follows the same structure:
 These phases polish and extend existing subsystems without introducing new
 architectural layers.
 
-### Phase 1 — Hardening and UI Polish
-
-**Goal:** Finish the production-readiness and local UI work that remains.
-
-#### Deliverables
-
-- Extend retry support with:
-  - selective retry policies
-  - retry backoff
-- Broaden cache-management policy beyond age-based pruning (size- or
-  count-based eviction).
-- Add task priority declarations so users can express relative urgency between
-  tasks in the same DAG tier; the scheduler should respect priority when
-  multiple tasks are ready to run concurrently.
-- Tighten documentation around partial resume, dry-run behavior, and resource
-  declarations.
-
-#### Key design points
-
-- This phase is explicitly for remaining gaps in areas that already exist.
-- The goal is to reduce ambiguity and operational rough edges before the runtime
-  surface area expands further.
-- UI work should remain local-first and should build on the current file-backed
-  provenance model.
-
-#### Validation
-
-- Re-run `VW-4`, `VW-5`, `VW-6`, and `VW-8` through the polished CLI and UI
-  paths and assert the richer retry, cache, and resource behavior is visible in
-  both CLI output and persisted provenance.
-- Assert the improved diagnostics distinguish common classes of failure such as
-  env mismatch, invalid paths, and packaging/importability errors.
-
----
-
-
 ### Phase 3 — UI Performance and Responsiveness
 
 **Goal:** Keep the local web UI fast and predictable as run history, task

--- a/ginkgo/cli/app.py
+++ b/ginkgo/cli/app.py
@@ -103,7 +103,18 @@ def _build_parser() -> argparse.ArgumentParser:
     explain_parser = cache_subparsers.add_parser("explain")
     explain_parser.add_argument("--run", required=True, dest="run_id")
     prune_parser = cache_subparsers.add_parser("prune")
-    prune_parser.add_argument("--older-than", required=True)
+    prune_parser.add_argument("--older-than", default=None)
+    prune_parser.add_argument(
+        "--max-size",
+        default=None,
+        help="Prune oldest entries until total size is at or below the target (e.g. 2GB, 500MB).",
+    )
+    prune_parser.add_argument(
+        "--max-entries",
+        type=int,
+        default=None,
+        help="Prune oldest entries until entry count is at or below this number.",
+    )
     prune_parser.add_argument("--dry-run", action="store_true")
 
     asset_parser = subparsers.add_parser("asset")

--- a/ginkgo/cli/commands/cache.py
+++ b/ginkgo/cli/commands/cache.py
@@ -55,23 +55,40 @@ def command_cache(args) -> int:
 
     if args.cache_command == "prune":
         rich_console.print("[bold green]🌿 ginkgo cache[/] [bold]prune[/]\n")
-        cutoff = _prune_cutoff(args.older_than)
-        entries = [
-            entry
-            for entry in list_cache_entries(CACHE_ROOT)
-            if entry.created_at is not None and entry.created_at < cutoff
-        ]
+        if args.older_than is None and args.max_size is None and args.max_entries is None:
+            rich_console.print(
+                "[red]Error:[/] provide at least one of --older-than, --max-size, "
+                "or --max-entries."
+            )
+            return 2
+
+        max_size_bytes = _parse_size_bytes(args.max_size) if args.max_size else None
+        if args.max_entries is not None and args.max_entries < 0:
+            rich_console.print("[red]Error:[/] --max-entries must be at least 0.")
+            return 2
+
+        all_entries = list_cache_entries(CACHE_ROOT)
+        entries = select_prune_entries(
+            entries=all_entries,
+            older_than=args.older_than,
+            max_size_bytes=max_size_bytes,
+            max_entries=args.max_entries,
+        )
         total_bytes = sum(entry.size_bytes for entry in entries)
 
         if args.dry_run:
+            reason = _describe_prune_policy(
+                older_than=args.older_than,
+                max_size=args.max_size,
+                max_entries=args.max_entries,
+            )
             rich_console.print(
-                f"[cyan]Preview:[/] {len(entries)} entries older than "
-                f"[bold]{args.older_than}[/] "
+                f"[cyan]Preview:[/] {len(entries)} entries {reason} "
                 f"([bold]{_format_size(total_bytes)}[/]) would be removed."
             )
             for entry in entries:
                 rich_console.print(
-                    f"[dim]-[/] {entry.cache_key} ({entry.task}, {entry.age}, {entry.size})"
+                    f"[dim]-[/] {entry.cache_key} ({entry.task}, {entry.age}, {entry.created})"
                 )
             return 0
 
@@ -220,6 +237,94 @@ def _prune_cutoff(older_than: str) -> datetime:
     """Return the UTC cutoff timestamp implied by a duration string."""
     duration = _parse_duration_seconds(older_than)
     return datetime.now(UTC) - duration
+
+
+def select_prune_entries(
+    *,
+    entries: list[CacheEntryRow],
+    older_than: str | None,
+    max_size_bytes: int | None,
+    max_entries: int | None,
+) -> list[CacheEntryRow]:
+    """Return the cache entries that satisfy the combined prune policy.
+
+    Parameters
+    ----------
+    entries : list[CacheEntryRow]
+        Existing cache entries; may be unordered.
+    older_than : str | None
+        Optional duration string. Entries with ``created_at`` older than the
+        cutoff are always selected.
+    max_size_bytes : int | None
+        When set, additional oldest entries are selected until total cache
+        size drops to or below this target.
+    max_entries : int | None
+        When set, additional oldest entries are selected until the remaining
+        entry count drops to or below this target.
+
+    Returns
+    -------
+    list[CacheEntryRow]
+        Entries to remove. Order follows the original iteration order for
+        display stability.
+    """
+    by_age_oldest_first = sorted(
+        entries,
+        key=lambda entry: entry.created_at or datetime.min.replace(tzinfo=UTC),
+    )
+    selected: set[Path] = set()
+
+    if older_than is not None:
+        cutoff = _prune_cutoff(older_than)
+        for entry in by_age_oldest_first:
+            if entry.created_at is not None and entry.created_at < cutoff:
+                selected.add(entry.path)
+
+    if max_size_bytes is not None or max_entries is not None:
+        remaining = [entry for entry in by_age_oldest_first if entry.path not in selected]
+        remaining_size = sum(entry.size_bytes for entry in remaining)
+        remaining_count = len(remaining)
+        for entry in remaining:
+            size_ok = max_size_bytes is None or remaining_size <= max_size_bytes
+            count_ok = max_entries is None or remaining_count <= max_entries
+            if size_ok and count_ok:
+                break
+            selected.add(entry.path)
+            remaining_size -= entry.size_bytes
+            remaining_count -= 1
+
+    return [entry for entry in entries if entry.path in selected]
+
+
+def _describe_prune_policy(
+    *,
+    older_than: str | None,
+    max_size: str | None,
+    max_entries: int | None,
+) -> str:
+    """Describe the active prune policy for dry-run output."""
+    parts = []
+    if older_than is not None:
+        parts.append(f"older than {older_than}")
+    if max_size is not None:
+        parts.append(f"over {max_size} cache size")
+    if max_entries is not None:
+        parts.append(f"over {max_entries} entries")
+    return f"matching policy ({'; '.join(parts)})"
+
+
+_SIZE_PATTERN = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB|K|M|G|T)?\s*$", re.IGNORECASE)
+
+
+def _parse_size_bytes(value: str) -> int:
+    """Parse a compact size string (e.g. ``2GB``) to an integer byte count."""
+    match = _SIZE_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValueError(f"Invalid --max-size {value!r}. Use e.g. 500MB, 2GB, 10GB.")
+    count = float(match.group(1))
+    unit = (match.group(2) or "B").upper().rstrip("B") or "B"
+    multipliers = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+    return int(count * multipliers[unit])
 
 
 def _parse_duration_seconds(value: str):

--- a/ginkgo/cli/commands/debug.py
+++ b/ginkgo/cli/commands/debug.py
@@ -68,6 +68,12 @@ def _debug_failure_details(
         stderr_rel = task.get("stderr_log")
         stderr_path = run_dir / stderr_rel if isinstance(stderr_rel, str) else None
         task_name = str(task.get("task", "unknown"))
+        failure = task.get("failure")
+        failure_kind = (
+            failure.get("kind")
+            if isinstance(failure, dict) and isinstance(failure.get("kind"), str)
+            else None
+        )
         details.append(
             _FailureDetails(
                 task_label=_task_base_name(task_name),
@@ -75,6 +81,7 @@ def _debug_failure_details(
                 log_path=stderr_path,
                 log_tail=log_tail,
                 error=str(task.get("error")) if task.get("error") is not None else None,
+                failure_kind=failure_kind,
                 inputs=task.get("inputs") if isinstance(task.get("inputs"), dict) else None,
             )
         )

--- a/ginkgo/cli/commands/run.py
+++ b/ginkgo/cli/commands/run.py
@@ -372,6 +372,11 @@ def _load_failure_details(
         node_id = task.node_id if task.node_id is not None else -1
         log_tail = _combined_log_tail(run_dir=run_dir, task=task, lines=tail_lines)
         stderr_path = run_dir / task.stderr_log if isinstance(task.stderr_log, str) else None
+        failure_kind = (
+            task.failure.get("kind")
+            if isinstance(task.failure, dict) and isinstance(task.failure.get("kind"), str)
+            else None
+        )
         details.append(
             _FailureDetails(
                 task_label=renderer.label_for_node(node_id) or task.name,
@@ -379,6 +384,7 @@ def _load_failure_details(
                 log_path=stderr_path,
                 log_tail=log_tail,
                 error=task.error,
+                failure_kind=failure_kind,
                 inputs=task.inputs if verbose else None,
             )
         )

--- a/ginkgo/cli/renderers/models.py
+++ b/ginkgo/cli/renderers/models.py
@@ -44,6 +44,7 @@ class _FailureDetails:
     log_path: Path | None
     log_tail: list[str]
     error: str | None = None
+    failure_kind: str | None = None
     inputs: dict[str, object] | None = None
 
 

--- a/ginkgo/cli/renderers/run.py
+++ b/ginkgo/cli/renderers/run.py
@@ -392,14 +392,33 @@ class _CliRunRenderer:
         return text
 
     def _render_failure_details(self, details: list[_FailureDetails]):
-        panels = [self._render_failure_panel(item) for item in details]
-        return Group(*panels)
+        parts: list[object] = []
+        category_summary = self._render_failure_category_summary(details)
+        if category_summary is not None:
+            parts.append(category_summary)
+        parts.extend(self._render_failure_panel(item) for item in details)
+        return Group(*parts)
+
+    def _render_failure_category_summary(self, details: list[_FailureDetails]) -> Text | None:
+        """Return a one-line summary grouping failures by category, if any."""
+        categorised = [item for item in details if item.failure_kind]
+        if not categorised:
+            return None
+        counts = Counter(item.failure_kind for item in categorised)
+        parts = [f"{kind}×{count}" for kind, count in sorted(counts.items())]
+        summary = Text()
+        summary.append("Failures by category: ", style="bold #7f1d1d")
+        summary.append(", ".join(parts), style="#7f1d1d")
+        summary.append("\n")
+        return summary
 
     def _render_failure_panel(self, details: _FailureDetails) -> Panel:
         summary = Table.grid(padding=(0, 1))
         summary.add_column(style="bold #7f1d1d", no_wrap=True)
         summary.add_column()
         summary.add_row("Task", details.task_label)
+        if details.failure_kind:
+            summary.add_row("Category", details.failure_kind)
         summary.add_row(
             "Exit code", str(details.exit_code) if details.exit_code is not None else "?"
         )

--- a/ginkgo/core/task.py
+++ b/ginkgo/core/task.py
@@ -37,6 +37,25 @@ class TaskDef:
         Cache-busting version tag.
     retries : int
         Additional retry attempts after the initial execution.
+    retry_on : type[BaseException] | tuple[type[BaseException], ...] | None
+        When set, only retry failures matching these exception classes.
+        ``None`` (default) retries every failure up to ``retries``.
+    retry_backoff : float
+        Base delay in seconds between retry attempts. ``0.0`` (default)
+        reruns immediately.
+    retry_backoff_multiplier : float
+        Exponential factor applied to the base delay. Delay for attempt
+        *k* (1-indexed) is ``retry_backoff * retry_backoff_multiplier ** (k - 1)``,
+        capped at ``retry_backoff_max``.
+    retry_backoff_max : float
+        Upper bound on the computed retry delay, in seconds.
+    retry_on_exit_codes : tuple[int, ...] | None
+        Shell-task only. When set, only retry failures whose exit code is
+        in this tuple. Ignored for non-shell tasks.
+    priority : int
+        Relative scheduling priority. When several tasks are ready at the
+        same time, higher-priority tasks are dispatched first. Range is
+        ``[-1000, 1000]``; default ``0``.
     kind : str
         Execution contract for the task body.
     threads : int
@@ -68,6 +87,12 @@ class TaskDef:
     env: str | None = None
     version: int = 1
     retries: int = 0
+    retry_on: type[BaseException] | tuple[type[BaseException], ...] | None = None
+    retry_backoff: float = 0.0
+    retry_backoff_multiplier: float = 2.0
+    retry_backoff_max: float = 60.0
+    retry_on_exit_codes: tuple[int, ...] | None = None
+    priority: int = 0
     kind: str = "python"
     threads: int = 1
     memory: str | None = None
@@ -93,6 +118,25 @@ class TaskDef:
             raise ValueError(f"threads must be at least 1, got {self.threads}")
         if self.gpu < 0:
             raise ValueError(f"gpu must be at least 0, got {self.gpu}")
+        if self.retry_backoff < 0:
+            raise ValueError(f"retry_backoff must be at least 0, got {self.retry_backoff}")
+        if self.retry_backoff_multiplier < 1:
+            raise ValueError(
+                f"retry_backoff_multiplier must be at least 1, got {self.retry_backoff_multiplier}"
+            )
+        if self.retry_backoff_max < 0:
+            raise ValueError(f"retry_backoff_max must be at least 0, got {self.retry_backoff_max}")
+        _validate_retry_on(self.retry_on)
+        if not isinstance(self.priority, int) or isinstance(self.priority, bool):
+            raise TypeError(f"priority must be an integer, got {type(self.priority).__name__}")
+        if abs(self.priority) > 1000:
+            raise ValueError(f"priority must be in range [-1000, 1000], got {self.priority}")
+        if self.retry_on_exit_codes is not None:
+            if self.kind != "shell":
+                raise ValueError("retry_on_exit_codes is only valid for shell tasks")
+            for code in self.retry_on_exit_codes:
+                if not isinstance(code, int) or isinstance(code, bool):
+                    raise ValueError(f"retry_on_exit_codes must be integers, got {code!r}")
 
         parsed_memory = _parse_memory(self.memory)
         object.__setattr__(self, "_memory_gb", parsed_memory)
@@ -161,6 +205,29 @@ class TaskDef:
         at execution time via the ``NotebookExpr``/``ScriptExpr`` sentinel.
         """
         return self._source_hash
+
+    def should_retry_exception(self, *, exc: BaseException) -> bool:
+        """Return whether ``exc`` matches the configured retry policy."""
+        if self.retry_on is None and self.retry_on_exit_codes is None:
+            return True
+
+        class_match = self.retry_on is None or isinstance(exc, self.retry_on)
+        if self.retry_on_exit_codes is not None:
+            exit_code = getattr(exc, "exit_code", None)
+            code_match = isinstance(exit_code, int) and exit_code in self.retry_on_exit_codes
+        else:
+            code_match = True
+
+        if self.retry_on is not None and self.retry_on_exit_codes is not None:
+            return class_match and code_match
+        return class_match and code_match
+
+    def retry_delay_seconds(self, *, attempt: int) -> float:
+        """Return the retry delay to wait before ``attempt`` (1-indexed)."""
+        if self.retry_backoff <= 0 or attempt < 1:
+            return 0.0
+        delay = self.retry_backoff * (self.retry_backoff_multiplier ** (attempt - 1))
+        return min(delay, self.retry_backoff_max)
 
     def __call__(self, **kwargs: Any) -> Expr | PartialCall:
         """Build an ``Expr`` (all required args supplied) or ``PartialCall``.
@@ -521,6 +588,12 @@ def task(
     env: str | None = None,
     version: int = 1,
     retries: int = 0,
+    retry_on: type[BaseException] | tuple[type[BaseException], ...] | None = None,
+    retry_backoff: float = 0.0,
+    retry_backoff_multiplier: float = 2.0,
+    retry_backoff_max: float = 60.0,
+    retry_on_exit_codes: tuple[int, ...] | None = None,
+    priority: int = 0,
     kind: str = "python",
     threads: int = 1,
     memory: str | None = None,
@@ -549,6 +622,20 @@ def task(
         Cache-busting version tag.  Bump when task logic changes.
     retries : int
         Additional retry attempts after the initial execution.
+    retry_on : type[BaseException] | tuple[type[BaseException], ...] | None
+        Narrow retries to specific exception classes. ``None`` retries any
+        failure.
+    retry_backoff : float
+        Base delay (seconds) before each retry. ``0.0`` disables the delay.
+    retry_backoff_multiplier : float
+        Exponential factor applied between attempts.
+    retry_backoff_max : float
+        Upper bound on the computed delay, in seconds.
+    retry_on_exit_codes : tuple[int, ...] | None
+        Shell-task only. Narrow retries to specific exit codes.
+    priority : int
+        Relative scheduling priority. Higher runs first among ready tasks.
+        Range ``[-1000, 1000]``; default ``0``.
     kind : str
         Execution contract for the task body. Ignored when ``_kind`` is given.
     threads : int
@@ -600,6 +687,12 @@ def task(
             env=env,
             version=version,
             retries=retries,
+            retry_on=retry_on,
+            retry_backoff=retry_backoff,
+            retry_backoff_multiplier=retry_backoff_multiplier,
+            retry_backoff_max=retry_backoff_max,
+            retry_on_exit_codes=retry_on_exit_codes,
+            priority=priority,
             kind=resolved_kind,
             threads=threads,
             memory=memory,
@@ -612,6 +705,21 @@ def task(
         )
 
     return decorator
+
+
+def _validate_retry_on(
+    retry_on: type[BaseException] | tuple[type[BaseException], ...] | None,
+) -> None:
+    """Validate that ``retry_on`` names only exception classes."""
+    if retry_on is None:
+        return
+    candidates: tuple[Any, ...] = retry_on if isinstance(retry_on, tuple) else (retry_on,)
+    for candidate in candidates:
+        if not (isinstance(candidate, type) and issubclass(candidate, BaseException)):
+            raise ValueError(
+                "retry_on must be an exception class or tuple of exception "
+                f"classes, got {candidate!r}"
+            )
 
 
 _MEMORY_PATTERN = re.compile(r"^(\d+(?:\.\d+)?)\s*(Gi|Mi|G|M|Ti|Ki)$")

--- a/ginkgo/runtime/evaluator.py
+++ b/ginkgo/runtime/evaluator.py
@@ -188,6 +188,7 @@ class _TaskNode:
     stderr_path: Path | None = None
     display_label: str | None = None
     attempt: int = 0
+    retry_ready_at: float | None = None
     secret_values: tuple[str, ...] = ()
     driver_sentinel: Any = None
     extra_source_hash: str | None = None
@@ -358,6 +359,7 @@ class _ConcurrentEvaluator:
                         self._interrupt_running_work()
 
                     if self._failure is None:
+                        self._promote_due_retries()
                         with self.profiler.timed("scheduler_prepare"):
                             self._prepare_pending_nodes()
                             self._finalize_dynamic_nodes()
@@ -369,14 +371,14 @@ class _ConcurrentEvaluator:
 
                         if self._is_root_resolved() and not self._running_futures:
                             return self._materialize(self._root_template)
-                    elif not self._running_futures:
-                        break
 
                     if self._running_futures:
+                        retry_wait = self._earliest_retry_wait() if self._failure is None else None
                         with self.profiler.timed("scheduler_wait"):
                             done, _ = wait(
                                 tuple(self._running_futures.keys()),
                                 return_when=FIRST_COMPLETED,
+                                timeout=retry_wait,
                             )
                         with self.profiler.timed("scheduler_consume_completed"):
                             self._consume_completed_futures(done)
@@ -387,6 +389,12 @@ class _ConcurrentEvaluator:
 
                     if self._is_root_resolved():
                         return self._materialize(self._root_template)
+
+                    retry_wait = self._earliest_retry_wait()
+                    if retry_wait is not None:
+                        # Short, signal-interruptable sleep until the next retry is due.
+                        time.sleep(min(retry_wait, 0.5))
+                        continue
 
                     if self._can_make_scheduler_progress():
                         continue
@@ -657,6 +665,7 @@ class _ConcurrentEvaluator:
                     node_id=node.node_id,
                     threads=node.threads,
                     memory_gb=node.memory_gb,
+                    priority=node.task_def.priority,
                     concurrency_group=node.concurrency_group,
                 )
                 for node in ready_nodes
@@ -810,7 +819,7 @@ class _ConcurrentEvaluator:
     def _handle_task_exception(self, *, node: _TaskNode, exc: BaseException) -> None:
         """Either retry a failed task attempt or fail the run."""
         sanitized_exc = sanitize_exception(exc=exc, secret_values=node.secret_values)
-        if self._failure is None and self._should_retry(node=node):
+        if self._failure is None and self._should_retry(node=node, exc=sanitized_exc):
             self._schedule_retry(node=node, exc=sanitized_exc)
             return
 
@@ -833,9 +842,11 @@ class _ConcurrentEvaluator:
             )
         )
 
-    def _should_retry(self, *, node: _TaskNode) -> bool:
+    def _should_retry(self, *, node: _TaskNode, exc: BaseException) -> bool:
         """Return whether the current failed attempt should be retried."""
-        return node.attempt <= node.task_def.retries
+        if node.attempt > node.task_def.retries:
+            return False
+        return node.task_def.should_retry_exception(exc=exc)
 
     def _schedule_retry(self, *, node: _TaskNode, exc: BaseException) -> None:
         """Reset node state so the scheduler can rerun the task from scratch."""
@@ -846,7 +857,15 @@ class _ConcurrentEvaluator:
             if path.exists():
                 shutil.rmtree(path)
 
-        node.state = "pending"
+        # Attempt is incremented on dispatch, so the next attempt is node.attempt + 1.
+        delay = node.task_def.retry_delay_seconds(attempt=node.attempt)
+        if delay > 0:
+            node.state = "waiting_retry"
+            node.retry_ready_at = time.monotonic() + delay
+        else:
+            node.state = "pending"
+            node.retry_ready_at = None
+
         node.resolved_args = None
         node.execution_args = None
         node.cache_key = None
@@ -881,6 +900,7 @@ class _ConcurrentEvaluator:
                 display_label=node.display_label,
                 retries_remaining=retries_remaining,
                 failure=classify_failure(exc=exc),
+                delay_seconds=delay,
             )
         )
 
@@ -1089,7 +1109,30 @@ class _ConcurrentEvaluator:
                 node.dynamic_dependency_ids
             ):
                 return True
+            if node.state == "waiting_retry":
+                return True
         return False
+
+    def _promote_due_retries(self) -> None:
+        """Transition retry-delayed nodes back to pending once their deadline passes."""
+        now = time.monotonic()
+        for node in self._nodes.values():
+            if node.state != "waiting_retry":
+                continue
+            if node.retry_ready_at is not None and node.retry_ready_at <= now:
+                node.state = "pending"
+                node.retry_ready_at = None
+
+    def _earliest_retry_wait(self) -> float | None:
+        """Return seconds until the next retry deadline, or ``None`` if none waiting."""
+        deadlines = [
+            node.retry_ready_at
+            for node in self._nodes.values()
+            if node.state == "waiting_retry" and node.retry_ready_at is not None
+        ]
+        if not deadlines:
+            return None
+        return max(0.0, min(deadlines) - time.monotonic())
 
     def _cancel_pending_futures(self) -> None:
         """Cancel queued futures that have not started yet."""

--- a/ginkgo/runtime/events.py
+++ b/ginkgo/runtime/events.py
@@ -163,6 +163,7 @@ class TaskRetrying(TaskEvent):
     event: str = "task_retrying"
     retries_remaining: int = 0
     failure: dict[str, Any] = field(default_factory=dict)
+    delay_seconds: float = 0.0
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/ginkgo/runtime/run_summary.py
+++ b/ginkgo/runtime/run_summary.py
@@ -73,6 +73,7 @@ class TaskSummary:
     duration_s: float | None
     exit_code: int | None
     error: str | None
+    failure: dict[str, Any] | None
     env: str
     cache_key: str | None
     stdout_log: str | None
@@ -303,6 +304,7 @@ def _build_task_summary(*, task_key: str, task: dict[str, Any]) -> TaskSummary:
         duration_s=_duration_seconds(started, finished),
         exit_code=task.get("exit_code") if isinstance(task.get("exit_code"), int) else None,
         error=task.get("error") if isinstance(task.get("error"), str) else None,
+        failure=task.get("failure") if isinstance(task.get("failure"), dict) else None,
         env=str(task.get("env") or "local"),
         cache_key=task.get("cache_key") if isinstance(task.get("cache_key"), str) else None,
         stdout_log=stdout_log,

--- a/ginkgo/runtime/scheduler.py
+++ b/ginkgo/runtime/scheduler.py
@@ -20,6 +20,9 @@ class SchedulableTask:
         Core footprint for the task.
     memory_gb : int
         Declared memory footprint for the task in GiB.
+    priority : int
+        Declared scheduling priority. Higher values run first when multiple
+        ready tasks contend for the same resources. Default is ``0``.
     concurrency_group : str | None
         Optional named concurrency group. When set, the scheduler will
         respect the corresponding entry in ``available_group_slots`` when
@@ -29,6 +32,7 @@ class SchedulableTask:
     node_id: int
     threads: int
     memory_gb: int
+    priority: int = 0
     concurrency_group: str | None = None
 
 
@@ -109,10 +113,18 @@ def _select_with_cp_sat(
 
     total_selected = sum(selected.values())
     total_cores = sum(task.threads * selected[task.node_id] for task in tasks)
+    priority_sum = sum(task.priority * selected[task.node_id] for task in tasks)
     order_bias = sum(
         (len(tasks) - index) * selected[task.node_id] for index, task in enumerate(tasks)
     )
-    model.Maximize(total_selected * 100000 + total_cores * 100 + order_bias)
+    # Weights establish a strict lexicographic preference:
+    # (1) dispatch as many tasks as possible,
+    # (2) fill the core budget,
+    # (3) prefer higher-priority tasks when (1) and (2) are tied,
+    # (4) break remaining ties in declaration order.
+    model.Maximize(
+        total_selected * 10_000_000 + total_cores * 10_000 + priority_sum * 100 + order_bias
+    )
 
     solver = cp_model.CpSolver()
     status = solver.Solve(model)

--- a/ginkgo/runtime/task_runners/shell.py
+++ b/ginkgo/runtime/task_runners/shell.py
@@ -137,16 +137,39 @@ def sanitize_exception(
 def classify_failure(*, exc: BaseException) -> dict[str, Any]:
     """Return a structured task failure summary."""
     # Imported lazily to avoid a hard import cycle with the notebook runner.
+    from ginkgo.envs.container import ContainerPrepareError, ContainerRuntimeNotFoundError
+    from ginkgo.envs.pixi import (
+        PixiEnvImportError,
+        PixiEnvNotFoundError,
+        PixiEnvPrepareError,
+    )
     from ginkgo.runtime.evaluator import CycleError
     from ginkgo.runtime.task_runners.notebook import NotebookTaskError
 
     message = str(exc)
     if isinstance(exc, CycleError):
         kind = "cycle_detected"
+    elif isinstance(
+        exc,
+        (
+            PixiEnvNotFoundError,
+            PixiEnvImportError,
+            PixiEnvPrepareError,
+            ContainerRuntimeNotFoundError,
+            ContainerPrepareError,
+        ),
+    ):
+        kind = "env_mismatch"
+    elif isinstance(exc, ModuleNotFoundError):
+        kind = "import_error"
+    elif isinstance(exc, ImportError):
+        kind = "import_error"
     elif isinstance(exc, CodecError):
         kind = "serialization_error"
     elif isinstance(exc, (ShellTaskError, NotebookTaskError)):
         kind = "shell_command_error"
+    elif isinstance(exc, (IsADirectoryError, NotADirectoryError, PermissionError)):
+        kind = "invalid_path"
     elif isinstance(exc, FileNotFoundError):
         kind = "missing_input" if "did not create" not in message else "output_validation_error"
     elif isinstance(exc, (TypeError, ValueError)):
@@ -154,7 +177,7 @@ def classify_failure(*, exc: BaseException) -> dict[str, Any]:
     else:
         exc_name = exc.__class__.__name__.lower()
         if "env" in exc_name or "container" in exc_name:
-            kind = "environment_error"
+            kind = "env_mismatch"
         elif "cache" in exc_name:
             kind = "cache_error"
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,57 @@ def main():
         assert result.returncode == 1
         assert "Invalid duration for --older-than" in result.stderr
 
+    def test_cache_prune_requires_at_least_one_policy(self) -> None:
+        result = _run_cli("cache", "prune", cwd=Path.cwd())
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "--older-than" in combined
+
+    def test_cache_prune_by_max_entries_removes_oldest(self) -> None:
+        cache_root = Path(".ginkgo") / "cache"
+        now = datetime.now(timezone.utc)
+        entries = []
+        for index, age_days in enumerate([100, 60, 30, 5]):
+            entry = cache_root / f"entry{index}"
+            entry.mkdir(parents=True)
+            ts = (now - timedelta(days=age_days)).isoformat()
+            (entry / "meta.json").write_text(
+                f'{{"function":"demo.x","timestamp":"{ts}"}}',
+                encoding="utf-8",
+            )
+            (entry / "output.json").write_text("{}", encoding="utf-8")
+            entries.append(entry)
+
+        result = _run_cli("cache", "prune", "--max-entries", "2", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert not entries[0].exists()
+        assert not entries[1].exists()
+        assert entries[2].exists()
+        assert entries[3].exists()
+
+    def test_cache_prune_by_max_size_removes_oldest_until_under_budget(self) -> None:
+        cache_root = Path(".ginkgo") / "cache"
+        now = datetime.now(timezone.utc)
+        entries = []
+        payload = "x" * 1024
+        for index, age_days in enumerate([100, 60, 5]):
+            entry = cache_root / f"sz{index}"
+            entry.mkdir(parents=True)
+            ts = (now - timedelta(days=age_days)).isoformat()
+            (entry / "meta.json").write_text(
+                f'{{"function":"demo.x","timestamp":"{ts}"}}',
+                encoding="utf-8",
+            )
+            (entry / "output.json").write_text(payload, encoding="utf-8")
+            entries.append(entry)
+
+        # Each entry holds ~1KB; cap total at 3KB so only the oldest must drop.
+        result = _run_cli("cache", "prune", "--max-size", "3KB", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert not entries[0].exists()
+        assert entries[1].exists()
+        assert entries[2].exists()
+
     def test_notebooks_lists_pairs_in_most_recent_run_order(self) -> None:
         older_run = Path(".ginkgo") / "runs" / "20260301_090000_000000_aaaaaaaa"
         newer_run = Path(".ginkgo") / "runs" / "20260302_090000_000000_bbbbbbbb"

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -110,6 +110,46 @@ def always_fail_once_task(log_path: str) -> str:
     raise RuntimeError("no retry configured")
 
 
+@task(retries=2, retry_on=IOError)
+def retry_only_ioerror_task(log_path: str, kind: str) -> str:
+    _append_line(log_path, "attempt")
+    if kind == "ioerror":
+        raise IOError("transient io")
+    raise ValueError("unexpected value")
+
+
+@task(retries=3, retry_backoff=0.05, retry_backoff_multiplier=2.0)
+def flaky_with_backoff_task(marker_path: str, log_path: str) -> str:
+    import time as _time
+
+    _append_line(log_path, f"attempt:{_time.monotonic():.6f}")
+    marker = Path(marker_path)
+    failures = int(marker.read_text(encoding="utf-8")) if marker.exists() else 0
+    if failures < 2:
+        marker.write_text(str(failures + 1), encoding="utf-8")
+        raise RuntimeError("still transient")
+    return "ok"
+
+
+@task(kind="shell", retries=2, retry_on_exit_codes=(7,))
+def shell_retry_on_exit_code_task(marker_path: str, output_path: str, log_path: str) -> file:
+    return shell(
+        cmd=(
+            f"if [ ! -f {marker_path} ]; then "
+            f"touch {marker_path}; "
+            "exit 7; "
+            f"fi; printf 'payload' > {output_path}"
+        ),
+        output=output_path,
+        log=log_path,
+    )
+
+
+@task(kind="shell", retries=2, retry_on_exit_codes=(137,))
+def shell_retry_skip_mismatched_exit_code_task(output_path: str, log_path: str) -> file:
+    return shell(cmd="exit 7", output=output_path, log=log_path)
+
+
 @task(kind="shell")
 def shell_write_output_task(output_path: str, log_path: str) -> file:
     return shell(
@@ -1071,6 +1111,69 @@ class TestEvaluate:
             "attempt",
             "attempt",
         ]
+
+    def test_retry_on_narrows_by_exception_class(self):
+        log_path = "retry-ioerror.log"
+
+        # IOError matches — task is retried.
+        with pytest.raises(IOError, match="transient io"):
+            evaluate(retry_only_ioerror_task(log_path=log_path, kind="ioerror"))
+        assert Path(log_path).read_text(encoding="utf-8").splitlines() == [
+            "attempt",
+            "attempt",
+            "attempt",
+        ]
+
+        # ValueError does not match — task fails immediately without retry.
+        log_path2 = "retry-skip.log"
+        with pytest.raises(ValueError, match="unexpected value"):
+            evaluate(retry_only_ioerror_task(log_path=log_path2, kind="value"))
+        assert Path(log_path2).read_text(encoding="utf-8").splitlines() == ["attempt"]
+
+    def test_retry_backoff_delays_attempts(self):
+        import time as _time
+
+        marker_path = "backoff.marker"
+        log_path = "backoff.log"
+
+        started = _time.monotonic()
+        assert (
+            evaluate(flaky_with_backoff_task(marker_path=marker_path, log_path=log_path)) == "ok"
+        )
+        elapsed = _time.monotonic() - started
+
+        # Two retries with base=0.05s and multiplier=2: delays 0.05 + 0.10 = 0.15s minimum.
+        assert elapsed >= 0.15
+        lines = Path(log_path).read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+
+        stamps = [float(line.split(":", 1)[1]) for line in lines]
+        assert stamps[1] - stamps[0] >= 0.04
+        assert stamps[2] - stamps[1] >= 0.09
+
+    def test_shell_retry_on_exit_codes_narrows(self, tmp_path: Path):
+        marker = tmp_path / "shell-retry.marker"
+        output = tmp_path / "shell-retry.out"
+        log = tmp_path / "shell-retry.log"
+
+        # Exit 7 matches — retried and succeeds.
+        result = evaluate(
+            shell_retry_on_exit_code_task(
+                marker_path=str(marker), output_path=str(output), log_path=str(log)
+            )
+        )
+        assert result == file(str(output))
+        assert output.read_text(encoding="utf-8") == "payload"
+
+        # Exit 7 does not match (policy expects 137) — fails immediately with no retry.
+        output2 = tmp_path / "shell-retry2.out"
+        log2 = tmp_path / "shell-retry2.log"
+        with pytest.raises(Exception):
+            evaluate(
+                shell_retry_skip_mismatched_exit_code_task(
+                    output_path=str(output2), log_path=str(log2)
+                )
+            )
 
     def test_cached_upstream_tasks_do_not_deadlock_newly_unblocked_downstream(
         self,

--- a/tests/test_scheduler_priority.py
+++ b/tests/test_scheduler_priority.py
@@ -1,0 +1,57 @@
+"""Priority tiebreak tests for the CP-SAT dispatch selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from ginkgo.core.task import TaskDef
+from ginkgo.runtime.scheduler import SchedulableTask, select_dispatch_subset
+
+
+class TestSchedulerPriority:
+    def test_priority_tiebreak_selects_higher_first(self) -> None:
+        ready = [
+            SchedulableTask(node_id=1, threads=2, memory_gb=0, priority=0),
+            SchedulableTask(node_id=2, threads=2, memory_gb=0, priority=10),
+            SchedulableTask(node_id=3, threads=2, memory_gb=0, priority=5),
+        ]
+        # Only 4 cores: 2 tasks can run concurrently.
+        selected = select_dispatch_subset(ready_tasks=ready, jobs=4, cores=4)
+        assert sorted(selected) == [2, 3]
+
+    def test_priority_does_not_overrule_task_count_maximization(self) -> None:
+        # Task A (priority 100) uses 4 cores. Tasks B, C (priority 0) use 1 core each.
+        # With 4 cores total we can select {B, C} (count=2) or {A} (count=1).
+        # total_selected dominates, so B and C must win despite lower priority.
+        ready = [
+            SchedulableTask(node_id=1, threads=4, memory_gb=0, priority=100),
+            SchedulableTask(node_id=2, threads=1, memory_gb=0, priority=0),
+            SchedulableTask(node_id=3, threads=1, memory_gb=0, priority=0),
+        ]
+        selected = select_dispatch_subset(ready_tasks=ready, jobs=4, cores=4)
+        assert sorted(selected) == [2, 3]
+
+    def test_priority_default_zero_does_not_change_selection(self) -> None:
+        ready = [
+            SchedulableTask(node_id=1, threads=1, memory_gb=0),
+            SchedulableTask(node_id=2, threads=1, memory_gb=0),
+            SchedulableTask(node_id=3, threads=1, memory_gb=0),
+        ]
+        selected = select_dispatch_subset(ready_tasks=ready, jobs=3, cores=3)
+        assert sorted(selected) == [1, 2, 3]
+
+
+class TestTaskDefPriorityValidation:
+    def test_priority_out_of_range_rejected(self) -> None:
+        def _f() -> int:
+            return 0
+
+        with pytest.raises(ValueError, match="priority must be in range"):
+            TaskDef(fn=_f, priority=10_000)
+
+    def test_priority_non_int_rejected(self) -> None:
+        def _f() -> int:
+            return 0
+
+        with pytest.raises(TypeError, match="priority must be an integer"):
+            TaskDef(fn=_f, priority=1.5)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- **Selective retry + backoff** — `@task(retry_on=..., retry_backoff=..., retry_on_exit_codes=...)`. Delayed retries sit in a new `waiting_retry` scheduler state; `TaskRetrying` events carry `delay_seconds`.
- **Size/count cache eviction** — `ginkgo cache prune --max-size 2GB --max-entries 500`, combinable with `--older-than`; oldest-first with orphan artifact GC.
- **Task priority** — `@task(priority=N)` as a strict CP-SAT tiebreaker. Never overrides total-selected or core-fill, so default workloads are unchanged.
- **Failure classification** — adds `env_mismatch`, `import_error`, `invalid_path` kinds; end-of-run renderer groups failures by category.
- **Docs** — architecture (execution-model, caching, cli, index) + user-facing guides on partial resume, dry-run, resource declarations, and eviction policies.

## Test plan

- [x] `pixi run pytest tests/` (excluding k8s/remote-provenance heavy suites): 599 passed, 5 skipped
- [x] New tests: retry policy classes/exit codes/backoff, cache size+count prune, scheduler priority tiebreak
- [x] `ruff check` + `ruff format` + `ty check` clean on touched files
- [ ] Manual smoke-run of VW-4/5/6/8 through polished CLI (follow-up)