### PR TITLE
feat: readable --dry-run task graph preview

### DIFF
--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -20,10 +20,22 @@ The current CLI supports:
 - `ginkgo env ls`
 - `ginkgo env clear`
 
-Implemented CLI features include dry-run validation, merged config overrides,
-human-readable run summaries, structured inspection and diagnostics, secret
-discovery and validation, cache inspection and eviction, failed-task
-debugging, and asset catalog inspection for local workspaces.
+Implemented CLI features include the dry-run execution-plan preview, merged
+config overrides, human-readable run summaries, structured inspection and
+diagnostics, secret discovery and validation, cache inspection and eviction,
+failed-task debugging, and asset catalog inspection for local workspaces.
+
+`ginkgo run --dry-run` validates the workflow and prints a static execution
+plan instead of running it: tasks grouped into dependency waves, each
+annotated `[cached]`, `[will run]`, or `[unknown]`, with static `.map()`
+fan-out fully expanded and a peak-resource summary. Cache status is resolved
+by a leaf-anchored cascade — a task is checkable only while every upstream
+dependency is a confirmed cache hit — so a fully warm rerun previews as all
+`[cached]`. The plan builder (`runtime/dry_run.py`) is read-only: no task
+runs, no environment is prepared, and no cached output is materialised. Large
+fan-out groups collapse unless `--verbose` is passed. `ginkgo test --dry-run`
+keeps its terse per-workflow validation line rather than printing a full plan
+for each discovered workflow.
 
 `ginkgo cache prune` accepts `--older-than <duration>`, `--max-size <size>`,
 and `--max-entries <N>`. At least one of the three is required; multiple

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from ginkgo.cli.common import RUNS_ROOT, RunMode, console
 from ginkgo.cli.renderers.common import environment_label, format_duration
