### PR TITLE
drop leading underscores from de-facto-public symbols (findings 10–13)

### DIFF
--- a/src/ginkgo/cli/__init__.py
+++ b/src/ginkgo/cli/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ginkgo.cli.renderers.common import (
     _core_unit_label,
-    _environment_label,
+    environment_label,
     _time_of_day_spinner,
     _truncate_task_label,
 )
@@ -31,7 +31,7 @@ def main(argv: list[str] | None = None) -> int:
 __all__ = [
     "main",
     "_core_unit_label",
-    "_environment_label",
+    "environment_label",
     "_time_of_day_spinner",
     "_truncate_task_label",
 ]

--- a/src/ginkgo/cli/commands/cache.py
+++ b/src/ginkgo/cli/commands/cache.py
@@ -16,8 +16,8 @@ from rich.table import Table
 from rich.text import Text
 
 from ginkgo.cli.common import CACHE_ROOT, console
-from ginkgo.cli.renderers.common import _task_base_name
-from ginkgo.runtime.artifacts.artifact_store import _make_writable_recursive
+from ginkgo.cli.renderers.common import task_base_name
+from ginkgo.runtime.artifacts.artifact_store import make_writable_recursive
 
 
 def command_cache(args) -> int:
@@ -176,7 +176,7 @@ def _cache_entry_row(entry: Path) -> CacheEntryRow:
     return CacheEntryRow(
         path=entry,
         cache_key=entry.name,
-        task=_task_base_name(function),
+        task=task_base_name(function),
         size=_format_size(size_bytes),
         size_bytes=size_bytes,
         age=_format_age(created_at),
@@ -349,7 +349,7 @@ def _safe_rmtree(path: Path) -> None:
     try:
         shutil.rmtree(path)
     except PermissionError:
-        _make_writable_recursive(path)
+        make_writable_recursive(path)
         shutil.rmtree(path)
 
 
@@ -481,6 +481,6 @@ def _entries_for_function(
         if exclude == entry.name:
             continue
         meta = _read_cache_meta(cache_root=cache_root, cache_key=entry.name)
-        if _task_base_name(str(meta.get("function", "unknown"))) == _task_base_name(function):
+        if task_base_name(str(meta.get("function", "unknown"))) == task_base_name(function):
             entries.append(meta)
     return entries

--- a/src/ginkgo/cli/commands/debug.py
+++ b/src/ginkgo/cli/commands/debug.py
@@ -7,9 +7,9 @@ import json
 from pathlib import Path
 
 from ginkgo.cli.common import console, resolve_run_dir
-from ginkgo.cli.renderers.common import _task_base_name
+from ginkgo.cli.renderers.common import task_base_name
 from ginkgo.cli.renderers.debug import render_debug_failure_panel, render_debug_header
-from ginkgo.cli.renderers.models import _FailureDetails
+from ginkgo.cli.renderers.models import FailureDetails
 from ginkgo.runtime.caching.provenance import combined_log_tail, load_manifest
 
 
@@ -48,9 +48,9 @@ def _debug_failure_details(
     *,
     run_dir: Path,
     failed_tasks: list[dict[str, object]],
-) -> list[_FailureDetails]:
+) -> list[FailureDetails]:
     """Return failure details for the rich ``ginkgo debug`` report."""
-    details: list[_FailureDetails] = []
+    details: list[FailureDetails] = []
     for task in sorted(failed_tasks, key=lambda item: int(item.get("node_id", -1))):
         log_tail = combined_log_tail(
             run_dir=run_dir,
@@ -68,8 +68,8 @@ def _debug_failure_details(
             else None
         )
         details.append(
-            _FailureDetails(
-                task_label=_task_base_name(task_name),
+            FailureDetails(
+                task_label=task_base_name(task_name),
                 exit_code=task.get("exit_code"),
                 log_path=stderr_path,
                 log_tail=log_tail,
@@ -93,7 +93,7 @@ def _debug_failure_payload(
         payload.append(
             {
                 "task_id": task.get("task_id"),
-                "task_name": _task_base_name(str(task.get("task", "unknown"))),
+                "task_name": task_base_name(str(task.get("task", "unknown"))),
                 "exit_code": task.get("exit_code"),
                 "error": task.get("error"),
                 "failure": task.get("failure"),

--- a/src/ginkgo/cli/commands/doctor.py
+++ b/src/ginkgo/cli/commands/doctor.py
@@ -9,7 +9,7 @@ import sys
 
 from ginkgo.cli.common import console
 from ginkgo.cli.workspace import resolve_workflow_path
-from ginkgo.config import _config_session
+from ginkgo.config import config_session
 from ginkgo.remote.access.doctor import collect_access_diagnostics
 from ginkgo.runtime.diagnostics import collect_workflow_diagnostics
 from ginkgo.runtime.environment.secrets import build_secret_resolver
@@ -21,7 +21,7 @@ def command_doctor(args) -> int:
         project_root=Path.cwd(),
         workflow=args.workflow,
     ).path
-    with _config_session(override_paths=[Path(path).resolve() for path in args.config]) as session:
+    with config_session(override_paths=[Path(path).resolve() for path in args.config]) as session:
         config = session.merged_loaded_values()
     diagnostics = collect_workflow_diagnostics(
         workflow_path=workflow_path,

--- a/src/ginkgo/cli/commands/inspect.py
+++ b/src/ginkgo/cli/commands/inspect.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from ginkgo.cli.common import resolve_run_dir
-from ginkgo.cli.renderers.common import _task_base_name
+from ginkgo.cli.renderers.common import task_base_name
 from ginkgo.cli.workspace import resolve_workflow_path
-from ginkgo.config import _config_session
+from ginkgo.config import config_session
 from ginkgo.core.flow import discover_flow
-from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+from ginkgo.runtime.evaluator import ConcurrentEvaluator
 from ginkgo.runtime.module_loader import load_module_from_path
 from ginkgo.runtime.caching.provenance import load_manifest
 
@@ -35,12 +35,12 @@ def command_inspect(args) -> int:
 
 def inspect_workflow(*, workflow_path: Path, config_paths: list[Path]) -> dict[str, Any]:
     """Return a static workflow graph snapshot."""
-    with _config_session(override_paths=config_paths):
+    with config_session(override_paths=config_paths):
         module = load_module_from_path(workflow_path)
         flow = discover_flow(module)
         expr = flow()
 
-    evaluator = _ConcurrentEvaluator()
+    evaluator = ConcurrentEvaluator()
     evaluator.validate(expr)
 
     nodes = []
@@ -48,7 +48,7 @@ def inspect_workflow(*, workflow_path: Path, config_paths: list[Path]) -> dict[s
         nodes.append(
             {
                 "task_id": f"task_{node.node_id:04d}",
-                "task_name": _task_base_name(node.task_def.name),
+                "task_name": task_base_name(node.task_def.name),
                 "kind": node.task_def.kind,
                 "env": node.task_def.env,
                 "execution_mode": node.task_def.execution_mode,
@@ -87,7 +87,7 @@ def inspect_run(*, run_dir: Path) -> dict[str, Any]:
                 )
             row: dict[str, Any] = {
                 "task_id": task_id,
-                "task_name": _task_base_name(str(task.get("task", "unknown"))),
+                "task_name": task_base_name(str(task.get("task", "unknown"))),
                 "status": task.get("status"),
                 "attempt": task.get("attempt"),
                 "attempts": task.get("attempts"),

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -14,24 +14,24 @@ from pathlib import Path
 from typing import Any
 
 from ginkgo.cli.common import RUNS_ROOT, RunMode, console
-from ginkgo.cli.renderers.common import _environment_label, _format_duration
+from ginkgo.cli.renderers.common import environment_label, format_duration
 from ginkgo.cli.renderers.jsonl import JsonlEventRenderer
 from ginkgo.cli.renderers.models import (
-    _AssetSummary,
-    _FailureDetails,
-    _NotebookSummary,
-    _ResourceRenderState,
-    _RunSummary,
+    CliAssetSummary,
+    FailureDetails,
+    CliNotebookSummary,
+    ResourceRenderState,
+    CliRunSummary,
 )
 from ginkgo.cli.renderers.rich import RichEventRenderer
-from ginkgo.cli.renderers.run import _CliRunRenderer
+from ginkgo.cli.renderers.run import CliRunRenderer
 from ginkgo.cli.workspace import resolve_workflow_path
-from ginkgo.config import _config_session, load_runtime_config
+from ginkgo.config import config_session, load_runtime_config
 from ginkgo.core.flow import discover_flow
 from ginkgo.envs.container import ContainerBackend
 from ginkgo.envs.pixi import PixiRegistry
 from ginkgo.runtime.backend import CompositeBackend, LocalBackend
-from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+from ginkgo.runtime.evaluator import ConcurrentEvaluator
 from ginkgo.runtime.module_loader import load_module_from_path
 from ginkgo.runtime.environment.resources import RunResourceMonitor
 from ginkgo.runtime.caching.provenance import (
@@ -102,7 +102,7 @@ def run_workflow(
     profiler.record(phase="cli_startup", seconds=time.perf_counter() - cli_startup_started)
 
     load_started = time.perf_counter()
-    with _config_session(override_paths=config_paths) as session:
+    with config_session(override_paths=config_paths) as session:
         with profiler.timed("workflow_module_import"):
             module = load_module_from_path(workflow_path)
         with profiler.timed("flow_construction"):
@@ -138,7 +138,7 @@ def run_workflow(
         remote_executor = _build_batch_executor(runtime_config=runtime_config)
         code_bundle_config = _load_code_bundle_config(runtime_config=runtime_config)
 
-    evaluator = _ConcurrentEvaluator(
+    evaluator = ConcurrentEvaluator(
         jobs=jobs,
         cores=cores,
         memory=memory,
@@ -156,7 +156,7 @@ def run_workflow(
     edge_count = sum(len(node.dependency_ids) for node in evaluator._nodes.values())
     env_count = len({node.task_def.env for node in evaluator._nodes.values() if node.task_def.env})
     planned_tasks = [
-        (node.node_id, node.task_def.name, _environment_label(node.task_def.env))
+        (node.node_id, node.task_def.name, environment_label(node.task_def.env))
         for node in sorted(evaluator._nodes.values(), key=lambda item: item.node_id)
     ]
 
@@ -187,7 +187,7 @@ def run_workflow(
 
     if output_mode not in {"agent", "agent_verbose"}:
         rich_console.print(
-            f"[cyan]📦[/] Loading workflow...  [green]done[/] ({_format_duration(load_elapsed)})"
+            f"[cyan]📦[/] Loading workflow...  [green]done[/] ({format_duration(load_elapsed)})"
         )
         rich_console.print(
             f"[green]🌱[/] Building expression tree...  [bold]{task_count}[/] tasks"
@@ -244,9 +244,9 @@ def run_workflow(
                     )
                 )
             else:
-                renderer = _CliRunRenderer(
+                renderer = CliRunRenderer(
                     console=rich_console,
-                    summary=_RunSummary(
+                    summary=CliRunSummary(
                         run_id=run_id,
                         mode=output_mode,
                         run_dir=recorder.run_dir,
@@ -254,10 +254,10 @@ def run_workflow(
                         memory=memory,
                         executor=executor,
                     ),
-                    resources=_ResourceRenderState(provider=resource_monitor.current_summary),
+                    resources=ResourceRenderState(provider=resource_monitor.current_summary),
                 )
                 bus.subscribe(RichEventRenderer(renderer=renderer))
-            evaluator = _ConcurrentEvaluator(
+            evaluator = ConcurrentEvaluator(
                 jobs=jobs,
                 cores=cores,
                 memory=memory,
@@ -367,11 +367,11 @@ def _load_failure_details(
     *,
     run_dir: Path,
     run_summary: RunSummary,
-    renderer: _CliRunRenderer,
+    renderer: CliRunRenderer,
     verbose: bool,
-) -> list[_FailureDetails]:
+) -> list[FailureDetails]:
     """Load failed-task diagnostics from a finished run."""
-    details: list[_FailureDetails] = []
+    details: list[FailureDetails] = []
     tail_lines = 20 if verbose else 10
     for task in run_summary.failed_tasks:
         node_id = task.node_id if task.node_id is not None else -1
@@ -388,7 +388,7 @@ def _load_failure_details(
             else None
         )
         details.append(
-            _FailureDetails(
+            FailureDetails(
                 task_label=renderer.label_for_node(node_id) or task.name,
                 exit_code=task.exit_code,
                 log_path=stderr_path,
@@ -432,14 +432,14 @@ def _print_profile_table(
 def _render_notebooks(
     *,
     run_summary: RunSummary,
-    renderer: _CliRunRenderer,
-) -> list[_NotebookSummary]:
+    renderer: CliRunRenderer,
+) -> list[CliNotebookSummary]:
     """Build CLI-renderer notebook rows from a run summary.
 
     Resolves rendered HTML paths against the run directory and substitutes
     runtime task labels when the renderer has them.
     """
-    rows: list[_NotebookSummary] = []
+    rows: list[CliNotebookSummary] = []
     for notebook in run_summary.notebooks:
         if notebook.rendered_html is None:
             continue
@@ -452,13 +452,13 @@ def _render_notebooks(
         task_label = (
             renderer.label_for_node(node_id) if isinstance(node_id, int) else None
         ) or notebook.base_name
-        rows.append(_NotebookSummary(task_label=task_label, html_path=html_path))
+        rows.append(CliNotebookSummary(task_label=task_label, html_path=html_path))
     return rows
 
 
-def _render_assets(*, run_summary: RunSummary) -> list[_AssetSummary]:
+def _render_assets(*, run_summary: RunSummary) -> list[CliAssetSummary]:
     """Build CLI-renderer asset rows from a run summary."""
-    return [_AssetSummary(name=asset.name) for asset in run_summary.assets]
+    return [CliAssetSummary(name=asset.name) for asset in run_summary.assets]
 
 
 def _load_code_bundle_config(*, runtime_config: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/ginkgo/cli/commands/secrets.py
+++ b/src/ginkgo/cli/commands/secrets.py
@@ -8,9 +8,9 @@ import sys
 
 from ginkgo.cli.common import console
 from ginkgo.cli.workspace import resolve_workflow_path
-from ginkgo.config import _config_session
+from ginkgo.config import config_session
 from ginkgo.core.flow import discover_flow
-from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+from ginkgo.runtime.evaluator import ConcurrentEvaluator
 from ginkgo.runtime.module_loader import load_module_from_path
 from ginkgo.runtime.environment.secrets import build_secret_resolver, collect_secret_refs
 
@@ -22,13 +22,13 @@ def command_secrets(args) -> int:
         workflow=args.workflow,
     ).path
 
-    with _config_session(override_paths=[Path(path).resolve() for path in args.config]) as session:
+    with config_session(override_paths=[Path(path).resolve() for path in args.config]) as session:
         module = load_module_from_path(workflow_path)
         flow = discover_flow(module)
         expr = flow()
         config = session.merged_loaded_values()
 
-    evaluator = _ConcurrentEvaluator()
+    evaluator = ConcurrentEvaluator()
     evaluator.validate(expr)
 
     refs = sorted(

--- a/src/ginkgo/cli/renderers/common.py
+++ b/src/ginkgo/cli/renderers/common.py
@@ -61,15 +61,15 @@ def _task_duration_plain(row: _TaskRow, *, now: float) -> str:
     if row.started_at is None:
         return "--"
     finished_at = row.finished_at if row.finished_at is not None else now
-    return _format_duration(max(0.0, finished_at - row.started_at))
+    return format_duration(max(0.0, finished_at - row.started_at))
 
 
-def _environment_label(env: str | None) -> str:
+def environment_label(env: str | None) -> str:
     """Return the task environment label for the CLI table."""
     return "local" if env is None else f"pixi:{env}"
 
 
-def _task_base_name(task_name: str) -> str:
+def task_base_name(task_name: str) -> str:
     """Return the task name without its module prefix."""
     return task_name.rsplit(".", 1)[-1]
 
@@ -101,7 +101,7 @@ def _truncate_task_label(label: str, *, max_width: int) -> str:
     return f"{base[:head_width]}...{base[-tail_width:]}{suffix}"
 
 
-def _format_duration(seconds: float) -> str:
+def format_duration(seconds: float) -> str:
     """Return a compact human-readable duration string."""
     if seconds < 1:
         return f"{seconds:.2f}s"

--- a/src/ginkgo/cli/renderers/debug.py
+++ b/src/ginkgo/cli/renderers/debug.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from ginkgo.cli.renderers.models import _FailureDetails
+from ginkgo.cli.renderers.models import FailureDetails
 
 
 def render_debug_header(*, run_dir: Path, manifest: dict[str, object], failures: int) -> Panel:
@@ -33,7 +33,7 @@ def render_debug_header(*, run_dir: Path, manifest: dict[str, object], failures:
     )
 
 
-def render_debug_failure_panel(details: _FailureDetails) -> Panel:
+def render_debug_failure_panel(details: FailureDetails) -> Panel:
     """Render a failed task report for ``ginkgo debug``."""
     summary = Table.grid(padding=(0, 1))
     summary.add_column(style="bold #7f1d1d", no_wrap=True)

--- a/src/ginkgo/cli/renderers/models.py
+++ b/src/ginkgo/cli/renderers/models.py
@@ -11,7 +11,7 @@ from ginkgo.cli.common import RunMode
 
 
 @dataclass(kw_only=True)
-class _RunSummary:
+class CliRunSummary:
     """Static metadata used across the CLI renderers."""
 
     run_id: str
@@ -36,7 +36,7 @@ class _TaskRow:
 
 
 @dataclass(kw_only=True)
-class _FailureDetails:
+class FailureDetails:
     """Renderable diagnostics for a failed task."""
 
     task_label: str
@@ -94,14 +94,14 @@ class _TaskGroup:
 
 
 @dataclass(frozen=True)
-class _ResourceRenderState:
+class ResourceRenderState:
     """Live resource summary provider for CLI rendering."""
 
     provider: Callable[[], dict[str, object]]
 
 
 @dataclass(frozen=True, kw_only=True)
-class _NotebookSummary:
+class CliNotebookSummary:
     """Rendered notebook artifact produced in a run."""
 
     task_label: str
@@ -109,7 +109,7 @@ class _NotebookSummary:
 
 
 @dataclass(frozen=True, kw_only=True)
-class _AssetSummary:
+class CliAssetSummary:
     """Asset materialised in a run."""
 
     name: str

--- a/src/ginkgo/cli/renderers/rich.py
+++ b/src/ginkgo/cli/renderers/rich.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from ginkgo.cli.renderers.run import _CliRunRenderer
+from ginkgo.cli.renderers.run import CliRunRenderer
 from ginkgo.runtime.events import (
     GinkgoEvent,
     TaskCacheHit,
@@ -21,7 +21,7 @@ from ginkgo.runtime.events import (
 class RichEventRenderer:
     """Translate runtime events into the existing Rich run renderer stream."""
 
-    def __init__(self, *, renderer: _CliRunRenderer) -> None:
+    def __init__(self, *, renderer: CliRunRenderer) -> None:
         self._renderer = renderer
 
     def __call__(self, event: GinkgoEvent) -> None:

--- a/src/ginkgo/cli/renderers/run.py
+++ b/src/ginkgo/cli/renderers/run.py
@@ -22,10 +22,10 @@ from ginkgo.cli.renderers.common import (
     _format_bytes,
     _format_cpu_percent,
     _core_unit_label,
-    _format_duration,
+    format_duration,
     _status_label,
     _status_text,
-    _task_base_name,
+    task_base_name,
     _task_duration_plain,
     _task_duration_text,
     _task_label_width,
@@ -33,11 +33,11 @@ from ginkgo.cli.renderers.common import (
     _truncate_task_label,
 )
 from ginkgo.cli.renderers.models import (
-    _AssetSummary,
-    _FailureDetails,
-    _NotebookSummary,
-    _ResourceRenderState,
-    _RunSummary,
+    CliAssetSummary,
+    FailureDetails,
+    CliNotebookSummary,
+    ResourceRenderState,
+    CliRunSummary,
     _TaskGroup,
     _TaskRow,
 )
@@ -46,15 +46,15 @@ _GROUP_THRESHOLD = 6
 """Minimum invocation count to collapse same-task rows into a group."""
 
 
-class _CliRunRenderer:
+class CliRunRenderer:
     """Render human-friendly task lifecycle output from evaluator JSON events."""
 
     def __init__(
         self,
         *,
         console: Console,
-        summary: _RunSummary,
-        resources: _ResourceRenderState | None = None,
+        summary: CliRunSummary,
+        resources: ResourceRenderState | None = None,
     ) -> None:
         self._console = console
         self._summary = summary
@@ -108,9 +108,9 @@ class _CliRunRenderer:
         elapsed: float,
         success: bool,
         resources: dict[str, object] | None = None,
-        failure_details: list[_FailureDetails] | None = None,
-        notebooks: list[_NotebookSummary] | None = None,
-        assets: list[_AssetSummary] | None = None,
+        failure_details: list[FailureDetails] | None = None,
+        notebooks: list[CliNotebookSummary] | None = None,
+        assets: list[CliAssetSummary] | None = None,
         remote_summary: str | None = None,
     ) -> None:
         """Print the final run summary."""
@@ -131,13 +131,13 @@ class _CliRunRenderer:
         executed = counts["succeeded"] + counts["failed"]
         if success:
             self._console.print(
-                f"\n[bold cyan]⏱[/] Completed in [bold]{_format_duration(elapsed)}[/] - "
+                f"\n[bold cyan]⏱[/] Completed in [bold]{format_duration(elapsed)}[/] - "
                 f"{executed} tasks executed, {cached} cached"
             )
         else:
             failed = counts["failed"]
             self._console.print(
-                f"\n[bold red]✖[/] Failed in [bold]{_format_duration(elapsed)}[/] - "
+                f"\n[bold red]✖[/] Failed in [bold]{format_duration(elapsed)}[/] - "
                 f"{executed} tasks executed, {cached} cached, {failed} failed"
             )
         resource_summary = resources or self._resource_summary()
@@ -313,7 +313,7 @@ class _CliRunRenderer:
                         bar_text.append_text(chunk)
                 bar_text.append(f" {terminal}/{total}", style="bold #134e4a")
                 elapsed = item.elapsed(now=now)
-                time_str = _format_duration(elapsed) if elapsed is not None else "--"
+                time_str = format_duration(elapsed) if elapsed is not None else "--"
                 table.add_row(
                     Text(
                         _truncate_task_label(item.label, max_width=max_label),
@@ -372,7 +372,7 @@ class _CliRunRenderer:
             f"Procs {_format_count(current.get('process_count'))}"
         )
 
-    def _render_notebooks(self, notebooks: list[_NotebookSummary]) -> Text:
+    def _render_notebooks(self, notebooks: list[CliNotebookSummary]) -> Text:
         """Render the list of notebooks materialised in this run."""
         text = Text()
         text.append(f"\n📓 Notebooks materialised ({len(notebooks)})\n", style="bold")
@@ -383,7 +383,7 @@ class _CliRunRenderer:
             text.append("\n")
         return text
 
-    def _render_assets(self, assets: list[_AssetSummary]) -> Text:
+    def _render_assets(self, assets: list[CliAssetSummary]) -> Text:
         """Render the list of assets materialised in this run."""
         text = Text()
         text.append(f"\n📦 Assets materialised ({len(assets)})\n", style="bold")
@@ -391,7 +391,7 @@ class _CliRunRenderer:
             text.append(f"  {asset.name}\n", style="bold #134e4a")
         return text
 
-    def _render_failure_details(self, details: list[_FailureDetails]):
+    def _render_failure_details(self, details: list[FailureDetails]):
         parts: list[object] = []
         category_summary = self._render_failure_category_summary(details)
         if category_summary is not None:
@@ -399,7 +399,7 @@ class _CliRunRenderer:
         parts.extend(self._render_failure_panel(item) for item in details)
         return Group(*parts)
 
-    def _render_failure_category_summary(self, details: list[_FailureDetails]) -> Text | None:
+    def _render_failure_category_summary(self, details: list[FailureDetails]) -> Text | None:
         """Return a one-line summary grouping failures by category, if any."""
         categorised = [item for item in details if item.failure_kind]
         if not categorised:
@@ -412,7 +412,7 @@ class _CliRunRenderer:
         summary.append("\n")
         return summary
 
-    def _render_failure_panel(self, details: _FailureDetails) -> Panel:
+    def _render_failure_panel(self, details: FailureDetails) -> Panel:
         summary = Table.grid(padding=(0, 1))
         summary.add_column(style="bold #7f1d1d", no_wrap=True)
         summary.add_column()
@@ -489,7 +489,7 @@ class _CliRunRenderer:
                     if self._rows[nid].task_name == name
                 }
                 env_label = env_labels.pop() if len(env_labels) == 1 else "mixed"
-                base = _task_base_name(name)
+                base = task_base_name(name)
                 group = _TaskGroup(
                     task_name=name,
                     label=f"{base} (×{name_counts[name]})",
@@ -531,7 +531,7 @@ class _CliRunRenderer:
                 status_widths.append(self._status_column_width() + len(f" {terminal}/{total}") + 1)
                 env_widths.append(len(item.env_label))
                 elapsed = item.elapsed(now=now)
-                time_widths.append(len(_format_duration(elapsed)) if elapsed is not None else 2)
+                time_widths.append(len(format_duration(elapsed)) if elapsed is not None else 2)
             else:
                 task_widths.append(len(_truncate_task_label(item.label, max_width=max_label)))
                 status_widths.append(len(_status_label(item.status)))

--- a/src/ginkgo/config.py
+++ b/src/ginkgo/config.py
@@ -87,7 +87,7 @@ def load_runtime_config(
 
 
 @contextmanager
-def _config_session(
+def config_session(
     *,
     override_paths: Sequence[str | Path] | None = None,
 ) -> Iterator[_ConfigSession]:

--- a/src/ginkgo/runtime/artifacts/artifact_store.py
+++ b/src/ginkgo/runtime/artifacts/artifact_store.py
@@ -631,7 +631,7 @@ def _remove_dest(dest_path: Path) -> None:
         dest_path.unlink()
 
 
-def _make_writable_recursive(path: Path) -> None:
+def make_writable_recursive(path: Path) -> None:
     """Restore write permissions on a read-only directory tree before deletion."""
     for child in path.rglob("*"):
         if child.is_dir():

--- a/src/ginkgo/runtime/diagnostics.py
+++ b/src/ginkgo/runtime/diagnostics.py
@@ -6,9 +6,9 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from ginkgo.config import _config_session
+from ginkgo.config import config_session
 from ginkgo.core.flow import discover_flow
-from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+from ginkgo.runtime.evaluator import ConcurrentEvaluator
 from ginkgo.runtime.module_loader import load_module_from_path
 from ginkgo.runtime.environment.secrets import SecretResolver
 
@@ -36,11 +36,11 @@ def collect_workflow_diagnostics(
 ) -> list[WorkflowDiagnostic]:
     """Collect structured workflow diagnostics."""
     try:
-        with _config_session(override_paths=config_paths):
+        with config_session(override_paths=config_paths):
             module = load_module_from_path(workflow_path)
             flow = discover_flow(module)
             expr = flow()
-        evaluator = _ConcurrentEvaluator(secret_resolver=secret_resolver)
+        evaluator = ConcurrentEvaluator(secret_resolver=secret_resolver)
         evaluator.validate(expr)
         return []
     except BaseException as exc:

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -154,7 +154,7 @@ def evaluate(
     Any
         The concrete result of evaluating the input.
     """
-    return _ConcurrentEvaluator(
+    return ConcurrentEvaluator(
         jobs=jobs,
         cores=cores,
         memory=memory,
@@ -206,7 +206,7 @@ class _TaskNode:
 
 
 @dataclass(kw_only=True)
-class _ConcurrentEvaluator:
+class ConcurrentEvaluator:
     """Concurrent evaluator with dependency tracking and cache integration."""
 
     jobs: int | None = None

--- a/src/ginkgo/runtime/task_runners/__init__.py
+++ b/src/ginkgo/runtime/task_runners/__init__.py
@@ -1,7 +1,7 @@
 """Task runners that execute the various task kinds.
 
 This package collects the per-kind execution helpers used by
-``_ConcurrentEvaluator``. Splitting them out of ``runtime/evaluator.py``
+``ConcurrentEvaluator``. Splitting them out of ``runtime/evaluator.py``
 keeps each runner small enough to reason about and unit-test in isolation.
 """
 

--- a/src/ginkgo/runtime/task_validation.py
+++ b/src/ginkgo/runtime/task_validation.py
@@ -2,7 +2,7 @@
 
 This module isolates the rules that decide whether a task definition,
 its resolved inputs, and its return value are well-formed. The logic was
-previously inlined in ``_ConcurrentEvaluator`` — extracting it lets the
+previously inlined in ``ConcurrentEvaluator`` — extracting it lets the
 scheduler stay focused on graph and lifecycle management while keeping
 validation independently testable.
 """

--- a/tests/test_cache_integrity.py
+++ b/tests/test_cache_integrity.py
@@ -236,12 +236,12 @@ class TestCachePruneReadOnly:
 
         # Prune everything by removing all entries directly.
         import shutil
-        from ginkgo.runtime.artifacts.artifact_store import _make_writable_recursive
+        from ginkgo.runtime.artifacts.artifact_store import make_writable_recursive
 
         for entry in cache_root.iterdir():
             if entry.is_dir():
                 try:
                     shutil.rmtree(entry)
                 except PermissionError:
-                    _make_writable_recursive(entry)
+                    make_writable_recursive(entry)
                     shutil.rmtree(entry)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
 from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.cli import (
     _core_unit_label,
-    _environment_label,
+    environment_label,
     _time_of_day_spinner,
     _truncate_task_label,
 )
@@ -1077,8 +1077,8 @@ class TestCliLabelTruncation:
 
 class TestCliEnvironmentLabels:
     def test_environment_label_formats_local_and_pixi_tasks(self) -> None:
-        assert _environment_label(None) == "local"
-        assert _environment_label("bioinfo_tools") == "pixi:bioinfo_tools"
+        assert environment_label(None) == "local"
+        assert environment_label("bioinfo_tools") == "pixi:bioinfo_tools"
 
 
 class TestCliCoreLabels:

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -268,7 +268,7 @@ class TestContainerKindRestriction:
             evaluate(python_in_container(x=1))
 
     def test_shell_task_with_container_env_passes_validation(self, tmp_path: Path):
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
         from ginkgo import shell, task
 
@@ -283,7 +283,7 @@ class TestContainerKindRestriction:
         # TypeError.  The backend.validate_envs call will fail because Docker
         # isn't available, but that's a different error.
         backend = ContainerBackend(project_root=tmp_path)
-        evaluator = _ConcurrentEvaluator(backend=backend)
+        evaluator = ConcurrentEvaluator(backend=backend)
         evaluator._root_template = shell_in_container(output_path=output)
         evaluator._root_dependency_ids = evaluator._register_value(evaluator._root_template)
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -28,7 +28,7 @@ from ginkgo import (
 )
 from ginkgo.envs.pixi import PixiRegistry
 from ginkgo.runtime.backend import LocalBackend
-from ginkgo.runtime.evaluator import CycleError, _ConcurrentEvaluator
+from ginkgo.runtime.evaluator import CycleError, ConcurrentEvaluator
 from tests.conftest import EventCollector
 from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.runtime.events import EventBus, TaskNotice
@@ -474,7 +474,7 @@ class TestEvaluate:
                 )
             raise AssertionError(command)
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
         result = evaluator.evaluate(expr)
         manifest = load_manifest(recorder.run_dir)
@@ -491,7 +491,7 @@ class TestEvaluate:
         assert manifest["tasks"]["task_0000"]["managed_kernel_name"].startswith("ginkgo-")
 
         # Re-evaluating with the same notebook hits cache.
-        cached = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        cached = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(
             cached._shell_runner,
             "_run_subprocess",
@@ -552,7 +552,7 @@ class TestEvaluate:
                 return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
             raise AssertionError(command)
 
-        first_evaluator = _ConcurrentEvaluator(provenance=first_recorder, jobs=1, cores=1)
+        first_evaluator = ConcurrentEvaluator(provenance=first_recorder, jobs=1, cores=1)
         monkeypatch.setattr(first_evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
         first_result = first_evaluator.evaluate(expr)
         first_manifest = load_manifest(first_recorder.run_dir)
@@ -571,7 +571,7 @@ class TestEvaluate:
             jobs=1,
             cores=1,
         )
-        cached_evaluator = _ConcurrentEvaluator(provenance=second_recorder, jobs=1, cores=1)
+        cached_evaluator = ConcurrentEvaluator(provenance=second_recorder, jobs=1, cores=1)
         monkeypatch.setattr(
             cached_evaluator._shell_runner,
             "_run_subprocess",
@@ -651,7 +651,7 @@ class TestEvaluate:
                 return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
             raise AssertionError(command)
 
-        evaluator = _ConcurrentEvaluator(
+        evaluator = ConcurrentEvaluator(
             provenance=recorder,
             jobs=1,
             cores=1,
@@ -715,7 +715,7 @@ class TestEvaluate:
                 return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
             raise AssertionError(command)
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1, event_bus=bus)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1, event_bus=bus)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
 
         result = evaluator.evaluate(expr)
@@ -733,7 +733,7 @@ class TestEvaluate:
             '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}', encoding="utf-8"
         )
         expr = notebook_ipynb_task(notebook_path=str(nb_path), value=7)
-        evaluator = _ConcurrentEvaluator(jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(jobs=1, cores=1)
 
         def fake_run_subprocess(
             *,
@@ -831,7 +831,7 @@ class TestEvaluate:
                 return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
             raise AssertionError(command)
 
-        evaluator = _ConcurrentEvaluator(
+        evaluator = ConcurrentEvaluator(
             provenance=recorder,
             jobs=2,
             cores=2,
@@ -874,7 +874,7 @@ class TestEvaluate:
                 )
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="run ok", stderr="")
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
         result = evaluator.evaluate(expr)
 
@@ -905,7 +905,7 @@ class TestEvaluate:
             output_path.write_text("done\n", encoding="utf-8")
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
 
-        evaluator = _ConcurrentEvaluator(jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
         result = evaluator.evaluate(expr)
 
@@ -947,7 +947,7 @@ class TestEvaluate:
                     (p / "task_0000.html").write_text("<html/>", encoding="utf-8")
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
 
-        ev1 = _ConcurrentEvaluator(jobs=1, cores=1)
+        ev1 = ConcurrentEvaluator(jobs=1, cores=1)
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(ev1._shell_runner, "_run_subprocess", fake_subprocess_ok)
         try:
@@ -1038,7 +1038,7 @@ class TestEvaluate:
         second = passthrough_task(value=first)
         first.args["value"] = second
 
-        evaluator = _ConcurrentEvaluator()
+        evaluator = ConcurrentEvaluator()
         with pytest.raises(
             CycleError,
             match="Detected cycle in workflow graph: test_evaluator.passthrough_task -> "
@@ -1383,7 +1383,7 @@ class TestInterruptHandling:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        evaluator = _ConcurrentEvaluator()
+        evaluator = ConcurrentEvaluator()
         future_one = Future()
         future_two = Future()
         tracked_one = _FakeTrackedProcess(pid=101)
@@ -1428,7 +1428,7 @@ class TestInterruptHandling:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        evaluator = _ConcurrentEvaluator()
+        evaluator = ConcurrentEvaluator()
         popen_calls: list[tuple[object, dict[str, object]]] = []
 
         class FakePopen:
@@ -1457,7 +1457,7 @@ class TestInterruptHandling:
 
 class TestPixiWorkerPayload:
     def test_build_worker_payload_does_not_contain_import_roots(self, tmp_path: Path) -> None:
-        evaluator = _ConcurrentEvaluator()
+        evaluator = ConcurrentEvaluator()
         expr = add_one_task(x=1)
         node_id = evaluator._register_expr(expr)
         node = evaluator._nodes[node_id]
@@ -1500,7 +1500,7 @@ class TestSecrets:
             secret_value=secret("API_TOKEN"),
             output_path="result.txt",
         )
-        evaluator = _ConcurrentEvaluator(
+        evaluator = ConcurrentEvaluator(
             jobs=1,
             cores=1,
             provenance=recorder,
@@ -1532,7 +1532,7 @@ class TestSecrets:
             config={},
             environ={"API_TOKEN": "rotated-token"},
         )
-        second_evaluator = _ConcurrentEvaluator(
+        second_evaluator = ConcurrentEvaluator(
             jobs=1,
             cores=1,
             provenance=second_recorder,
@@ -1564,7 +1564,7 @@ class TestSecrets:
             memory=None,
             params={},
         )
-        evaluator = _ConcurrentEvaluator(
+        evaluator = ConcurrentEvaluator(
             jobs=1,
             cores=1,
             provenance=recorder,
@@ -1607,7 +1607,7 @@ class TestAssets:
             memory=None,
             params={},
         )
-        evaluator = _ConcurrentEvaluator(jobs=1, cores=1, provenance=recorder)
+        evaluator = ConcurrentEvaluator(jobs=1, cores=1, provenance=recorder)
 
         result = evaluator.evaluate(
             transform_asset_task(
@@ -1656,7 +1656,7 @@ class TestAssets:
             memory=None,
             params={},
         )
-        first_evaluator = _ConcurrentEvaluator(jobs=1, cores=1, provenance=first_recorder)
+        first_evaluator = ConcurrentEvaluator(jobs=1, cores=1, provenance=first_recorder)
         assert first_evaluator.evaluate(expr) == "hello"
 
         second_recorder = RunProvenanceRecorder(
@@ -1668,7 +1668,7 @@ class TestAssets:
             memory=None,
             params={},
         )
-        second_evaluator = _ConcurrentEvaluator(jobs=1, cores=1, provenance=second_recorder)
+        second_evaluator = ConcurrentEvaluator(jobs=1, cores=1, provenance=second_recorder)
         assert second_evaluator.evaluate(expr) == "hello"
 
         manifest = load_manifest(second_recorder.run_dir)
@@ -1705,7 +1705,7 @@ class TestAssets:
             memory=None,
             params={},
         )
-        first_evaluator = _ConcurrentEvaluator(jobs=1, cores=1, provenance=first_recorder)
+        first_evaluator = ConcurrentEvaluator(jobs=1, cores=1, provenance=first_recorder)
         first_result = first_evaluator.evaluate(
             shell_asset_with_payload_task(output_path="shell.txt", payload="first")
         )
@@ -1723,7 +1723,7 @@ class TestAssets:
             memory=None,
             params={},
         )
-        second_evaluator = _ConcurrentEvaluator(jobs=1, cores=1, provenance=second_recorder)
+        second_evaluator = ConcurrentEvaluator(jobs=1, cores=1, provenance=second_recorder)
         second_result = second_evaluator.evaluate(
             shell_asset_with_payload_task(output_path="shell.txt", payload="second")
         )
@@ -1750,7 +1750,7 @@ class TestAssets:
             memory=None,
             params={},
         )
-        evaluator = _ConcurrentEvaluator(jobs=1, cores=1, provenance=recorder)
+        evaluator = ConcurrentEvaluator(jobs=1, cores=1, provenance=recorder)
 
         result = evaluator.evaluate(
             nested_asset_inputs_task(

--- a/tests/test_fuse_tuning.py
+++ b/tests/test_fuse_tuning.py
@@ -163,9 +163,9 @@ class TestFallbackNotice:
     """Evaluator should emit a TaskNotice when access stats report a fallback."""
 
     def test_notice_emitted_when_fallback_reason_present(self) -> None:
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
-        evaluator = _ConcurrentEvaluator.__new__(_ConcurrentEvaluator)
+        evaluator = ConcurrentEvaluator.__new__(ConcurrentEvaluator)
         evaluator.event_bus = MagicMock()
         evaluator.profiler = MagicMock()
         evaluator.profiler.timed.return_value.__enter__ = lambda self: None
@@ -194,9 +194,9 @@ class TestFallbackNotice:
         assert "/dev/fuse" in event.message
 
     def test_no_notice_when_fallback_reason_absent(self) -> None:
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
-        evaluator = _ConcurrentEvaluator.__new__(_ConcurrentEvaluator)
+        evaluator = ConcurrentEvaluator.__new__(ConcurrentEvaluator)
         evaluator.event_bus = MagicMock()
         evaluator.profiler = MagicMock()
         evaluator.profiler.timed.return_value.__enter__ = lambda self: None

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -24,9 +24,9 @@ class TestLoadModuleFromPath:
 
         importlib.reload(ginkgo)
 
-        from ginkgo.config import _config_session
+        from ginkgo.config import config_session
 
-        assert _config_session is not None
+        assert config_session is not None
         assert callable(ginkgo.config)
         assert not isinstance(ginkgo.config, ModuleType)
 

--- a/tests/test_subworkflow.py
+++ b/tests/test_subworkflow.py
@@ -17,7 +17,7 @@ from ginkgo.runtime.caching.provenance import (
     load_manifest,
     make_run_id,
 )
-from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+from ginkgo.runtime.evaluator import ConcurrentEvaluator
 from ginkgo.runtime.task_runners.subworkflow import (
     DEPTH_ENV,
     PARENT_RUN_ENV,
@@ -100,7 +100,7 @@ class TestRecursionGuard:
             cores=1,
         )
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         runner = evaluator._subworkflow_runner
 
         class _FakeNode:
@@ -158,7 +158,7 @@ class TestEvaluatorDispatch:
                 stderr="",
             )
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
 
         result = evaluator.evaluate(call_child_task(workflow_path=str(child_path), region="emea"))
@@ -203,7 +203,7 @@ class TestEvaluatorDispatch:
                 stderr="something broke\n",
             )
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
 
         with pytest.raises(SubWorkflowError) as exc_info:
@@ -222,7 +222,7 @@ class TestEvaluatorDispatch:
         child_path.write_text("", encoding="utf-8")
 
         recorder = self._make_recorder(tmp_path)
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
 
         with pytest.raises(TypeError, match="subworkflow"):
             evaluator.evaluate(call_child_wrong_return(workflow_path=str(child_path)))
@@ -245,7 +245,7 @@ class TestEvaluatorDispatch:
                 stderr="",
             )
 
-        evaluator = _ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
+        evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
 
         with pytest.raises(RuntimeError, match="GINKGO_CHILD_RUN_ID"):

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -283,7 +283,7 @@ class TestPixiShellTask:
     @pixi_required
     def test_shell_task_cached_on_rerun(self, tmp_path: Path) -> None:
         """Second evaluate() with unchanged inputs returns from cache (no pixi invocation)."""
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
         from ginkgo.runtime.backend import LocalBackend
         from ginkgo.runtime.events import EventBus, TaskCacheHit
 
@@ -301,7 +301,7 @@ class TestPixiShellTask:
             lambda event: cache_events.append(event) if isinstance(event, TaskCacheHit) else None
         )
 
-        evaluator = _ConcurrentEvaluator(
+        evaluator = ConcurrentEvaluator(
             backend=LocalBackend(pixi_registry=registry),
             event_bus=bus,
         )

--- a/tests/test_warm_run_optimizations.py
+++ b/tests/test_warm_run_optimizations.py
@@ -223,16 +223,16 @@ class TestWarmRunIntegration:
 
     def test_warm_run_completes_cached_dag_before_dispatch(self, tmp_path: Path) -> None:
         """A fully cached DAG should not enter task execution on the warm run."""
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
         output = tmp_path / "output.txt"
 
         expr1 = consume_file(input_file=produce_file(output_path=str(output)))
-        evaluator1 = _ConcurrentEvaluator()
+        evaluator1 = ConcurrentEvaluator()
         assert evaluator1.evaluate(expr1) == 7
 
         expr2 = consume_file(input_file=produce_file(output_path=str(output)))
-        evaluator2 = _ConcurrentEvaluator()
+        evaluator2 = ConcurrentEvaluator()
         evaluator2._start_task_execution = MagicMock(  # type: ignore[method-assign]
             side_effect=AssertionError("warm cached DAG should not dispatch task execution")
         )
@@ -242,16 +242,16 @@ class TestWarmRunIntegration:
 
     def test_warm_run_skips_environment_preparation(self, tmp_path: Path) -> None:
         """A warm cache hit should not prepare task environments."""
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
         output = tmp_path / "output.txt"
 
         expr1 = consume_file(input_file=produce_file(output_path=str(output)))
-        evaluator1 = _ConcurrentEvaluator()
+        evaluator1 = ConcurrentEvaluator()
         assert evaluator1.evaluate(expr1) == 7
 
         expr2 = consume_file(input_file=produce_file(output_path=str(output)))
-        evaluator2 = _ConcurrentEvaluator()
+        evaluator2 = ConcurrentEvaluator()
         evaluator2._prepare_task_environment = MagicMock(  # type: ignore[method-assign]
             side_effect=AssertionError("warm cached task should not prepare environments")
         )
@@ -282,20 +282,20 @@ class TestTrustWorkspace:
 
     def test_trust_workspace_warm_run(self, tmp_path: Path) -> None:
         """A --trust-workspace warm run should hit cache via stat index."""
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
         output = tmp_path / "output.txt"
 
         # Cold run (builds stat index).
         expr1 = consume_file(input_file=produce_file(output_path=str(output)))
-        evaluator1 = _ConcurrentEvaluator()
+        evaluator1 = ConcurrentEvaluator()
         result1 = evaluator1.evaluate(expr1)
         assert result1 == 7
 
         # Warm run with trust_workspace.
         collector = EventCollector()
         expr2 = consume_file(input_file=produce_file(output_path=str(output)))
-        evaluator2 = _ConcurrentEvaluator(trust_workspace=True, event_bus=collector.bus)
+        evaluator2 = ConcurrentEvaluator(trust_workspace=True, event_bus=collector.bus)
         result2 = evaluator2.evaluate(expr2)
         assert result2 == 7
 
@@ -303,7 +303,7 @@ class TestTrustWorkspace:
 
     def test_versioned_remote_input_warm_run_skips_staging(self, tmp_path: Path) -> None:
         """Pinned remote inputs can hit cache without staging on the warm run."""
-        from ginkgo.runtime.evaluator import _ConcurrentEvaluator
+        from ginkgo.runtime.evaluator import ConcurrentEvaluator
 
         class _FakeStagingCache:
             def __init__(self, *, root: Path, fail: bool = False) -> None:
@@ -323,11 +323,11 @@ class TestTrustWorkspace:
 
         ref = remote_file("s3://bucket/cacheable.txt", version_id="v1")
 
-        evaluator1 = _ConcurrentEvaluator()
+        evaluator1 = ConcurrentEvaluator()
         evaluator1._stager._staging_cache = _FakeStagingCache(root=tmp_path / "stage-cold")
         assert evaluator1.evaluate(read_versioned_remote_file(path=ref)) == "cacheable"
 
-        evaluator2 = _ConcurrentEvaluator()
+        evaluator2 = ConcurrentEvaluator()
         evaluator2._stager._staging_cache = _FakeStagingCache(
             root=tmp_path / "stage-warm", fail=True
         )


### PR DESCRIPTION
Renames _ConcurrentEvaluator → ConcurrentEvaluator, _CliRunRenderer →
CliRunRenderer, _RunSummary → CliRunSummary, _AssetSummary →
CliAssetSummary, _NotebookSummary → CliNotebookSummary, _FailureDetails →
FailureDetails, _ResourceRenderState → ResourceRenderState,
_environment_label → environment_label, _format_duration → format_duration,
_task_base_name → task_base_name, _config_session → config_session, and
_make_writable_recursive → make_writable_recursive across src/ and tests/.

Updates all definition sites, import sites, usages, type annotations, and
docstring/comment references. Leaves the local _task_base_name in
cli/commands/notebooks.py and the still-private _TaskRow/_TaskGroup and
other helpers untouched.

https://claude.ai/code/session_0158fRtFyyzvEKrPU7KmdCvx