### PR TITLE
chore: add Trivy and detect-secrets security CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -42,4 +42,4 @@ jobs:
           detect-secrets scan \
             --exclude-files 'pixi\.lock|uv\.lock|.*\.ipynb' \
             --baseline .secrets.baseline
-          git diff --exit-code .secrets.baseline
+          git diff .secrets.baseline | grep -v '"generated_at"' | grep -q '^[+-][^+-]' && exit 1 || exit 0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,45 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install detect-secrets
+        run: pip install detect-secrets==1.5.0
+
+      - name: Check for new secrets
+        run: |
+          detect-secrets scan \
+            --exclude-files 'pixi\.lock|uv\.lock|.*\.ipynb' \
+            --baseline .secrets.baseline
+          git diff --exit-code .secrets.baseline

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,164 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "pixi\\.lock|uv\\.lock|.*\\.ipynb"
+      ]
+    }
+  ],
+  "results": {
+    "benchmarks/sources/bioinfo_agam.toml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/sources/bioinfo_agam.toml",
+        "hashed_secret": "d0954ae01fb1ba26ca8835a06193318b34a3c02f",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "src/ginkgo/cli/commands/secrets.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/ginkgo/cli/commands/secrets.py",
+        "hashed_secret": "38b62be4bddaa5661c7d6b8e36e28159314df5c7",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      }
+    ],
+    "tests/test_subworkflow.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_subworkflow.py",
+        "hashed_secret": "432500caea0b94e6f00a8392a0a8822905c1201b",
+        "is_verified": false,
+        "line_number": 151,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2026-05-15T16:00:40Z"
+}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -160,5 +164,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T16:00:40Z"
+  "generated_at": "2026-05-15T16:04:35Z"
 }


### PR DESCRIPTION
## Summary

- Adds `security.yml` GitHub Actions workflow with two jobs:
  - **trivy**: filesystem scan for CRITICAL/HIGH CVEs, uploads SARIF results to the GitHub Security tab
  - **detect-secrets**: scans for secrets on every PR/push, diffs against committed baseline to catch net-new additions
- Adds `.secrets.baseline` with three pre-audited false positives (git commit hash, variable named `secrets_command`, fake test run ID)

## Test plan

- [ ] Verify Trivy job passes and results appear in the Security tab
- [ ] Verify detect-secrets job passes on this branch
- [ ] Introduce a dummy secret on a test branch and confirm detect-secrets job fails