### PR TITLE
Support pyproject.toml as a Pixi environment manifest

### DIFF
--- a/docs/architecture/execution-model.md
+++ b/docs/architecture/execution-model.md
@@ -147,7 +147,9 @@ The evaluator dispatches work through a `TaskBackend` protocol (`runtime/backend
 
 **LocalBackend** wraps `PixiRegistry` for existing Pixi-based execution.
 Shell tasks may declare `env="name"` to run against a Pixi environment under
-`envs/<name>/pixi.toml`, or against an explicit manifest path. This path is
+`envs/<name>/`, where the manifest is either a `pixi.toml` or a `pyproject.toml`
+carrying a `[tool.pixi]` section (Pixi accepts both natively), or against an
+explicit manifest path. This path is
 responsible for env discovery, validation, lock hashing for cache invalidation,
 environment preparation before dispatch, and shell execution through Pixi.
 

--- a/src/ginkgo/cli/commands/env.py
+++ b/src/ginkgo/cli/commands/env.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ginkgo.cli.common import console
-from ginkgo.envs.pixi import PixiRegistry
+from ginkgo.envs.pixi import PixiRegistry, _env_manifest
 
 
 @dataclass(frozen=True)
@@ -97,8 +97,10 @@ def list_project_envs(*, registry: PixiRegistry) -> list[EnvEntryRow]:
         if not envs_dir.is_dir():
             continue
         for child in sorted(envs_dir.iterdir(), key=lambda path: path.name):
-            manifest = child / "pixi.toml"
-            if not child.is_dir() or not manifest.is_file():
+            if not child.is_dir():
+                continue
+            manifest = _env_manifest(child)
+            if manifest is None:
                 continue
             resolved_manifest = manifest.resolve()
             if resolved_manifest in seen_manifests:

--- a/src/ginkgo/envs/pixi.py
+++ b/src/ginkgo/envs/pixi.py
@@ -1,7 +1,9 @@
 """Pixi environment registry and subprocess helpers.
 
 Environments are resolved from ``envs/<env_name>/`` under the project root, or
-from an explicit path to a ``pixi.toml``. Explicit conda environment specs
+from an explicit path to a ``pixi.toml``. A named environment directory may
+instead carry a ``pyproject.toml`` with a ``[tool.pixi]`` section, which Pixi
+accepts as a manifest natively. Explicit conda environment specs
 (``environment.yml`` / ``environment.yaml``) are imported into a generated
 neighboring Pixi workspace under ``.ginkgo-pixi/`` and then executed through
 the normal Pixi path.
@@ -12,6 +14,7 @@ from __future__ import annotations
 
 import subprocess
 import shutil
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -55,6 +58,57 @@ class PixiEnvPrepareError(RuntimeError):
         super().__init__(f"Failed to prepare Pixi env {str(manifest)!r}: {details}")
 
 
+def _is_pixi_pyproject(path: Path) -> bool:
+    """Return whether *path* is a ``pyproject.toml`` carrying ``[tool.pixi]``.
+
+    Parameters
+    ----------
+    path : Path
+        Candidate manifest path.
+
+    Returns
+    -------
+    bool
+        True only when *path* is a readable ``pyproject.toml`` whose parsed
+        contents contain a ``[tool.pixi]`` table. Unreadable or malformed TOML
+        is treated as a non-match rather than an error.
+    """
+    if path.name != "pyproject.toml" or not path.is_file():
+        return False
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    tool = data.get("tool")
+    return isinstance(tool, dict) and "pixi" in tool
+
+
+def _env_manifest(env_dir: Path) -> Path | None:
+    """Return the Pixi manifest within *env_dir*, or None if absent.
+
+    Prefers ``pixi.toml``; falls back to a ``pyproject.toml`` that carries a
+    ``[tool.pixi]`` section.
+
+    Parameters
+    ----------
+    env_dir : Path
+        Directory of a named environment (``envs/<name>/``).
+
+    Returns
+    -------
+    Path | None
+        Path to the manifest file, or ``None`` when neither manifest exists.
+    """
+    pixi_toml = env_dir / "pixi.toml"
+    if pixi_toml.is_file():
+        return pixi_toml
+    pyproject = env_dir / "pyproject.toml"
+    if _is_pixi_pyproject(pyproject):
+        return pyproject
+    return None
+
+
 def _list_envs(envs_dir: Path) -> list[str]:
     """Return sorted names of discoverable environments under envs_dir."""
     if not envs_dir.is_dir():
@@ -62,7 +116,7 @@ def _list_envs(envs_dir: Path) -> list[str]:
     return sorted(
         child.name
         for child in envs_dir.iterdir()
-        if child.is_dir() and (child / "pixi.toml").is_file()
+        if child.is_dir() and _env_manifest(child) is not None
     )
 
 
@@ -130,13 +184,14 @@ class PixiRegistry:
         Parameters
         ----------
         env : str
-            Environment name (resolved from ``envs/<name>/``) or an explicit
-            path to a ``pixi.toml``.
+            Environment name (resolved from ``envs/<name>/``, where the
+            manifest may be ``pixi.toml`` or a ``pyproject.toml`` with a
+            ``[tool.pixi]`` section) or an explicit path to a manifest file.
 
         Returns
         -------
         Path
-            Absolute path to the ``pixi.toml``.
+            Absolute path to the resolved manifest.
 
         Raises
         ------
@@ -152,8 +207,8 @@ class PixiRegistry:
             return manifest.resolve()
 
         for envs_dir in self._envs_dirs:
-            manifest = envs_dir / env / "pixi.toml"
-            if manifest.is_file():
+            manifest = _env_manifest(envs_dir / env)
+            if manifest is not None:
                 return manifest.resolve()
 
         searched = self._envs_dirs[0] if self._envs_dirs else None

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -27,6 +27,9 @@ from ginkgo.envs.pixi import (
     PixiEnvNotFoundError,
     PixiEnvPrepareError,
     PixiRegistry,
+    _env_manifest,
+    _is_pixi_pyproject,
+    _list_envs,
 )
 
 
@@ -249,6 +252,109 @@ class TestPixiRegistry:
         registry = PixiRegistry(project_root=_TESTS_DIR)
         with pytest.raises(TypeError, match="Foreign environments only support driver tasks"):
             _evaluate(my_flow(), registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pyproject.toml as a Pixi manifest (no subprocess)
+# ---------------------------------------------------------------------------
+
+
+_PYPROJECT_WITH_PIXI = (
+    "[project]\n"
+    "name = 'demo'\n"
+    "version = '0.1.0'\n"
+    "\n"
+    "[tool.pixi.workspace]\n"
+    "channels = []\n"
+    "platforms = []\n"
+)
+
+_PYPROJECT_WITHOUT_PIXI = "[project]\nname = 'demo'\nversion = '0.1.0'\n"
+
+
+def _write_env(envs_root: Path, name: str, *, filename: str, content: str) -> Path:
+    """Create ``envs_root/<name>/<filename>`` with *content* and return its path."""
+    manifest = envs_root / name / filename
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(content, encoding="utf-8")
+    return manifest
+
+
+class TestPixiPyprojectManifest:
+    def test_is_pixi_pyproject_detects_tool_pixi_section(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "pyproject.toml"
+        manifest.write_text(_PYPROJECT_WITH_PIXI, encoding="utf-8")
+        assert _is_pixi_pyproject(manifest) is True
+
+    def test_is_pixi_pyproject_rejects_pyproject_without_tool_pixi(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "pyproject.toml"
+        manifest.write_text(_PYPROJECT_WITHOUT_PIXI, encoding="utf-8")
+        assert _is_pixi_pyproject(manifest) is False
+
+    def test_is_pixi_pyproject_rejects_non_pyproject_filename(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "pixi.toml"
+        manifest.write_text("[tool.pixi.workspace]\n", encoding="utf-8")
+        assert _is_pixi_pyproject(manifest) is False
+
+    def test_is_pixi_pyproject_rejects_malformed_toml(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "pyproject.toml"
+        manifest.write_text("[tool.pixi\nbroken = ", encoding="utf-8")
+        assert _is_pixi_pyproject(manifest) is False
+
+    def test_resolve_named_env_with_pyproject_manifest(self, tmp_path: Path) -> None:
+        manifest = _write_env(
+            tmp_path / "envs", "ml_env", filename="pyproject.toml", content=_PYPROJECT_WITH_PIXI
+        )
+        registry = PixiRegistry(project_root=tmp_path)
+        assert registry.resolve(env="ml_env") == manifest.resolve()
+
+    def test_resolve_prefers_pixi_toml_over_pyproject(self, tmp_path: Path) -> None:
+        pixi_toml = _write_env(
+            tmp_path / "envs",
+            "both",
+            filename="pixi.toml",
+            content="[workspace]\nname = 'both'\nchannels = []\nplatforms = []\n",
+        )
+        _write_env(
+            tmp_path / "envs", "both", filename="pyproject.toml", content=_PYPROJECT_WITH_PIXI
+        )
+        registry = PixiRegistry(project_root=tmp_path)
+        assert registry.resolve(env="both") == pixi_toml.resolve()
+
+    def test_resolve_named_env_ignores_pyproject_without_tool_pixi(self, tmp_path: Path) -> None:
+        _write_env(
+            tmp_path / "envs", "plain", filename="pyproject.toml", content=_PYPROJECT_WITHOUT_PIXI
+        )
+        registry = PixiRegistry(project_root=tmp_path)
+        with pytest.raises(PixiEnvNotFoundError, match="plain"):
+            registry.resolve(env="plain")
+
+    def test_lock_hash_reads_lockfile_beside_pyproject(self, tmp_path: Path) -> None:
+        _write_env(
+            tmp_path / "envs", "ml_env", filename="pyproject.toml", content=_PYPROJECT_WITH_PIXI
+        )
+        (tmp_path / "envs" / "ml_env" / "pixi.lock").write_text("locked\n", encoding="utf-8")
+        registry = PixiRegistry(project_root=tmp_path)
+        digest = registry.lock_hash(env="ml_env")
+        assert isinstance(digest, str)
+        assert len(digest) == 64  # BLAKE3 hex digest
+
+    def test_list_envs_discovers_pyproject_and_pixi_toml(self, tmp_path: Path) -> None:
+        envs_root = tmp_path / "envs"
+        _write_env(
+            envs_root,
+            "alpha",
+            filename="pixi.toml",
+            content="[workspace]\nname = 'alpha'\nchannels = []\nplatforms = []\n",
+        )
+        _write_env(envs_root, "beta", filename="pyproject.toml", content=_PYPROJECT_WITH_PIXI)
+        _write_env(envs_root, "gamma", filename="pyproject.toml", content=_PYPROJECT_WITHOUT_PIXI)
+        assert _list_envs(envs_root) == ["alpha", "beta"]
+
+    def test_env_manifest_returns_none_for_empty_directory(self, tmp_path: Path) -> None:
+        env_dir = tmp_path / "envs" / "empty"
+        env_dir.mkdir(parents=True)
+        assert _env_manifest(env_dir) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #86. Pixi identifies a `pyproject.toml` as one of its manifests by the presence of a `[tool.pixi]` table (confirmed against the [Pixi docs](https://pixi.prefix.dev/latest/python/pyproject_toml/)), but `PixiRegistry` only looked for `pixi.toml`. This extends named-env resolution to also detect `envs/<name>/pyproject.toml`, validated via `tomllib` to confirm a `[tool.pixi]` table is present.

```
envs/
  my_ml_env/
    pyproject.toml   # contains [tool.pixi.workspace] (channels + platforms)
    pixi.lock        # generated by pixi
```

## Changes

- **`_is_pixi_pyproject()`** — validates a `pyproject.toml` carries a `[tool.pixi]` table; malformed/unreadable TOML is a non-match, not an error. The check mirrors exactly how Pixi itself recognises the file.
- **`_env_manifest()`** — shared discovery helper that prefers `pixi.toml` and falls back to a valid `pyproject.toml`.
- Rewired `_list_envs()` and `PixiRegistry.resolve()` through `_env_manifest()`.
- Updated CLI `list_project_envs()` to discover pyproject-based envs too, keeping `ginkgo env` consistent with resolution.

## Why downstream needs no changes

`prepare`, `exec_argv`, and `lock_hash` all operate on the resolved manifest path (`--manifest-path <path>`) and `pixi.lock` alongside it. Pixi accepts `--manifest-path pyproject.toml` natively, so lock-file hashing, provenance, and execution flow through unchanged. Explicit-path resolution already worked.

A `pyproject.toml` with a `[tool.pixi]` table but missing required workspace metadata (`channels`/`platforms`) passes Ginkgo's detection but fails when Pixi runs — surfacing as a `PixiEnvPrepareError` carrying Pixi's own message. Ginkgo locates the manifest; Pixi validates its contents.

## Tests

Added `TestPixiPyprojectManifest` (10 unit tests): `[tool.pixi]` detection incl. malformed/wrong-filename rejection, named-env resolution to a pyproject, `pixi.toml`-preferred-over-pyproject ordering, ignoring a `[tool.pixi]`-less pyproject, lock hashing beside a pyproject, and `_list_envs` discovery.

- `pytest tests/test_vw_pixi.py` → 30 passed; `test_cli.py -k env` → 4 passed
- `ty check` and `ruff` clean

Also updated `docs/architecture/execution-model.md`.