### PR TITLE
fix: cache GC no longer deletes catalogued asset artifacts

### DIFF
--- a/src/ginkgo/cli/commands/cache.py
+++ b/src/ginkgo/cli/commands/cache.py
@@ -353,19 +353,11 @@ def _safe_rmtree(path: Path) -> None:
         shutil.rmtree(path)
 
 
-def _gc_orphan_artifacts(cache_root: Path) -> None:
-    """Remove artifacts not referenced by any remaining cache entry.
-
-    Scans all ``meta.json`` files under *cache_root* to collect referenced
-    artifact IDs, then deletes any artifacts in the sibling ``artifacts/``
-    directory that are not referenced.
-    """
-    artifacts_root = cache_root.parent / "artifacts"
-    if not artifacts_root.exists():
-        return
-
-    # Collect all referenced artifact IDs from surviving cache entries.
+def _cache_artifact_ids(cache_root: Path) -> set[str]:
+    """Return artifact IDs referenced by surviving cache entries."""
     referenced: set[str] = set()
+    if not cache_root.exists():
+        return referenced
     for entry_dir in cache_root.iterdir():
         if not entry_dir.is_dir():
             continue
@@ -378,6 +370,51 @@ def _gc_orphan_artifacts(cache_root: Path) -> None:
             continue
         for artifact_id in meta.get("artifact_ids", {}).values():
             referenced.add(artifact_id)
+    return referenced
+
+
+def _asset_artifact_ids(assets_root: Path) -> set[str]:
+    """Return artifact IDs referenced by every catalogued asset version.
+
+    The asset catalog and the cache share a single content-addressed
+    artifact store. Asset versions are intended to outlive the ephemeral
+    cache, so their artifacts must be kept alive even when no cache entry
+    still references them. Each version is persisted at
+    ``<assets_root>/<namespace>/<name>/versions/v-<id>/meta.yaml``.
+    """
+    referenced: set[str] = set()
+    if not assets_root.exists():
+        return referenced
+    for meta_path in assets_root.glob("*/*/versions/v-*/meta.yaml"):
+        try:
+            meta = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+        except (yaml.YAMLError, OSError):
+            continue
+        artifact_id = meta.get("artifact_id")
+        if isinstance(artifact_id, str) and artifact_id:
+            referenced.add(artifact_id)
+    return referenced
+
+
+def _gc_orphan_artifacts(cache_root: Path) -> None:
+    """Remove artifacts not referenced by any cache entry or catalogued asset.
+
+    Collects referenced artifact IDs from every surviving cache entry's
+    ``meta.json`` *and* from every asset version in the sibling ``assets/``
+    catalog, then deletes any artifact in the sibling ``artifacts/``
+    directory that neither references.
+
+    The cache and the asset catalog share one artifact store. Scanning only
+    the cache would treat asset-only artifacts as orphans and delete data
+    the asset catalog still points to, so the asset catalog must be scanned
+    here as well.
+    """
+    artifacts_root = cache_root.parent / "artifacts"
+    if not artifacts_root.exists():
+        return
+
+    referenced = _cache_artifact_ids(cache_root)
+    referenced |= _asset_artifact_ids(cache_root.parent / "assets")
 
     # Remove orphaned artifacts via the store's delete method.
     from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore

--- a/src/ginkgo/runtime/artifacts/value_codec.py
+++ b/src/ginkgo/runtime/artifacts/value_codec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import io
+import logging
 import pickle
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -16,6 +17,8 @@ from ginkgo.core.types import file, folder, tmp_dir
 
 if TYPE_CHECKING:
     from ginkgo.runtime.artifacts.artifact_store import ArtifactStore
+
+logger = logging.getLogger(__name__)
 
 INLINE_BYTES_LIMIT = 256 * 1024
 
@@ -454,10 +457,21 @@ def _decode_bytes(*, codec_name: str, data: bytes) -> Any:
 
 
 def _try_encode_dataframe_parquet(value: Any) -> bytes | None:
+    """Encode a DataFrame to Parquet bytes, or return None if it cannot.
+
+    Returning ``None`` makes the caller fall back to pickle, which is not
+    portable across pandas/Python versions. The Parquet failure is logged
+    rather than swallowed silently so the format downgrade is diagnosable.
+    """
     buffer = io.BytesIO()
     try:
         value.to_parquet(buffer, index=True)
     except Exception:
+        logger.warning(
+            "DataFrame could not be encoded as Parquet; falling back to "
+            "pickle (not portable across pandas/Python versions).",
+            exc_info=True,
+        )
         return None
     return buffer.getvalue()
 

