### PR TITLE
refactor: extract LogDrain from ConcurrentEvaluator (issue #59 PR 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ benchmarks/results/
 AGENTS.md
 CLAUDE.md
 .claude/
+.agents/
 
 # uncoded symbol index (regenerated locally via `uncoded sync`)
 .uncoded/

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -18,8 +18,6 @@ from concurrent.futures import (
 from dataclasses import dataclass, field
 from multiprocessing import Manager, get_context
 from pathlib import Path
-from queue import Empty
-from threading import Event, Thread
 from typing import Any
 
 from ginkgo.core.asset import AssetRef, AssetVersion
@@ -57,7 +55,6 @@ from ginkgo.runtime.events import (
     TaskCacheMiss,
     TaskCompleted,
     TaskFailed,
-    TaskLog,
     TaskNotice,
     TaskReady,
     TaskRetrying,
@@ -65,6 +62,7 @@ from ginkgo.runtime.events import (
     TaskStaging,
     TaskStarted,
 )
+from ginkgo.runtime.log_drain import LogDrain
 from ginkgo.runtime.module_loader import resolve_module_file
 from ginkgo.runtime.caching.provenance import RunProvenanceRecorder
 from ginkgo.runtime.profiling import ProfileRecorder
@@ -239,14 +237,7 @@ class ConcurrentEvaluator:
     )
     _shell_executor: ThreadPoolExecutor | None = field(default=None, init=False, repr=False)
     _staging_executor: ThreadPoolExecutor | None = field(default=None, init=False, repr=False)
-    _log_event_queue: Any = field(default=None, init=False, repr=False)
-    _log_drain_stop: Event | None = field(default=None, init=False, repr=False)
-    _log_drain_thread: Thread | None = field(default=None, init=False, repr=False)
-    _task_log_sequences: dict[tuple[int, str], int] = field(
-        default_factory=dict,
-        init=False,
-        repr=False,
-    )
+    _log_drain: LogDrain = field(init=False, repr=False)
     _staging_jobs: int = field(default=0, init=False, repr=False)
     code_bundle_config: dict[str, Any] | None = None
     _remote_watcher_executor: ThreadPoolExecutor | None = field(
@@ -301,10 +292,14 @@ class ConcurrentEvaluator:
             backend=self.backend,
             secret_resolver=self.secret_resolver,
         )
+        self._log_drain = LogDrain(
+            event_bus=self.event_bus,
+            run_id_provider=lambda: self._run_id,
+        )
         self._shell_runner = ShellRunner(
             backend=self.backend,
             validator=self._validator,
-            log_emitter_factory=self._task_log_emitter,
+            log_emitter_factory=self._log_drain.make_emitter,
         )
         self._notebook_runner = NotebookRunner(
             backend=self.backend,
@@ -363,7 +358,7 @@ class ConcurrentEvaluator:
             self._python_executor = python_executor
             self._shell_executor = shell_executor
             self._staging_executor = staging_executor
-            self._start_log_drain(queue=log_manager.Queue())
+            self._log_drain.start(queue=log_manager.Queue())
             try:
                 while True:
                     if signals.exception is not None and self._failure is None:
@@ -413,7 +408,7 @@ class ConcurrentEvaluator:
 
                     raise RuntimeError("Scheduler reached a deadlock with unresolved tasks")
             finally:
-                self._stop_log_drain()
+                self._log_drain.stop()
                 self._python_executor = None
                 self._shell_executor = None
                 self._materialization_log.save()
@@ -1221,69 +1216,6 @@ class ConcurrentEvaluator:
                 if process.is_alive():
                     process.kill()
 
-    def _start_log_drain(self, *, queue: Any) -> None:
-        """Start draining worker log chunks from the multiprocessing queue."""
-        self._log_event_queue = queue
-        self._log_drain_stop = Event()
-        self._log_drain_thread = Thread(
-            target=self._drain_log_events,
-            name="ginkgo-log-drain",
-            daemon=True,
-        )
-        self._log_drain_thread.start()
-
-    def _stop_log_drain(self) -> None:
-        """Stop the worker log drain thread."""
-        if self._log_drain_stop is not None:
-            self._log_drain_stop.set()
-        if self._log_drain_thread is not None:
-            self._log_drain_thread.join(timeout=1.0)
-        self._log_event_queue = None
-        self._log_drain_stop = None
-        self._log_drain_thread = None
-
-    def _drain_log_events(self) -> None:
-        """Convert queued worker log chunks into runtime events."""
-        if self._log_event_queue is None or self._log_drain_stop is None:
-            return
-
-        while True:
-            try:
-                payload = self._log_event_queue.get(timeout=0.1)
-            except Empty:
-                if self._log_drain_stop.is_set():
-                    return
-                continue
-            except Exception:
-                return
-
-            chunk = payload.get("chunk")
-            stream = payload.get("stream")
-            task_id = payload.get("task_id")
-            if (
-                not isinstance(chunk, str)
-                or not isinstance(stream, str)
-                or not isinstance(task_id, str)
-                or not chunk
-            ):
-                continue
-            node_id = int(task_id.split("_")[-1])
-            sequence_key = (node_id, stream)
-            sequence = self._task_log_sequences.get(sequence_key, 0) + 1
-            self._task_log_sequences[sequence_key] = sequence
-            self._emit_event(
-                TaskLog(
-                    run_id=str(payload.get("run_id") or self._run_id),
-                    task_id=task_id,
-                    task_name=str(payload.get("task_name") or ""),
-                    attempt=int(payload.get("attempt") or 0),
-                    display_label=payload.get("display_label"),
-                    stream=stream,
-                    chunk=chunk,
-                    sequence=sequence,
-                )
-            )
-
     def _running_cores(self) -> int:
         """Return the core footprint of currently running tasks."""
         return sum(self._nodes[node_id].threads for node_id, _ in self._running_futures.values())
@@ -1736,7 +1668,7 @@ class ConcurrentEvaluator:
             "task_name": node.task_def.name,
             "attempt": node.attempt,
             "display_label": node.display_label,
-            "log_event_queue": self._log_event_queue,
+            "log_event_queue": self._log_drain.queue,
             "env": node.task_def.env,
             "module": node.task_def.fn.__module__,
             "module_file": resolve_module_file(node.task_def.fn.__module__),
@@ -2119,30 +2051,6 @@ class ConcurrentEvaluator:
             with self.profiler.timed("event_emit"):
                 self.event_bus.emit(event)
 
-    def _task_log_emitter(self, *, node: _TaskNode, stream: str) -> Any:
-        """Return a task-log callback bound to one task node and stream."""
-
-        def emit(chunk: str) -> None:
-            if not chunk:
-                return
-            sequence_key = (node.node_id, stream)
-            sequence = self._task_log_sequences.get(sequence_key, 0) + 1
-            self._task_log_sequences[sequence_key] = sequence
-            self._emit_event(
-                TaskLog(
-                    run_id=self._run_id,
-                    task_id=_task_id_for_node(node.node_id),
-                    task_name=node.task_def.name,
-                    attempt=node.attempt,
-                    display_label=node.display_label,
-                    stream=stream,
-                    chunk=chunk,
-                    sequence=sequence,
-                )
-            )
-
-        return emit
-
     def _run_driver_task(self, *, node: _TaskNode) -> Any:
         """Run a driver-task wrapper on the scheduler process.
 
@@ -2157,7 +2065,7 @@ class ConcurrentEvaluator:
             stdout_path=str(node.stdout_path) if node.stdout_path is not None else None,
             stderr_path=str(node.stderr_path) if node.stderr_path is not None else None,
             secret_values=node.secret_values,
-            log_emitter=lambda *, stream, chunk: self._task_log_emitter(
+            log_emitter=lambda *, stream, chunk: self._log_drain.make_emitter(
                 node=node,
                 stream=stream,
             )(chunk),

--- a/src/ginkgo/runtime/log_drain.py
+++ b/src/ginkgo/runtime/log_drain.py
@@ -1,0 +1,136 @@
+"""Convert worker log chunks into ``TaskLog`` events.
+
+Two paths emit ``TaskLog`` events into the evaluator's event bus:
+
+* In-process emitters returned by :py:meth:`LogDrain.make_emitter`, called
+  directly by the shell runner and the driver-task wrapper as chunks become
+  available on the scheduler process.
+* Subprocess workers, which push chunks onto a multiprocessing queue. A
+  daemon thread owned by :class:`LogDrain` drains that queue and emits one
+  event per chunk.
+
+Both paths share a single per-(node, stream) sequence counter so that the
+order of chunks is well-defined across the two sources.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from queue import Empty
+from threading import Event, Thread
+from typing import Any, Callable
+
+from ginkgo.runtime.events import EventBus, TaskLog
+
+
+def _task_id_for_node(node_id: int) -> str:
+    return f"task_{node_id:04d}"
+
+
+@dataclass(kw_only=True)
+class LogDrain:
+    """Owns the worker log queue, drain thread, and per-task sequence counter."""
+
+    event_bus: EventBus | None
+    run_id_provider: Callable[[], str]
+    _queue: Any = field(default=None, init=False, repr=False)
+    _stop: Event | None = field(default=None, init=False, repr=False)
+    _thread: Thread | None = field(default=None, init=False, repr=False)
+    _sequences: dict[tuple[int, str], int] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    @property
+    def queue(self) -> Any:
+        """Return the active log event queue, or ``None`` when stopped."""
+        return self._queue
+
+    def start(self, *, queue: Any) -> None:
+        """Start draining worker log chunks from ``queue``."""
+        self._queue = queue
+        self._stop = Event()
+        self._thread = Thread(
+            target=self._drain,
+            name="ginkgo-log-drain",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the drain thread and release the queue."""
+        if self._stop is not None:
+            self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+        self._queue = None
+        self._stop = None
+        self._thread = None
+
+    def make_emitter(self, *, node: Any, stream: str) -> Callable[[str], None]:
+        """Return a per-(node, stream) callback that emits one ``TaskLog`` event."""
+
+        def emit(chunk: str) -> None:
+            if not chunk:
+                return
+            sequence_key = (node.node_id, stream)
+            sequence = self._sequences.get(sequence_key, 0) + 1
+            self._sequences[sequence_key] = sequence
+            self._emit(
+                TaskLog(
+                    run_id=self.run_id_provider(),
+                    task_id=_task_id_for_node(node.node_id),
+                    task_name=node.task_def.name,
+                    attempt=node.attempt,
+                    display_label=node.display_label,
+                    stream=stream,
+                    chunk=chunk,
+                    sequence=sequence,
+                )
+            )
+
+        return emit
+
+    def _drain(self) -> None:
+        if self._queue is None or self._stop is None:
+            return
+
+        while True:
+            try:
+                payload = self._queue.get(timeout=0.1)
+            except Empty:
+                if self._stop.is_set():
+                    return
+                continue
+            except Exception:
+                return
+
+            chunk = payload.get("chunk")
+            stream = payload.get("stream")
+            task_id = payload.get("task_id")
+            if (
+                not isinstance(chunk, str)
+                or not isinstance(stream, str)
+                or not isinstance(task_id, str)
+                or not chunk
+            ):
+                continue
+            node_id = int(task_id.split("_")[-1])
+            sequence_key = (node_id, stream)
+            sequence = self._sequences.get(sequence_key, 0) + 1
+            self._sequences[sequence_key] = sequence
+            self._emit(
+                TaskLog(
+                    run_id=str(payload.get("run_id") or self.run_id_provider()),
+                    task_id=task_id,
+                    task_name=str(payload.get("task_name") or ""),
+                    attempt=int(payload.get("attempt") or 0),
+                    display_label=payload.get("display_label"),
+                    stream=stream,
+                    chunk=chunk,
+                    sequence=sequence,
+                )
+            )
+
+    def _emit(self, event: object) -> None:
+        if self.event_bus is not None:
+            self.event_bus.emit(event)

--- a/src/ginkgo/runtime/log_drain.py
+++ b/src/ginkgo/runtime/log_drain.py
@@ -36,9 +36,7 @@ class LogDrain:
     _queue: Any = field(default=None, init=False, repr=False)
     _stop: Event | None = field(default=None, init=False, repr=False)
     _thread: Thread | None = field(default=None, init=False, repr=False)
-    _sequences: dict[tuple[int, str], int] = field(
-        default_factory=dict, init=False, repr=False
-    )
+    _sequences: dict[tuple[int, str], int] = field(default_factory=dict, init=False, repr=False)
 
     @property
     def queue(self) -> Any:


### PR DESCRIPTION
Move the four worker-log-drain methods out of `ConcurrentEvaluator` into
a new `runtime/log_drain.py` module. `LogDrain` owns the multiprocessing
queue, the daemon drain thread, and the per-(node, stream) sequence
counter shared between the in-process emitter (used by ShellRunner and
the driver-task wrapper) and the drain thread that consumes worker
chunks.

Net change in evaluator.py: -103/+11 lines. Four instance fields collapse
into one (`_log_drain`); `Empty`, `Event`, `Thread`, and `TaskLog` imports
are no longer needed.

Behaviour is preserved with one minor nuance: `TaskLog` emissions no
longer pass through `profiler.timed("event_emit")`. The profiler's
`event_emit` totals exclude `TaskLog` events; other events are
unaffected. As a side effect, the daemon drain thread no longer mutates
ProfileRecorder state from a non-scheduler thread.