### PR TITLE
feat: add one-line curl installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ notebook tasks, caching, CLI usage, and a canonical example workflow.
 
 ## Installation
 
+### Quick install (curl)
+
+Install the `ginkgo` CLI in one line. Requires [uv](https://docs.astral.sh/uv/getting-started/installation/)
+to be installed:
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/sanjaynagi/ginkgo/main/install.sh | sh
+```
+
+This installs `ginkgo` from `main` into an isolated environment via `uv tool
+install`. Re-run the same command to upgrade.
+
 ### Pixi
 
 For local development:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Ginkgo installer — installs the `ginkgo` CLI as an isolated uv tool.
+#
+# Usage:
+#   curl -LsSf https://raw.githubusercontent.com/sanjaynagi/ginkgo/main/install.sh | sh
+#
+# Requires `uv` to be installed and on PATH. This installer does not bootstrap
+# uv; install it first if missing:
+#   https://docs.astral.sh/uv/getting-started/installation/
+
+set -eu
+
+REPO_URL="git+https://github.com/sanjaynagi/ginkgo.git@main"
+
+info() { printf '\033[1;32m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$1" >&2; }
+err()  { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; }
+
+# Require uv — this installer does not bootstrap it.
+if ! command -v uv >/dev/null 2>&1; then
+    err "uv is required but was not found on PATH."
+    err "Install uv first, then re-run this script:"
+    err "  https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+fi
+
+# Install (or reinstall) the ginkgo CLI into its own isolated environment.
+info "Installing ginkgo from ${REPO_URL}"
+uv tool install --force "$REPO_URL"
+
+# Pixi is needed at runtime for pixi-backed task environments; warn if absent.
+if ! command -v pixi >/dev/null 2>&1; then
+    warn "pixi was not found on PATH."
+    warn "Workflows that use pixi-backed task environments need pixi installed:"
+    warn "  https://pixi.sh/"
+fi
+
+# Confirm the CLI is reachable on PATH.
+if command -v ginkgo >/dev/null 2>&1; then
+    info "Installed: $(ginkgo --version 2>/dev/null || echo ginkgo)"
+else
+    warn "ginkgo was installed but is not on PATH."
+    warn "Add uv's tool bin directory to PATH, then restart your shell:"
+    warn "  uv tool update-shell"
+fi


### PR DESCRIPTION
## Summary

Adds a one-line `curl | sh` installer for the `ginkgo` CLI, since ginkgo is not on PyPI and must install from GitHub.

```bash
curl -LsSf https://raw.githubusercontent.com/sanjaynagi/ginkgo/main/install.sh | sh
```

## What it does

- **`install.sh`** — requires `uv` on PATH (errors with install instructions if missing; does **not** bootstrap uv). Installs ginkgo from `main` via `uv tool install --force` into an isolated environment. Re-running upgrades. Warns (non-fatal) if `pixi` is absent, since pixi is needed at runtime for pixi-backed task environments.
- **`README.md`** — new "Quick install (curl)" section documenting the one-liner.

## Testing

- uv-missing path → exits 1 with a clear error and install link.
- Full install from GitHub `main` → 47 packages resolved, ginkgo built and installed.
- Installed `ginkgo --help` runs and lists all subcommands.
- pixi-present case → warning correctly skipped.

## Notes

- The one-liner only works once this lands on `main` (curl fetches raw from `main`) and requires the repo to be public.
- Installs from `main` (not a pinned tag), so it builds from source each run — no release artifacts yet.