--- a/tests/test_cache_prune_assets.py
+++ b/tests/test_cache_prune_assets.py
@@ -1,0 +1,65 @@
+"""Regression tests: cache GC must not delete catalogued asset artifacts.
+
+The cache and the asset catalog share a single content-addressed artifact
+store. ``ginkgo cache prune`` / ``cache clear`` run ``_gc_orphan_artifacts``,
+which previously collected referenced artifact IDs from cache entries only —
+deleting artifacts that asset versions still referenced.
+"""
+
+from pathlib import Path
+
+from ginkgo.cli.commands.cache import _gc_orphan_artifacts
+from ginkgo.core.asset import AssetKey, make_asset_version
+from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
+from ginkgo.runtime.artifacts.asset_store import AssetStore
+
+
+def _ginkgo_dirs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Return (cache_root, artifacts_root, assets_root) under a fresh tree."""
+    base = tmp_path / ".ginkgo"
+    cache_root = base / "cache"
+    cache_root.mkdir(parents=True)
+    return cache_root, base / "artifacts", base / "assets"
+
+
+def test_gc_keeps_artifact_referenced_only_by_an_asset(tmp_path):
+    """An artifact reachable only from the asset catalog must survive GC."""
+    cache_root, artifacts_root, assets_root = _ginkgo_dirs(tmp_path)
+
+    # Store a blob and register an asset version pointing at it. No cache
+    # entry references the blob.
+    store = LocalArtifactStore(root=artifacts_root)
+    record = store.store_bytes(data=b"asset payload", extension="parquet")
+
+    asset_store = AssetStore(root=assets_root)
+    asset_store.register_version(
+        version=make_asset_version(
+            key=AssetKey(namespace="default", name="demo_table"),
+            kind="table",
+            artifact_id=record.artifact_id,
+            content_hash=record.digest_hex,
+            run_id="run-1",
+            producer_task="pkg.workflow.build_table",
+            metadata=None,
+        )
+    )
+
+    _gc_orphan_artifacts(cache_root)
+
+    assert store.exists(artifact_id=record.artifact_id), (
+        "GC deleted an artifact still referenced by a catalogued asset"
+    )
+
+
+def test_gc_deletes_artifact_referenced_by_neither_cache_nor_asset(tmp_path):
+    """A genuinely orphaned artifact is still collected — GC stays effective."""
+    cache_root, artifacts_root, _ = _ginkgo_dirs(tmp_path)
+
+    store = LocalArtifactStore(root=artifacts_root)
+    record = store.store_bytes(data=b"truly orphaned", extension="bin")
+
+    _gc_orphan_artifacts(cache_root)
+
+    assert not store.exists(artifact_id=record.artifact_id), (
+        "GC failed to delete a genuinely orphaned artifact"
+    )


### PR DESCRIPTION
## Problem

The cache and the asset catalog share a single content-addressed artifact store at `.ginkgo/artifacts`. `_gc_orphan_artifacts` — run after every `ginkgo cache prune` **and** every `ginkgo cache clear <key>` — decided artifact liveness by scanning **cache entries only** (`.ginkgo/cache/*/meta.json`).

Asset versions are meant to outlive the ephemeral cache. But an artifact reachable only from a catalogued asset version was treated as an orphan and deleted. The asset-version record survives, so `AssetRef.load()` then returns a path to a file that no longer exists — `ginkgo asset show`, web-UI previews, and downstream consumers all break. Routine cache hygiene silently destroyed curated data.

A second, smaller issue: `_try_encode_dataframe_parquet` caught every exception and returned `None`, silently downgrading DataFrame storage to pickle (not portable across pandas/Python versions) with zero signal.

## Changes

- **`cache.py`** — `_gc_orphan_artifacts` now keeps an artifact alive if referenced by a cache entry **or** a catalogued asset version. Scan split into `_cache_artifact_ids` and new `_asset_artifact_ids` (globs `<assets>/*/*/versions/v-*/meta.yaml`).
- **`value_codec.py`** — Parquet encode failures are logged (`warning`, with traceback) instead of swallowed.

## Tests

New `tests/test_cache_prune_assets.py`:
- `test_gc_keeps_artifact_referenced_only_by_an_asset` — regression guard; **fails on pre-fix code** (artifact deleted), passes after.
- `test_gc_deletes_artifact_referenced_by_neither_cache_nor_asset` — confirms GC still collects genuine orphans.

`test_cache_integrity.py` (14), `test_asset_store` / `test_assets` / `test_value_codec` (54) all pass. ruff clean; no new `ty` diagnostics.