### PR TITLE
docs: fix factual errors and fill gaps (closes #76)

### DIFF
--- a/docs/architecture/agent-operability.md
+++ b/docs/architecture/agent-operability.md
@@ -23,8 +23,9 @@ Rich CLI output and agent-mode JSONL output are separate renderings of the
 same runtime event stream.
 
 - Human operators continue to use the Rich run renderer.
-- Agents can use `ginkgo run --agent` to receive one JSON event per line on
-  stdout.
+- Agents use `ginkgo run --agent` to receive one JSON event per line on stdout.
+- `ginkgo run --agent --verbose` extends the JSONL stream with per-task log
+  output, which is omitted from the default agent stream.
 
 The legacy structured stderr task stream used by direct `evaluate(...)`
 callers remains available when no event bus is attached, preserving backward

--- a/docs/architecture/execution-model.md
+++ b/docs/architecture/execution-model.md
@@ -151,11 +151,11 @@ Shell tasks may declare `env="name"` to run against a Pixi environment under
 responsible for env discovery, validation, lock hashing for cache invalidation,
 environment preparation before dispatch, and shell execution through Pixi.
 
-**ContainerBackend** (`envs/container.py`) supports Docker and Podman execution for **shell tasks only**. Container envs are declared via URI schemes: `env="docker://image:tag"` or `env="oci://image:tag"`. The project root is bind-mounted at its host-side absolute path so that paths in shell commands resolve without rewriting.
+**ContainerBackend** (`envs/container.py`) supports Docker and Podman execution for shell, notebook, and script tasks. Container envs are declared via URI schemes: `env="docker://image:tag"` or `env="oci://image:tag"`. The project root is bind-mounted at its host-side absolute path so that paths in shell commands resolve without rewriting.
 
 **CompositeBackend** routes env strings to the correct backend based on the URI scheme. Container env URIs go to `ContainerBackend`; everything else goes to `LocalBackend`.
 
-Foreign execution environments do not support Python tasks. Ginkgo treats `env=...` as a shell-task boundary only, which keeps foreign execution command-oriented and avoids requiring the Ginkgo runtime to be importable inside every target environment. This is enforced at validation time before any work starts.
+Foreign execution environments do not support Python tasks. `env=...` is valid on shell, notebook, and script tasks only. This keeps foreign execution command-oriented and avoids requiring the Ginkgo runtime to be importable inside every target environment. This is enforced at validation time before any work starts.
 
 Image digests (not mutable tags) are used for cache key identity, ensuring cache invalidation when image contents change.
 

--- a/docs/architecture/package-layout.md
+++ b/docs/architecture/package-layout.md
@@ -55,21 +55,19 @@ ginkgo/
 │   ├── publisher.py         # remote output publishing
 │   ├── resolve.py           # backend factory
 │   ├── staging.py           # remote input staging
-│   └── worker.py            # remote worker entry point
+│   ├── worker.py            # remote worker entry point
+│   └── access/              # FUSE / staged remote input access
+│       ├── doctor.py        # access-layer diagnostics
+│       ├── mounted.py       # FUSE-mount coordination
+│       ├── protocol.py      # wire encoding for fuse refs
+│       ├── resolver.py      # RemoteInputResolver
+│       ├── staged.py        # staged (download) access path
+│       ├── worker_hydration.py  # worker-side input hydration
+│       └── drivers/         # per-provider FUSE drivers (s3, gcsfuse, rclone)
 ├── envs/
 │   ├── container.py      # ContainerBackend (Docker/Podman)
 │   └── pixi.py
-├── cli/
-│   ├── app.py
-│   └── commands/
-└── ui/
-    ├── server/
-    │   ├── __init__.py      # re-exports create_ui_server
-    │   ├── app.py           # HTTP/WebSocket handler and route wiring
-    │   ├── live.py          # live-state capture and diffing
-    │   ├── payloads.py      # run/task/workspace/cache payload builders
-    │   ├── utils.py         # shared formatting helpers
-    │   ├── websocket.py     # WebSocket framing
-    │   └── workspaces.py    # WorkspaceRecord, WorkspaceRegistry, discovery
-    └── static/
+└── cli/
+    ├── app.py
+    └── commands/
 ```

--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -116,10 +116,12 @@ collapses to one HTML document.
 Nothing is silently clipped. Every cap surfaces as either a
 `trunc-note` banner or a `message` field on the preview.
 
-`--embed-full-assets` copies the raw artifact bytes for table / text
-assets into `artifacts/<artifact_id>...` in addition to the rendered
-preview. Previews themselves still obey the row/byte caps — this flag is
-about archival completeness, not in-document rendering.
+`--embed-full-assets` copies the raw artifact bytes for any asset whose
+artifact is stored as a single file (`path.is_file()`) into
+`artifacts/<artifact_id>...` in addition to the rendered preview.
+Directory-backed artifacts (e.g. zarr stores) are excluded. Previews
+themselves still obey the row/byte caps — this flag is about archival
+completeness, not in-document rendering.
 
 ## Aesthetic
 

--- a/docs/architecture/task-model.md
+++ b/docs/architecture/task-model.md
@@ -9,9 +9,11 @@
 - `threads=...`, `memory=...`, `gpu=...` for resource declarations
 - `remote=True` for explicit remote dispatch
 
-Python tasks always execute in the scheduler's own Python environment. If a
-task needs a different Pixi or container environment, it must be declared with
-`kind="shell"` and invoke the desired script or command explicitly.
+Python tasks execute in a spawned subprocess worker pool (`ProcessPoolExecutor`,
+spawn context). A `ThreadPoolExecutor` fallback is used when the OS disallows
+process spawning (e.g. certain container environments). Python tasks cannot
+declare an `env`; to run code in a specific environment, use `kind="shell"`,
+`kind="script"`, or `kind="notebook"` instead.
 
 Task parameters use regular positional-or-keyword signatures — do not add a
 `*,` separator to force keyword-only. The runtime always binds task arguments
@@ -35,7 +37,7 @@ For Pixi-backed shell tasks, the foreign environment does not import the task's
 defining `workflow.py` module. The scheduler evaluates the wrapper locally and
 dispatches only the shell payload through Pixi.
 
-Shell tasks can also run inside Docker or Podman containers by declaring a container env:
+Shell, notebook, and script tasks can all run inside Docker or Podman containers by declaring a container env:
 
 ```python
 @task(kind="shell", env="docker://biocontainers/samtools:1.17")

--- a/docs/site/guide/assets.md
+++ b/docs/site/guide/assets.md
@@ -57,14 +57,16 @@ bytes, so an asset key gives you a stable handle with full version history.
 ```bash
 ginkgo asset ls                 # all asset keys
 ginkgo asset versions <key>     # version history for one key
-ginkgo asset inspect <ref>      # metadata for one asset version
-ginkgo asset show <ref>         # render the asset payload
+ginkgo asset show <ref>         # kind-specific metadata stats (schema, shape, dimensions, etc.)
+ginkgo asset inspect <ref>      # raw AssetVersion record (artifact_id, content_hash, run_id, path)
 ginkgo models [run_id]          # model assets with their recorded metrics
 ```
 
 ## HTML Reports
 
-`ginkgo report` renders a finished run as a self-contained HTML report:
+`ginkgo report` renders a **completed** run (status `succeeded` or `failed`) as
+a self-contained HTML report. Running or pending runs are rejected with an
+error.
 
 ```bash
 ginkgo report                   # the most recent run
@@ -78,13 +80,17 @@ metrics), and links to rendered notebooks. By default it is written to
 
 Useful flags:
 
-- `--single-file` — emit one HTML file with CSS, fonts, and figures inlined as
-  data URIs; easy to share or attach.
+- `--single-file` — emit one HTML file with CSS, fonts, figures, and log files
+  inlined as data URIs; easy to share or attach. Notebook iframes are not
+  inlined and remain as relative references.
 - `--out <dir>` — write the report bundle somewhere other than the default.
 - `--open` / `--no-open` — open (or do not open) the report in a browser when
   the build finishes.
-- `--embed-full-assets` — copy full artifact bytes into the bundle alongside the
-  rendered previews.
+- `--embed-full-assets` — copy artifact bytes into the bundle alongside the
+  rendered previews. Only applies to assets stored as single files; directory-
+  backed artifacts (e.g. zarr stores) are excluded.
+- `--max-log-lines N` — control how many log lines are shown per failed task
+  (default 80).
 
 To list just the rendered notebook artifacts produced by runs, use
 `ginkgo notebooks`.

--- a/docs/site/guide/cli.md
+++ b/docs/site/guide/cli.md
@@ -90,9 +90,29 @@ ginkgo debug <run_id>
 ```
 
 `ginkgo doctor` catches environment and configuration problems before a run.
+Pass `--json` for structured output suitable for programmatic use:
+
+```bash
+ginkgo doctor workflow.py --json
+```
+
 `ginkgo debug` is most useful after the fact: once a run directory exists, it
 surfaces recorded task status, logs, and cache behavior without manually
 navigating `.ginkgo/runs/`.
+
+`ginkgo cache` has several subcommands beyond listing:
+
+```bash
+ginkgo cache ls                          # list cached task results
+ginkgo cache explain --run <run_id>      # explain cache decisions for a run
+ginkgo cache prune --older-than 7d       # remove entries older than a duration
+ginkgo cache prune --max-size 10GB       # remove entries to stay under a size limit
+ginkgo cache prune --max-entries 500     # remove entries to stay under an entry count
+ginkgo cache clear <cache_key>           # remove a specific cache entry
+```
+
+`cache prune` requires at least one of `--older-than`, `--max-size`, or
+`--max-entries`. Add `--dry-run` to preview what would be removed.
 
 ## A Typical Loop
 

--- a/docs/site/guide/concepts.md
+++ b/docs/site/guide/concepts.md
@@ -95,10 +95,10 @@ lifecycle.
 
 ## The Runtime Is Local-First
 
-Today, Ginkgo's orchestration logic stays in the local Python process. It can
-dispatch shell work into Pixi environments or containers, but graph
-construction, scheduling, caching decisions, and provenance recording remain
-local and explicit.
+Today, Ginkgo's orchestration logic stays in the local Python process. Graph
+construction, scheduling, caching decisions, and provenance recording all happen
+locally. Python task bodies run in a spawned subprocess worker pool; shell,
+script, and notebook tasks run via Pixi environments or containers.
 
 ## See Also
 

--- a/docs/site/guide/tasks-and-flows.md
+++ b/docs/site/guide/tasks-and-flows.md
@@ -37,7 +37,7 @@ task body does:
 
 | Kind | Decorator | Body returns | Executes |
 |---|---|---|---|
-| Python | `@task()` | a Python value | in the scheduler's own Python process |
+| Python | `@task()` | a Python value | in a spawned subprocess worker (`ProcessPoolExecutor`) |
 | Shell | `@task("shell")` | `shell(cmd=..., output=...)` | a shell command, optionally inside a declared environment |
 | Script | `@task("script")` | `script(path, output=...)` | a `.py` or `.R` script file, with inputs passed as `--flags` |
 | Notebook | `@task("notebook")` | `notebook(path, output=...)` | a Jupyter or marimo notebook, rendered to HTML |
@@ -45,7 +45,8 @@ task body does:
 
 The kind can be passed positionally (`@task("shell")`) or by keyword
 (`@task(kind="shell")`). Shell, script, and notebook tasks can each declare an
-`env`; Python tasks always run in the scheduler's own process.
+`env`; Python tasks cannot declare an `env` and always run in a spawned worker
+process.
 
 Side by side, the five bodies look like this:
 
@@ -86,8 +87,9 @@ The sections below cover each kind.
 
 ## Python Tasks
 
-Use `@task()` for Python code that should execute in the scheduler's own Python
-environment.
+Use `@task()` for pure Python computation. The task body runs in a spawned
+subprocess worker (`ProcessPoolExecutor`, spawn context). A `ThreadPoolExecutor`
+fallback is used in environments that disallow process spawning.
 
 ```python
 from pathlib import Path
@@ -130,7 +132,8 @@ def fastq_stats(sample_id: str, fastq: file) -> file:
 
 The wrapper function runs locally on the scheduler. It builds the concrete shell
 payload from resolved values, and only that payload is executed in the foreign
-environment.
+environment. Shell, script, and notebook tasks can all declare an `env`; Python
+tasks cannot.
 
 ## Script Tasks
 

--- a/src/ginkgo/runtime/remote_input_resolver.py
+++ b/src/ginkgo/runtime/remote_input_resolver.py
@@ -234,9 +234,13 @@ class RemoteStager:
         task_policy = TaskAccessPolicy.from_task_def(task_def)
         access_config = self._get_access_config()
 
-        # Fuse streaming is only meaningful on the remote dispatch path.
-        # For local tasks (no remote executor will run them), force
-        # `stage` so downstream code receives a normal local path.
+        # Fuse mounting is currently only wired for the remote dispatch
+        # path: the worker hydrates fuse markers via `MountedAccess`, but
+        # the local process-pool path has no equivalent mount lifecycle.
+        # For local tasks, force `stage` so downstream code receives a
+        # normal local path. (Local FUSE on a host with a healthy driver
+        # would also be useful for sparse reads of large objects; see the
+        # follow-up tracked on PR #41.)
         dispatches_remote = bool(
             getattr(task_def, "remote", False) or getattr(task_def, "gpu", 0) > 0
         )


### PR DESCRIPTION
## Summary

- **Python task execution**: corrected to "spawned subprocess worker (`ProcessPoolExecutor`)" in `concepts.md`, `tasks-and-flows.md`, `task-model.md`
- **Container `env=` scope**: corrected from "shell-only" to "shell, notebook, and script" in `tasks-and-flows.md`, `execution-model.md`, `task-model.md`
- **`ginkgo asset show`**: corrected description (renders kind-specific metadata stats, not the payload); clarified `inspect` shows raw `AssetVersion` record
- **`--single-file`**: noted that notebook iframes are not inlined
- **`--embed-full-assets`**: noted file-only restriction (directory-backed artifacts excluded)
- **`--embed-full-assets` in `reporting.md`**: corrected from "table/text only" to "any `is_file()` artifact"
- **`ginkgo report` terminal-only**: documented that running/pending runs are rejected
- **`package-layout.md`**: removed stale `ui/` subtree; added `remote/access/` subpackage
- **`cli.md`**: added `ginkgo doctor --json`, `ginkgo cache explain`, and `ginkgo cache prune` flag documentation
- **`agent-operability.md`**: documented `--agent --verbose` log-stream behaviour

Closes #76