### PR TITLE
refactor: dedupe shared payload helpers across remote executors

### DIFF
--- a/src/ginkgo/remote/_executor_common.py
+++ b/src/ginkgo/remote/_executor_common.py
@@ -1,0 +1,85 @@
+"""Shared helpers for the remote executor backends (Kubernetes, GCP Batch).
+
+The two executor modules (`kubernetes.py`, `gcp_batch.py`) share a small set
+of attempt-payload helpers — encoding, naming, fuse detection, and worker
+log parsing. They live here so both backends import a single copy.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+
+def _encode_payload(attempt: dict[str, Any]) -> str:
+    """Encode a worker payload as a base64 JSON string."""
+    payload_json = json.dumps(attempt, default=str)
+    return base64.b64encode(payload_json.encode()).decode()
+
+
+def _generate_job_name(attempt: dict[str, Any]) -> str:
+    """Generate a unique remote-job identifier from the attempt payload.
+
+    Produces a name compatible with both Kubernetes Jobs and GCP Batch
+    jobs: lowercase, starts with a letter, alphanumeric + hyphens, no
+    longer than 63 characters. Appends a short content-hash suffix so
+    resubmissions of the same (run_id, task_id, attempt) do not collide.
+    """
+    run_id = attempt.get("run_id", "unknown")
+    task_id = attempt.get("task_id", "unknown")
+    attempt_num = attempt.get("attempt", 0)
+    digest = hashlib.sha256(json.dumps(attempt, sort_keys=True, default=str).encode())
+    suffix = digest.hexdigest()[:6]
+    name = f"ginkgo-{run_id}-{task_id}-{attempt_num}-{suffix}"
+    name = name.lower().replace("_", "-")
+    if len(name) > 63:
+        name = name[:63]
+    return name.rstrip("-")
+
+
+def _payload_requires_fuse(attempt: dict[str, Any]) -> bool:
+    """Return True when the payload contains any fuse-marked inputs."""
+    from ginkgo.remote.access.protocol import FUSE_FILE_TYPE, FUSE_FOLDER_TYPE
+
+    fuse_tags = {FUSE_FILE_TYPE, FUSE_FOLDER_TYPE}
+
+    def walk(value: Any) -> bool:
+        if isinstance(value, dict):
+            if value.get("__ginkgo_type__") in fuse_tags:
+                return True
+            return any(walk(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(walk(item) for item in value)
+        return False
+
+    return walk(attempt.get("args"))
+
+
+def _parse_worker_output(logs: str, *, source_label: str = "job logs") -> dict[str, Any]:
+    """Parse the worker result from container log output.
+
+    The remote worker prints a single JSON line to stdout as its last
+    output. Search backwards from the end to find it. ``source_label``
+    is interpolated into the fallback error payload so callers can
+    surface a more specific origin (e.g. ``"pod logs"``).
+    """
+    for line in reversed(logs.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    message = f"No worker output found in {source_label}"
+    return {
+        "ok": False,
+        "error": {
+            "type": "RuntimeError",
+            "module": "builtins",
+            "message": message,
+            "args": [message],
+        },
+    }

--- a/src/ginkgo/remote/gcp_batch.py
+++ b/src/ginkgo/remote/gcp_batch.py
@@ -7,89 +7,24 @@ infrastructure.
 
 from __future__ import annotations
 
-import base64
-import hashlib
 import json
 import logging
 import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from ginkgo.remote._executor_common import (
+    _encode_payload,
+    _generate_job_name,
+    _parse_worker_output,
+    _payload_requires_fuse,
+)
 from ginkgo.runtime.remote_executor import (
     RemoteJobResult,
     RemoteJobState,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _encode_payload(attempt: dict[str, Any]) -> str:
-    """Encode a worker payload as a base64 JSON string."""
-    payload_json = json.dumps(attempt, default=str)
-    return base64.b64encode(payload_json.encode()).decode()
-
-
-def _generate_job_id(attempt: dict[str, Any]) -> str:
-    """Generate a unique GCP Batch job ID from the attempt payload.
-
-    GCP Batch job IDs must be lowercase, start with a letter, and contain
-    only letters, numbers, and hyphens.  Max 63 characters.
-
-    Appends a short content hash to avoid collisions on resubmission.
-    """
-    run_id = attempt.get("run_id", "unknown")
-    task_id = attempt.get("task_id", "unknown")
-    attempt_num = attempt.get("attempt", 0)
-    digest = hashlib.sha256(json.dumps(attempt, sort_keys=True, default=str).encode())
-    suffix = digest.hexdigest()[:6]
-    name = f"ginkgo-{run_id}-{task_id}-{attempt_num}-{suffix}"
-    name = name.lower().replace("_", "-")
-    if len(name) > 63:
-        name = name[:63]
-    return name.rstrip("-")
-
-
-def _payload_requires_fuse(attempt: dict[str, Any]) -> bool:
-    """Return True when the payload contains any fuse-marked inputs."""
-    from ginkgo.remote.access.protocol import FUSE_FILE_TYPE, FUSE_FOLDER_TYPE
-
-    fuse_tags = {FUSE_FILE_TYPE, FUSE_FOLDER_TYPE}
-
-    def walk(value: Any) -> bool:
-        if isinstance(value, dict):
-            if value.get("__ginkgo_type__") in fuse_tags:
-                return True
-            return any(walk(item) for item in value.values())
-        if isinstance(value, (list, tuple)):
-            return any(walk(item) for item in value)
-        return False
-
-    return walk(attempt.get("args"))
-
-
-def _parse_worker_output(logs: str) -> dict[str, Any]:
-    """Parse the worker result from container log output.
-
-    The remote worker prints a single JSON line to stdout as its last
-    output.  Search backwards from the end to find it.
-    """
-    for line in reversed(logs.splitlines()):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            return json.loads(line)
-        except json.JSONDecodeError:
-            continue
-    return {
-        "ok": False,
-        "error": {
-            "type": "RuntimeError",
-            "module": "builtins",
-            "message": "No worker output found in job logs",
-            "args": ["No worker output found in job logs"],
-        },
-    }
 
 
 @dataclass(kw_only=True)
@@ -238,7 +173,7 @@ class GCPBatchExecutor:
             ),
         )
 
-        job_id = _generate_job_id(attempt)
+        job_id = _generate_job_name(attempt)
         parent = f"projects/{self.project}/locations/{self.region}"
 
         created = client.create_job(

--- a/src/ginkgo/remote/kubernetes.py
+++ b/src/ginkgo/remote/kubernetes.py
@@ -6,87 +6,26 @@ Kubernetes cluster.  One Job per attempt; Ginkgo handles retries.
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import json
 import os
 import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from ginkgo.remote._executor_common import (
+    _encode_payload,
+    _generate_job_name,
+    _parse_worker_output as _parse_worker_output_common,
+    _payload_requires_fuse,
+)
 from ginkgo.runtime.remote_executor import (
     RemoteJobResult,
     RemoteJobState,
 )
 
 
-def _encode_payload(attempt: dict[str, Any]) -> str:
-    """Encode a worker payload as a base64 JSON string."""
-    payload_json = json.dumps(attempt, default=str)
-    return base64.b64encode(payload_json.encode()).decode()
-
-
-def _generate_job_name(attempt: dict[str, Any]) -> str:
-    """Generate a unique Kubernetes Job name from the attempt payload.
-
-    Appends a short hash suffix derived from the payload content to avoid
-    collisions when the same (run_id, task_id, attempt) is resubmitted.
-    """
-    run_id = attempt.get("run_id", "unknown")
-    task_id = attempt.get("task_id", "unknown")
-    attempt_num = attempt.get("attempt", 0)
-    # Short content-hash suffix for uniqueness across resubmissions.
-    digest = hashlib.sha256(json.dumps(attempt, sort_keys=True, default=str).encode())
-    suffix = digest.hexdigest()[:6]
-    # K8s names must be <= 63 chars, lowercase alphanumeric + hyphens.
-    name = f"ginkgo-{run_id}-{task_id}-{attempt_num}-{suffix}"
-    name = name.lower().replace("_", "-")
-    if len(name) > 63:
-        name = name[:63]
-    return name.rstrip("-")
-
-
-def _payload_requires_fuse(attempt: dict[str, Any]) -> bool:
-    """Return True when the payload contains any fuse-marked inputs."""
-    from ginkgo.remote.access.protocol import FUSE_FILE_TYPE, FUSE_FOLDER_TYPE
-
-    fuse_tags = {FUSE_FILE_TYPE, FUSE_FOLDER_TYPE}
-
-    def walk(value: Any) -> bool:
-        if isinstance(value, dict):
-            if value.get("__ginkgo_type__") in fuse_tags:
-                return True
-            return any(walk(item) for item in value.values())
-        if isinstance(value, (list, tuple)):
-            return any(walk(item) for item in value)
-        return False
-
-    return walk(attempt.get("args"))
-
-
 def _parse_worker_output(logs: str) -> dict[str, Any]:
-    """Parse the worker result from pod log output.
-
-    The remote worker prints a single JSON line to stdout as its last
-    output.  We search backwards from the end to find it.
-    """
-    for line in reversed(logs.splitlines()):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            return json.loads(line)
-        except json.JSONDecodeError:
-            continue
-    return {
-        "ok": False,
-        "error": {
-            "type": "RuntimeError",
-            "module": "builtins",
-            "message": "No worker output found in pod logs",
-            "args": ["No worker output found in pod logs"],
-        },
-    }
+    """Parse the worker result from pod log output."""
+    return _parse_worker_output_common(logs, source_label="pod logs")
 
 
 class _RefreshingApi:


### PR DESCRIPTION
## Summary

Addresses findings **3, 4, 5, and 6** of #53 — all four are duplications between `ginkgo/remote/kubernetes.py` and `ginkgo/remote/gcp_batch.py`, so they fit cohesively into a single refactor.

- New module `src/ginkgo/remote/_executor_common.py` holds the four helpers that the two executors used to carry byte-for-byte copies of:
  - `_encode_payload` (finding 3)
  - `_payload_requires_fuse` (finding 4)
  - `_parse_worker_output` (finding 5)
  - `_generate_job_name` (finding 6 — `_generate_job_id` in `gcp_batch.py` and `_generate_job_name` in `kubernetes.py` were functionally identical and produced names compatible with both Kubernetes Job and GCP Batch job ID constraints; collapsed under the single name and updated the GCP caller)
- `kubernetes.py` keeps a 2-line `_parse_worker_output` wrapper so its fallback error message still reads "pod logs" instead of the generic "job logs" — preserving the only meaningful user-visible difference between the two original copies.

Net diff: **-141 / +100** lines across the two executors; both still re-export the helper names at module scope, so existing tests (which import from `ginkgo.remote.kubernetes`) keep working unchanged.

## Test plan

- [x] `pytest tests/test_kubernetes_executor.py tests/test_remote_access.py` — 56 passed
- [x] `ruff check` clean on the three touched files
- [x] `ruff format --check` clean
- [ ] CI on the PR


---
_Generated by [Claude Code](https://claude.ai/code/session_012J9bCfQa7bZ7scCytZ4M2d)_