### PR TITLE
feat: add --version flag to the ginkgo CLI

### DIFF
--- a/src/ginkgo/cli/app.py
+++ b/src/ginkgo/cli/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import sys
 from typing import Sequence
 
@@ -65,8 +66,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 2
 
 
+def _ginkgo_version() -> str:
+    """Return the installed ginkgo package version, or ``"unknown"`` if unavailable."""
+    try:
+        return importlib.metadata.version("ginkgo")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+        return "unknown"
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ginkgo")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_ginkgo_version()}",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     run_parser = subparsers.add_parser("run")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import Counter
 import re
 import subprocess
+import tomllib
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
@@ -63,6 +64,14 @@ def _seed_asset(*, cwd: Path, name: str, text: str, run_id: str, alias: str | No
     if alias is not None:
         asset_store.set_alias(key=version.key, alias=alias, version_id=version.version_id)
     return version.version_id
+
+
+def test_version_flag_reports_pyproject_version() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    expected = pyproject["project"]["version"]
+    result = _run_cli("--version", cwd=REPO_ROOT)
+    assert result.returncode == 0
+    assert result.stdout.strip() == f"ginkgo {expected}"
 
 
 class TestCliRunAndCache:


### PR DESCRIPTION
## Summary

Closes #63. Adds a `--version` flag to the top-level `ginkgo` CLI parser.

Previously `ginkgo --version` errored because the flag did not exist. It now prints the installed package version and exits 0.

## Changes

- `src/ginkgo/cli/app.py` — `_build_parser` registers a `--version` argument (`action="version"`). A `_ginkgo_version()` helper resolves the version from package metadata via `importlib.metadata.version("ginkgo")`, falling back to `"unknown"` if the package is not found. Reading from installed metadata keeps the value in sync with `[project] version` in `pyproject.toml` with no hardcoded duplicate.
- `tests/test_cli.py` — `test_version_flag_reports_pyproject_version` asserts `ginkgo --version` exits 0 and prints `ginkgo <version>` matching `[project] version` in `pyproject.toml`.

`action="version"` exits during argument parsing, before the required-subcommand check, so `ginkgo --version` works without a subcommand.

## Verification

- `ginkgo --version` → `ginkgo 0.1.0`, exit 0
- `pixi run precommit` passes (ruff, ty, uncoded all green)
- new test passes