+from ginkgo.cli.renderers.dry_run import render_dry_run_plan
 from ginkgo.cli.renderers.jsonl import JsonlEventRenderer
 from ginkgo.cli.renderers.models import (
     CliAssetSummary,
@@ -39,6 +40,7 @@ from ginkgo.runtime.caching.provenance import (
     combined_log_tail,
     make_run_id,
 )
+from ginkgo.runtime.dry_run import build_dry_run_plan
 from ginkgo.runtime.environment.secrets import build_secret_resolver
 from ginkgo.runtime.events import EventBus, RunCompleted, RunStarted, RunValidated
 from ginkgo.runtime.notifications.notifications import build_notification_service
@@ -78,6 +80,7 @@ def run_workflow(
     trust_workspace: bool = False,
     profile: bool = False,
     executor: str = "local",
+    plan_preview: bool = True,
 ) -> int:
     profiler = ProfileRecorder(enabled=profile)
     cli_startup_started = time.perf_counter()
@@ -177,6 +180,16 @@ def run_workflow(
                 RunCompleted(
                     run_id=run_id, status="success", task_counts={"validated": task_count}
                 )
+            )
+        elif plan_preview:
+            plan = build_dry_run_plan(
+                evaluator=evaluator,
+                workflow_label=workflow_path.name,
+            )
+            render_dry_run_plan(
+                plan=plan,
+                console=rich_console,
+                verbose=output_mode == "verbose",
             )
         else:
             rich_console.print(

--- a/src/ginkgo/cli/commands/test.py
+++ b/src/ginkgo/cli/commands/test.py
@@ -36,6 +36,9 @@ def command_test(args) -> int:
             cores=None,
             memory=None,
             dry_run=args.dry_run,
+            # `ginkgo test` validates many workflows; keep the per-workflow
+            # output terse rather than printing a full plan for each.
+            plan_preview=False,
         )
         if exit_code != 0:
             status = exit_code

--- a/src/ginkgo/cli/renderers/dry_run.py
+++ b/src/ginkgo/cli/renderers/dry_run.py
@@ -1,0 +1,149 @@
+"""Rich rendering for the ``ginkgo run --dry-run`` execution-plan preview."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from rich.console import Console
+from rich.text import Text
+
+from ginkgo.cli.renderers.common import environment_label
+from ginkgo.runtime.dry_run import CacheStatus, DryRunPlan, PlannedTask, PlanWave
+
+# Fan-out groups larger than this collapse to a single line unless --verbose.
+_COLLAPSE_THRESHOLD = 8
+
+# Longest task-label column before truncation.
+_MAX_LABEL_WIDTH = 46
+
+_GLYPH: dict[CacheStatus, str] = {"cached": "✓", "will_run": "•", "unknown": "?"}
+_STYLE: dict[CacheStatus, str] = {"cached": "green", "will_run": "cyan", "unknown": "yellow"}
+_TAG: dict[CacheStatus, str] = {
+    "cached": "[cached]",
+    "will_run": "[will run]",
+    "unknown": "[unknown]",
+}
+
+
+def render_dry_run_plan(*, plan: DryRunPlan, console: Console, verbose: bool) -> None:
+    """Print a wave-grouped static execution plan for a dry run.
+
+    Parameters
+    ----------
+    plan : DryRunPlan
+        The plan to render.
+    console : Console
+        Destination Rich console.
+    verbose : bool
+        When ``True``, expand every fan-out branch instead of collapsing
+        large groups.
+    """
+    console.print(_header(plan))
+
+    if plan.task_count == 0:
+        console.print(Text("  no tasks in workflow", style="dim"))
+        return
+
+    label_width = min(
+        _MAX_LABEL_WIDTH,
+        max(len(task.label) for wave in plan.waves for task in wave.tasks),
+    )
+    for wave in plan.waves:
+        console.print()
+        _render_wave(wave=wave, console=console, label_width=label_width, verbose=verbose)
+
+    console.print()
+    console.print(_summary(plan))
+
+
+def _header(plan: DryRunPlan) -> Text:
+    """Return the one-line plan header."""
+    header = Text("Dry run", style="bold")
+    waves = "wave" if plan.wave_count == 1 else "waves"
+    tasks = "task" if plan.task_count == 1 else "tasks"
+    header.append(f"  ·  {plan.task_count} {tasks}  ·  {plan.wave_count} {waves}", style="dim")
+    if plan.task_count > 0 and plan.cached_count == plan.task_count:
+        header.append("  ·  all cached, run would be a no-op", style="green")
+    return header
+
+
+def _render_wave(*, wave: PlanWave, console: Console, label_width: int, verbose: bool) -> None:
+    """Print one wave: a header line followed by its tasks."""
+    header = Text(f"Wave {wave.index}", style="bold")
+    if len(wave.tasks) > 1:
+        header.append(f"  ·  {len(wave.tasks)} tasks", style="dim")
+    console.print(header)
+
+    # Fan-out branches of one mapped task collapse to a single line.
+    groups: dict[str, list[PlannedTask]] = {}
+    for task in wave.tasks:
+        if task.mapped:
+            groups.setdefault(task.base_name, []).append(task)
+
+    collapsed: set[str] = set()
+    for task in wave.tasks:
+        group = groups.get(task.base_name) if task.mapped else None
+        if group is not None and len(group) > _COLLAPSE_THRESHOLD and not verbose:
+            if task.base_name not in collapsed:
+                collapsed.add(task.base_name)
+                _render_collapsed_group(base_name=task.base_name, group=group, console=console)
+            continue
+        console.print(_render_task_line(task=task, label_width=label_width))
+
+
+def _render_task_line(*, task: PlannedTask, label_width: int) -> Text:
+    """Return the rendered line for a single task."""
+    style = _STYLE[task.cache_status]
+    label = task.label
+    if len(label) > label_width:
+        label = label[: label_width - 1] + "…"
+
+    line = Text("  ")
+    line.append(f"{_GLYPH[task.cache_status]} ", style=style)
+    line.append(label.ljust(label_width))
+    line.append("  ")
+    line.append(_TAG[task.cache_status], style=style)
+    if task.kind != "python":
+        line.append(f"  · {task.kind}", style="dim")
+    if task.env is not None:
+        line.append(f"  · {environment_label(task.env)}", style="dim")
+    return line
+
+
+def _render_collapsed_group(*, base_name: str, group: list[PlannedTask], console: Console) -> None:
+    """Print a single collapsed line for a large fan-out group."""
+    counts = Counter(task.cache_status for task in group)
+    breakdown = ", ".join(
+        f"{counts[status]} {_TAG[status].strip('[]')}"
+        for status in ("cached", "will_run", "unknown")
+        if counts[status]
+    )
+    line = Text("  ")
+    line.append(f"{base_name} × {len(group)}", style="bold")
+    line.append(f"   {breakdown}", style="dim")
+    console.print(line)
+
+    shown = 3
+    sample = " · ".join(task.label for task in group[:shown])
+    detail = Text(f"    {sample}", style="dim")
+    remaining = len(group) - shown
+    if remaining > 0:
+        detail.append(f"  (+{remaining} more — --verbose for all)", style="dim")
+    console.print(detail)
+
+
+def _summary(plan: DryRunPlan) -> Text:
+    """Return the trailing resource / no-execution summary line."""
+    resources = plan.resources
+    parts: list[str] = []
+    if resources.peak_wave_threads:
+        parts.append(
+            f"{resources.peak_wave_threads} cores peak (wave {resources.peak_wave_index})"
+        )
+    if resources.peak_wave_memory_gb:
+        parts.append(f"{resources.peak_wave_memory_gb} GiB peak")
+    if resources.gpu_task_count:
+        suffix = "" if resources.gpu_task_count == 1 else "s"
+        parts.append(f"{resources.gpu_task_count} GPU task{suffix}")
+    parts.append("no tasks executed")
+    return Text("  ·  ".join(parts), style="dim")

--- a/src/ginkgo/runtime/caching/cache.py
+++ b/src/ginkgo/runtime/caching/cache.py
@@ -157,6 +157,25 @@ class CacheStore:
             artifact_store=self._artifact_store,
         )
 
+    def has_entry(self, *, cache_key: str) -> bool:
+        """Return whether a cache entry exists for the given key.
+
+        Read-only existence check: it does not decode or materialise the
+        cached value. Used by the ``--dry-run`` plan preview to predict
+        cache hits without running tasks.
+
+        Parameters
+        ----------
+        cache_key : str
+            The cache key to probe.
+
+        Returns
+        -------
+        bool
+            ``True`` if a stored output exists for the key.
+        """
+        return (self._entry_dir(cache_key) / "output.json").is_file()
+
     def save(
         self,
         *,

--- a/src/ginkgo/runtime/dry_run.py
+++ b/src/ginkgo/runtime/dry_run.py
@@ -1,0 +1,321 @@
+"""Static execution-plan preview for ``ginkgo run --dry-run``.
+
+Turns the validated task graph held by a :class:`ConcurrentEvaluator` into a
+structured, render-ready plan: concurrency waves, per-task cache status, and a
+resource summary. The builder is pure and read-only — no task is executed, no
+environment prepared, and no cached output materialised into the workspace.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from ginkgo.runtime.caching.cache import MISSING
+
+if TYPE_CHECKING:
+    from ginkgo.runtime.evaluator import ConcurrentEvaluator, _TaskNode
+
+CacheStatus = Literal["cached", "will_run", "unknown"]
+
+_DRIVER_KINDS = {"notebook", "script"}
+
+
+@dataclass(kw_only=True)
+class PlannedTask:
+    """One task in the dry-run plan.
+
+    Parameters
+    ----------
+    node_id : int
+        Stable scheduler node id.
+    base_name : str
+        Task name without its module prefix.
+    label : str
+        Display label; includes resolved fan-out parameters for mapped tasks.
+    kind : str
+        Task kind (``python``, ``shell``, ``notebook``, ``script``).
+    env : str | None
+        Declared environment, or ``None`` for the local environment.
+    mapped : bool
+        Whether the task is a fan-out branch from ``.map()`` / ``.product_map()``.
+    threads : int
+        Declared core budget.
+    memory_gb : int
+        Declared memory budget in GiB (``0`` when unset).
+    gpu : int
+        Declared GPU count.
+    cache_status : CacheStatus
+        ``cached``, ``will_run``, or ``unknown`` (not determinable without
+        running an upstream task).
+    """
+
+    node_id: int
+    base_name: str
+    label: str
+    kind: str
+    env: str | None
+    mapped: bool
+    threads: int
+    memory_gb: int
+    gpu: int
+    cache_status: CacheStatus
+
+
+@dataclass(kw_only=True)
+class PlanWave:
+    """A group of tasks with no dependencies on one another.
+
+    Parameters
+    ----------
+    index : int
+        1-based wave number.
+    tasks : list[PlannedTask]
+        Tasks in the wave, in scheduler-registration order.
+    """
+
+    index: int
+    tasks: list[PlannedTask]
+
+
+@dataclass(kw_only=True)
+class ResourceSummary:
+    """Aggregate resource demand across a dry-run plan.
+
+    Parameters
+    ----------
+    total_threads : int
+        Sum of declared core budgets across all tasks.
+    peak_wave_threads : int
+        Largest per-wave core total.
+    peak_wave_index : int
+        1-based index of the wave with the largest core total (``0`` if empty).
+    total_memory_gb : int
+        Sum of declared memory budgets in GiB.
+    peak_wave_memory_gb : int
+        Largest per-wave memory total in GiB.
+    gpu_task_count : int
+        Number of tasks declaring ``gpu > 0``.
+    """
+
+    total_threads: int
+    peak_wave_threads: int
+    peak_wave_index: int
+    total_memory_gb: int
+    peak_wave_memory_gb: int
+    gpu_task_count: int
+
+
+@dataclass(kw_only=True)
+class DryRunPlan:
+    """A render-ready static execution plan.
+
+    Parameters
+    ----------
+    workflow_label : str
+        Human-readable workflow name (typically the file name).
+    task_count : int
+        Total number of tasks in the static graph.
+    wave_count : int
+        Number of dependency waves.
+    waves : list[PlanWave]
+        The waves, in execution order.
+    resources : ResourceSummary
+        Aggregate resource demand.
+    cached_count, will_run_count, unknown_count : int
+        Task counts per cache status.
+    """
+
+    workflow_label: str
+    task_count: int
+    wave_count: int
+    waves: list[PlanWave]
+    resources: ResourceSummary
+    cached_count: int
+    will_run_count: int
+    unknown_count: int
+
+
+def build_dry_run_plan(*, evaluator: ConcurrentEvaluator, workflow_label: str) -> DryRunPlan:
+    """Build a static execution plan from a validated evaluator.
+
+    Must be called after ``evaluator.validate(...)``. Read-only: it resolves
+    arguments and probes the cache, but executes no tasks and materialises
+    nothing into the workspace.
+
+    Parameters
+    ----------
+    evaluator : ConcurrentEvaluator
+        An evaluator whose static graph has already been built by ``validate``.
+    workflow_label : str
+        Human-readable workflow name for the plan header.
+
+    Returns
+    -------
+    DryRunPlan
+        The structured plan, grouped into dependency waves.
+    """
+    nodes = evaluator._nodes
+    waves_by_node = _assign_waves(nodes)
+    topo_order = sorted(nodes, key=lambda node_id: (waves_by_node[node_id], node_id))
+    cache_status = _resolve_cache_status(evaluator=evaluator, topo_order=topo_order)
+
+    planned: dict[int, PlannedTask] = {}
+    for node_id in topo_order:
+        node = nodes[node_id]
+        task_def = node.task_def
+        planned[node_id] = PlannedTask(
+            node_id=node_id,
+            base_name=task_def.name.rsplit(".", 1)[-1],
+            label=_task_label(node),
+            kind=task_def.kind,
+            env=task_def.env,
+            mapped=node.expr.mapped,
+            threads=task_def.threads,
+            memory_gb=_memory_gb(task_def),
+            gpu=task_def.gpu,
+            cache_status=cache_status[node_id],
+        )
+
+    wave_count = (max(waves_by_node.values()) + 1) if waves_by_node else 0
+    waves = [
+        PlanWave(
+            index=index + 1,
+            tasks=[planned[nid] for nid in topo_order if waves_by_node[nid] == index],
+        )
+        for index in range(wave_count)
+    ]
+
+    statuses = [task.cache_status for task in planned.values()]
+    return DryRunPlan(
+        workflow_label=workflow_label,
+        task_count=len(nodes),
+        wave_count=wave_count,
+        waves=waves,
+        resources=_summarise_resources(waves),
+        cached_count=statuses.count("cached"),
+        will_run_count=statuses.count("will_run"),
+        unknown_count=statuses.count("unknown"),
+    )
+
+
+def _assign_waves(nodes: dict[int, _TaskNode]) -> dict[int, int]:
+    """Assign each node a 0-based wave (longest dependency path to a root)."""
+    indegree = {node_id: len(node.dependency_ids) for node_id, node in nodes.items()}
+    dependents: dict[int, list[int]] = {node_id: [] for node_id in nodes}
+    for node_id, node in nodes.items():
+        for dep_id in node.dependency_ids:
+            dependents[dep_id].append(node_id)
+
+    wave = {node_id: 0 for node_id, degree in indegree.items() if degree == 0}
+    queue = deque(wave)
+    while queue:
+        node_id = queue.popleft()
+        for child_id in dependents[node_id]:
+            wave[child_id] = max(wave.get(child_id, 0), wave[node_id] + 1)
+            indegree[child_id] -= 1
+            if indegree[child_id] == 0:
+                queue.append(child_id)
+    return wave
+
+
+def _resolve_cache_status(
+    *, evaluator: ConcurrentEvaluator, topo_order: list[int]
+) -> dict[int, CacheStatus]:
+    """Resolve cache status for every node via a leaf-anchored cascade.
+
+    Nodes are visited in topological order. A node is checkable only while
+    every dependency is a confirmed cache hit; once the chain breaks, the node
+    and everything below it is ``unknown``.
+    """
+    nodes = evaluator._nodes
+    status: dict[int, CacheStatus] = {}
+    for node_id in topo_order:
+        status[node_id] = _probe_node(evaluator=evaluator, node=nodes[node_id], status=status)
+    return status
+
+
+def _probe_node(
+    *, evaluator: ConcurrentEvaluator, node: _TaskNode, status: dict[int, CacheStatus]
+) -> CacheStatus:
+    """Return the cache status of one node, given resolved upstream statuses."""
+    # Downstream of anything not known-cached: the cache key cannot be
+    # computed without first running an upstream task.
+    if any(status.get(dep_id) != "cached" for dep_id in node.dependency_ids):
+        return "unknown"
+
+    # Notebook/script cache keys fold in a source hash obtained by evaluating
+    # the task body; skip them rather than run user code during a dry run.
+    if node.task_def.kind in _DRIVER_KINDS:
+        return "unknown"
+
+    cache_store = evaluator._cache_store
+    try:
+        resolved_args = evaluator._resolve_task_args(
+            expr=node.expr,
+            task_def=node.task_def,
+            node=node,
+            include_tmp_dirs=False,
+            stage_remote_refs=False,
+        )
+        cache_key, _ = cache_store.build_cache_key(
+            task_def=node.task_def,
+            resolved_args=resolved_args,
+        )
+    except Exception:
+        # Cache status is best-effort: any resolution failure degrades the
+        # node to "unknown" rather than aborting the preview.
+        return "unknown"
+
+    if not cache_store.has_entry(cache_key=cache_key):
+        return "will_run"
+
+    cached_value = cache_store.load(cache_key=cache_key)
+    if cached_value is MISSING:
+        return "will_run"
+
+    # Record the hit so dependents can resolve their own arguments against
+    # this output, mirroring the evaluator's prepare-phase cache fast path.
+    node.cache_key = cache_key
+    node.result = cached_value
+    node.state = "completed"
+    return "cached"
+
+
+def _task_label(node: _TaskNode) -> str:
+    """Return a display label, including resolved fan-out parameters."""
+    base_name = node.task_def.name.rsplit(".", 1)[-1]
+    parts = node.expr.display_label_parts
+    if parts:
+        return f"{base_name}[{','.join(parts)}]"
+    return f"{base_name}()"
+
+
+def _memory_gb(task_def: object) -> int:
+    """Return a task's declared memory budget in whole GiB (``0`` when unset)."""
+    memory = getattr(task_def, "memory_gb", None)
+    return int(memory) if memory else 0
+
+
+def _summarise_resources(waves: list[PlanWave]) -> ResourceSummary:
+    """Aggregate per-task resource declarations into run- and wave-level totals."""
+    all_tasks = [task for wave in waves for task in wave.tasks]
+    peak_threads = 0
+    peak_index = 0
+    peak_memory = 0
+    for wave in waves:
+        wave_threads = sum(task.threads for task in wave.tasks)
+        if wave_threads > peak_threads:
+            peak_threads = wave_threads
+            peak_index = wave.index
+        peak_memory = max(peak_memory, sum(task.memory_gb for task in wave.tasks))
+
+    return ResourceSummary(
+        total_threads=sum(task.threads for task in all_tasks),
+        peak_wave_threads=peak_threads,
+        peak_wave_index=peak_index,
+        total_memory_gb=sum(task.memory_gb for task in all_tasks),
+        peak_wave_memory_gb=peak_memory,
+        gpu_task_count=sum(1 for task in all_tasks if task.gpu > 0),
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -660,7 +660,7 @@ def main():
 
 
 class TestCliDryRun:
-    def test_run_dry_run_validates_without_execution(self) -> None:
+    def test_run_dry_run_previews_plan_without_executing(self) -> None:
         Path("workflow.py").write_text(
             """
 from pathlib import Path
@@ -682,10 +682,82 @@ def main():
         result = _run_cli("run", "workflow.py", "--dry-run", cwd=Path.cwd())
         assert result.returncode == 0, result.stderr
         assert "🌿 ginkgo run workflow.py --dry-run" in result.stdout
-        assert "✓ workflow.py (dry-run) - 1 tasks validated" in result.stdout
+        assert "Dry run" in result.stdout
+        assert "1 task" in result.stdout
+        assert "Wave 1" in result.stdout
+        assert "write_marker()" in result.stdout
+        assert "[will run]" in result.stdout
+        assert "no tasks executed" in result.stdout
         assert not Path("should-not-exist.txt").exists()
         runs_root = Path(".ginkgo") / "runs"
         assert not runs_root.exists() or list(runs_root.iterdir()) == []
+
+    def test_run_dry_run_groups_waves_and_expands_fanout(self) -> None:
+        Path("workflow.py").write_text(
+            """
+from ginkgo import flow, task
+
+@task()
+def prepare() -> str:
+    return "ready"
+
+@task()
+def analyse(base: str, sample: str) -> str:
+    return f"{base}:{sample}"
+
+@flow
+def main():
+    base = prepare()
+    return analyse(base=base).map(sample=["alpha", "beta", "gamma"])
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run_cli("run", "workflow.py", "--dry-run", cwd=Path.cwd())
+        assert result.returncode == 0, result.stderr
+        assert "Dry run" in result.stdout
+        assert "4 tasks" in result.stdout
+        assert "Wave 1" in result.stdout
+        assert "Wave 2" in result.stdout
+        assert "prepare()" in result.stdout
+        for sample in ("alpha", "beta", "gamma"):
+            assert f"analyse[{sample}]" in result.stdout
+        # The leaf task's cache state is determinable; fan-out branches
+        # downstream of a will-run task are not.
+        assert "[will run]" in result.stdout
+        assert "[unknown]" in result.stdout
+        assert "no tasks executed" in result.stdout
+
+    def test_run_dry_run_reports_cached_tasks_after_a_real_run(self) -> None:
+        Path("workflow.py").write_text(
+            """
+from ginkgo import flow, task
+
+@task()
+def upstream() -> int:
+    return 21
+
+@task()
+def downstream(value: int) -> int:
+    return value * 2
+
+@flow
+def main():
+    return downstream(value=upstream())
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        first = _run_cli("run", "workflow.py", cwd=Path.cwd())
+        assert first.returncode == 0, first.stderr
+
+        preview = _run_cli("run", "workflow.py", "--dry-run", cwd=Path.cwd())
+        assert preview.returncode == 0, preview.stderr
+        assert "all cached" in preview.stdout
+        assert preview.stdout.count("[cached]") == 2
+        assert "[will run]" not in preview.stdout
 
     def test_run_dry_run_fails_for_invalid_workflow(self) -> None:
         Path("invalid_workflow.py").write_text(


### PR DESCRIPTION
## Summary

Closes #67. `ginkgo run --dry-run` previously printed a single line (`✓ workflow.py (dry-run) - N tasks validated`). It now prints a structured static execution plan so users can verify what a run will do before committing to it.

## What it shows

- **Waves** — tasks grouped into topological dependency layers (tasks in a wave have no dependency on one another).
- **Cache status** — each task annotated `[cached]`, `[will run]`, or `[unknown]`, resolved by a **leaf-anchored cascade**: a task is checkable only while every upstream dependency is a confirmed cache hit, so a fully warm rerun previews as all `[cached]` ("run would be a no-op").
- **Fan-out** — static `.map()` / `.product_map()` branches are fully expanded with their resolved labels; groups larger than 8 collapse to one line unless `--verbose`.
- **Resources** — peak per-wave core / memory demand and GPU task count.

```
🌿 ginkgo run wf.py --dry-run

Dry run  ·  7 tasks  ·  4 waves

Wave 1  ·  2 tasks
  ✓ download_reference()     [cached]
  ✓ filter_snps()            [cached]

Wave 2  ·  3 tasks
  • allele_frequencies[YRI]  [will run]
  • allele_frequencies[CEU]  [will run]
  • allele_frequencies[CHB]  [will run]

Wave 3
  ? merge_frequencies()      [unknown]

Wave 4
  ? qc_report()              [unknown]

3 cores peak (wave 2)  ·  no tasks executed
```

## Design

- **`runtime/dry_run.py`** — pure, read-only plan builder. Built off the graph already produced by `evaluator.validate()`. The cache cascade reuses the evaluator's own `_resolve_task_args` + `CacheStore.build_cache_key` so dry-run keys cannot diverge from real-run keys; any resolution failure degrades a node to `[unknown]` rather than aborting. No task executes, no environment is prepared, and no cached output is materialised into the workspace.
- **`cli/renderers/dry_run.py`** — wave-grouped Rich renderer.
- **`CacheStore.has_entry`** — read-only cache-entry existence check (no decode, no materialisation).
- Kept off the `ConcurrentEvaluator` class, which issue #59 is actively decomposing.
- `ginkgo test --dry-run` keeps its terse per-workflow validation line via a new `run_workflow(plan_preview=False)` parameter — it validates many workflows and a full plan per workflow would be noise.

## Limitations (by design)

- Waves are dependency-only; real concurrency is further bounded by `--jobs` / `--cores` / `max_concurrent`.
- Dynamic fan-out (a task that *returns* an `ExprList` at runtime) is not statically knowable — such tasks appear as a single node.
- Notebook/script cache status shows `[unknown]` — their cache key needs the task body evaluated, which a dry run does not do.

## Tests

`tests/test_cli.py::TestCliDryRun` — plan preview without execution, wave grouping + fan-out expansion + unknown-cascade, and an all-`[cached]` warm rerun. Full suite: 672 passed, 5 skipped. `pixi run precommit` clean.