### PR TITLE
Test suite coherence & simplification audit (#89)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -58,6 +58,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/37/3922951a55a3d0f0340e884929087ce08e333cbb16a86002535c095960fc/gcsfs-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
@@ -66,6 +67,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -77,23 +79,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/46/2c/5c160dbdef7123f8cc97fd8ece7e0198627a426a2a49614845e9086feb8d/kubernetes-36.0.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -103,10 +113,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/c5/d53bddd2c0949833fcb4ea06f9d5dd1c40575a1a4214cd1021eff57ba301/google_auth-2.54.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl
@@ -115,7 +128,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/82/b9/e73d5d9f405cba7706c539aa8b311b49d4c2f3d698d9c12f815231169c71/ipykernel-7.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/13/c1c3d0f889115ad33e2122efd16c842f8588aab7e0d243f29125a0ee8ad5/marimo-0.23.4-py3-none-any.whl
@@ -128,14 +144,19 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/b3/4eeb9f59c4e7e07e1f08704b6508249eea5760878810014e636026300416/google_cloud_appengine_logging-1.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/e8/9c25ca0598ee7029f8febe5a67367c14751ce45d869d857dd5d9a089f602/google_cloud_batch-0.22.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -147,7 +168,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/99/27c70286bfa3503e43f845578ed5c2ab30c0cc68e525c168286f05f9a51c/google_cloud_audit_log-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
@@ -167,7 +190,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
@@ -180,6 +205,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/d5/91035dd77e0033dfb00d52b2bcad1e4f7408eb931981f86a1584301670a8/google_cloud_logging-3.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
@@ -225,6 +251,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/37/3922951a55a3d0f0340e884929087ce08e333cbb16a86002535c095960fc/gcsfs-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl
@@ -232,6 +259,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl
@@ -243,13 +272,20 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/46/2c/5c160dbdef7123f8cc97fd8ece7e0198627a426a2a49614845e9086feb8d/kubernetes-36.0.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
@@ -259,6 +295,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -267,10 +304,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/c5/d53bddd2c0949833fcb4ea06f9d5dd1c40575a1a4214cd1021eff57ba301/google_auth-2.54.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
@@ -280,7 +319,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/82/b9/e73d5d9f405cba7706c539aa8b311b49d4c2f3d698d9c12f815231169c71/ipykernel-7.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -297,14 +339,19 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/b3/4eeb9f59c4e7e07e1f08704b6508249eea5760878810014e636026300416/google_cloud_appengine_logging-1.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/e8/9c25ca0598ee7029f8febe5a67367c14751ce45d869d857dd5d9a089f602/google_cloud_batch-0.22.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
@@ -314,6 +361,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/99/27c70286bfa3503e43f845578ed5c2ab30c0cc68e525c168286f05f9a51c/google_cloud_audit_log-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
@@ -333,7 +382,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
@@ -348,6 +399,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/35/ddbc4bec5f0eca26e334afc3f37a39ce52018c28732c6b8b0f5cbe2e7c5e/oci-2.173.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/d5/91035dd77e0033dfb00d52b2bcad1e4f7408eb931981f86a1584301670a8/google_cloud_logging-3.16.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1200,6 +1252,29 @@ packages:
   version: 2.6.1
   sha256: f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/10/37/3922951a55a3d0f0340e884929087ce08e333cbb16a86002535c095960fc/gcsfs-2026.4.0-py3-none-any.whl
+  name: gcsfs
+  version: 2026.4.0
+  sha256: d9e838834d8cce6cb623c6a6a5fad66a4d122dc5c609d4b1c1977b55f759dcc5
+  requires_dist:
+  - aiohttp>=3.9.0,!=4.0.0a0,!=4.0.0a1
+  - decorator>4.1.2
+  - fsspec>=2026.4.0
+  - google-auth-oauthlib
+  - google-auth>=1.2
+  - google-cloud-storage-control
+  - google-cloud-storage>=3.9.0
+  - requests
+  - crcmod ; extra == 'crc'
+  - flake8 ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-asyncio ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest-subtests ; extra == 'dev'
+  - pytest-timeout ; extra == 'dev'
+  - fusepy ; extra == 'gcsfuse'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
   name: pytz
   version: 2026.1.post1
@@ -1358,6 +1433,56 @@ packages:
   - html5lib ; extra == 'html5lib'
   - lxml ; extra == 'lxml'
   requires_python: '>=3.7.0'
+- pypi: https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl
+  name: google-cloud-storage
+  version: 3.12.0
+  sha256: 3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c
+  requires_dist:
+  - google-auth>=2.26.1,<3.0.0
+  - google-api-core>=2.27.0,<3.0.0
+  - google-cloud-core>=2.4.2,<3.0.0
+  - google-resumable-media>=2.7.2,<3.0.0
+  - requests>=2.22.0,<3.0.0
+  - google-crc32c>=1.6.0,<2.0.0
+  - google-api-core[grpc]>=2.27.0,<3.0.0 ; extra == 'grpc'
+  - grpcio>=1.59.0,<2.0.0 ; python_full_version < '3.14' and extra == 'grpc'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  - grpcio-status>=1.59.0,<2.0.0 ; python_full_version < '3.14' and extra == 'grpc'
+  - grpcio-status>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  - proto-plus>=1.22.3,<2.0.0 ; python_full_version < '3.13' and extra == 'grpc'
+  - proto-plus>=1.25.0,<2.0.0 ; python_full_version >= '3.13' and extra == 'grpc'
+  - protobuf>=4.25.8,<8.0.0 ; extra == 'grpc'
+  - grpc-google-iam-v1>=0.14.0,<1.0.0 ; extra == 'grpc'
+  - protobuf>=3.20.2,<7.0.0 ; extra == 'protobuf'
+  - opentelemetry-api>=1.1.0,<2.0.0 ; extra == 'tracing'
+  - google-cloud-testutils ; extra == 'testing'
+  - numpy ; extra == 'testing'
+  - psutil ; extra == 'testing'
+  - py-cpuinfo ; extra == 'testing'
+  - pytest-benchmark ; extra == 'testing'
+  - pyyaml ; extra == 'testing'
+  - mock ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-asyncio ; extra == 'testing'
+  - pytest-rerunfailures ; extra == 'testing'
+  - pytest-xdist ; extra == 'testing'
+  - google-cloud-testutils ; extra == 'testing'
+  - google-cloud-iam ; extra == 'testing'
+  - google-cloud-pubsub ; extra == 'testing'
+  - google-cloud-kms ; extra == 'testing'
+  - brotli ; extra == 'testing'
+  - coverage ; extra == 'testing'
+  - pyopenssl ; extra == 'testing'
+  - opentelemetry-sdk ; extra == 'testing'
+  - flake8 ; extra == 'testing'
+  - black ; extra == 'testing'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl
+  name: google-crc32c
+  version: 1.8.0
+  sha256: e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
   name: certifi
   version: 2026.4.22
@@ -1512,10 +1637,45 @@ packages:
   version: 3.6.0
   sha256: 43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl
+  name: grpcio
+  version: 1.81.1
+  sha256: d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e
+  requires_dist:
+  - typing-extensions~=4.12
+  - grpcio-tools>=1.81.1 ; extra == 'protobuf'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
   name: distlib
   version: 0.4.0
   sha256: 9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16
+- pypi: https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl
+  name: google-cloud-storage-control
+  version: 1.12.0
+  sha256: 20f7f1252fa5635d47e12f746aa69d719e31eb9405cbbd14cdfba317db27d421
+  requires_dist:
+  - google-api-core[grpc]>=2.17.1,<3.0.0
+  - google-auth>=2.14.1,!=2.24.0,!=2.25.0,<3.0.0
+  - grpcio>=1.59.0,<2.0.0
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14'
+  - proto-plus>=1.22.3,<2.0.0
+  - proto-plus>=1.25.0,<2.0.0 ; python_full_version >= '3.13'
+  - protobuf>=4.25.8,<8.0.0
+  - grpc-google-iam-v1>=0.14.0,<1.0.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+  name: websocket-client
+  version: 1.9.0
+  sha256: af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef
+  requires_dist:
+  - pytest ; extra == 'test'
+  - websockets ; extra == 'test'
+  - python-socks ; extra == 'optional'
+  - wsaccel ; extra == 'optional'
+  - sphinx>=6.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=1.1.0 ; extra == 'docs'
+  - myst-parser>=2.0.0 ; extra == 'docs'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
   name: sphinxcontrib-devhelp
   version: 2.0.0
@@ -1537,6 +1697,15 @@ packages:
   version: 23.0.1
   sha256: 4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl
+  name: google-auth-oauthlib
+  version: 1.4.0
+  sha256: 251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070
+  requires_dist:
+  - google-auth>=2.15.0,!=2.43.0,!=2.44.0,!=2.45.0,<3.0.0
+  - requests-oauthlib>=0.7.0
+  - click>=6.0.0 ; extra == 'tool'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
   name: urllib3
   version: 2.6.3
@@ -1548,6 +1717,15 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl
+  name: requests-oauthlib
+  version: 2.0.0
+  sha256: 7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36
+  requires_dist:
+  - oauthlib>=3.0.0
+  - requests>=2.0.0
+  - oauthlib[signedtoken]>=3.0.0 ; extra == 'rsa'
+  requires_python: '>=3.4'
 - pypi: https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl
   name: sphinx-basic-ng
   version: 1.0.0b2
@@ -1586,11 +1764,40 @@ packages:
   version: 2.8.3
   sha256: ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/46/2c/5c160dbdef7123f8cc97fd8ece7e0198627a426a2a49614845e9086feb8d/kubernetes-36.0.2-py2.py3-none-any.whl
+  name: kubernetes
+  version: 36.0.2
+  sha256: faf9b5241b58de0c4a5069f2a0ffc8ac06fece7215156cd3d3ba081a78a858b6
+  requires_dist:
+  - certifi>=14.5.14
+  - six>=1.9.0
+  - python-dateutil>=2.5.3
+  - pyyaml>=6.0.3
+  - websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*
+  - requests
+  - requests-oauthlib
+  - urllib3>=1.24.2,!=2.6.0
+  - durationpy>=0.7
+  - certifi>=14.5.14
+  - six>=1.9.0
+  - python-dateutil>=2.5.3
+  - pyyaml>=6.0.3
+  - urllib3>=1.24.2,!=2.6.0
+  - aiohttp>=3.13.5,<4.0.0
+  - google-auth>=1.0.1 ; extra == 'google-auth'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
   version: 3.4.7
   sha256: bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
+  name: pyasn1-modules
+  version: 0.4.2
+  sha256: 29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a
+  requires_dist:
+  - pyasn1>=0.6.1,<0.7.0
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: cffi
   version: 2.0.0
@@ -1640,6 +1847,11 @@ packages:
   - pytest ; extra == 'dev'
   - setuptools ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+  name: google-crc32c
+  version: 1.8.0
+  sha256: b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
   name: tornado
   version: 6.5.5
@@ -1677,6 +1889,11 @@ packages:
   - sphinx>=5 ; extra == 'standalone'
   - pytest ; extra == 'test'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl
+  name: pyasn1
+  version: 0.6.3
+  sha256: a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl
   name: s3fs
   version: 2026.4.0
@@ -1799,6 +2016,43 @@ packages:
   - uri-template ; extra == 'format-nongpl'
   - webcolors>=24.6.0 ; extra == 'format-nongpl'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/70/c5/d53bddd2c0949833fcb4ea06f9d5dd1c40575a1a4214cd1021eff57ba301/google_auth-2.54.0-py3-none-any.whl
+  name: google-auth
+  version: 2.54.0
+  sha256: 784e9837f92244141250470d47c893df50cbab485ce491aca5e9deb558ad2b48
+  requires_dist:
+  - pyasn1-modules>=0.2.1
+  - cryptography>=38.0.3
+  - cryptography>=38.0.3 ; extra == 'cryptography'
+  - aiohttp>=3.8.0,<4.0.0 ; extra == 'aiohttp'
+  - requests>=2.20.0,<3.0.0 ; extra == 'aiohttp'
+  - pyopenssl ; extra == 'enterprise-cert'
+  - pyopenssl>=20.0.0 ; extra == 'pyopenssl'
+  - pyjwt>=2.0 ; extra == 'pyjwt'
+  - pyu2f>=0.1.5 ; extra == 'reauth'
+  - requests>=2.20.0,<3.0.0 ; extra == 'requests'
+  - grpcio ; extra == 'testing'
+  - flask ; extra == 'testing'
+  - freezegun ; extra == 'testing'
+  - pyjwt>=2.0 ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-localserver ; extra == 'testing'
+  - pyopenssl>=20.0.0 ; extra == 'testing'
+  - pyu2f>=0.1.5 ; extra == 'testing'
+  - responses ; extra == 'testing'
+  - urllib3 ; extra == 'testing'
+  - packaging ; extra == 'testing'
+  - aiohttp>=3.8.0,<4.0.0 ; extra == 'testing'
+  - requests>=2.20.0,<3.0.0 ; extra == 'testing'
+  - aioresponses ; extra == 'testing'
+  - pytest-asyncio ; extra == 'testing'
+  - pyopenssl<24.3.0 ; extra == 'testing'
+  - aiohttp<3.10.0 ; extra == 'testing'
+  - urllib3 ; extra == 'urllib3'
+  - packaging ; extra == 'urllib3'
+  - rsa>=3.1.4,<5 ; extra == 'rsa'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
   name: sphinx
   version: 9.1.0
@@ -1827,6 +2081,14 @@ packages:
   version: 4.9.6
   sha256: e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: grpcio
+  version: 1.81.1
+  sha256: 410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6
+  requires_dist:
+  - typing-extensions~=4.12
+  - grpcio-tools>=1.81.1 ; extra == 'protobuf'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
   name: babel
   version: 2.18.0
@@ -1847,6 +2109,14 @@ packages:
   version: 1.5.3
   sha256: 5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl
+  name: proto-plus
+  version: 1.28.0
+  sha256: a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8
+  requires_dist:
+  - protobuf>=4.25.8,<8.0.0
+  - google-api-core>=1.31.5 ; extra == 'testing'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
   name: alabaster
   version: 1.0.0
@@ -2016,11 +2286,51 @@ packages:
   requires_dist:
   - wcwidth
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl
+  name: google-cloud-core
+  version: 2.6.0
+  sha256: 6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e
+  requires_dist:
+  - google-api-core>=2.11.0,<3.0.0
+  - google-auth>=2.14.1,!=2.24.0,!=2.25.0,<3.0.0
+  - grpcio>=1.47.0,<2.0.0 ; python_full_version < '3.14' and extra == 'grpc'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  - grpcio-status>=1.47.0,<2.0.0 ; extra == 'grpc'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl
+  name: google-api-core
+  version: 2.31.0
+  sha256: ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab
+  requires_dist:
+  - googleapis-common-protos>=1.63.2,<2.0.0
+  - protobuf>=5.29.6,<8.0.0
+  - proto-plus>=1.24.0,<2.0.0
+  - proto-plus>=1.25.0,<2.0.0 ; python_full_version >= '3.13'
+  - google-auth>=2.14.1,<3.0.0
+  - requests>=2.33.0,<3.0.0
+  - google-auth[aiohttp]>=2.14.1,<3.0.0 ; extra == 'async-rest'
+  - aiohttp>=3.13.4 ; extra == 'async-rest'
+  - grpcio>=1.41.0,<2.0.0 ; extra == 'grpc'
+  - grpcio>=1.49.1,<2.0.0 ; python_full_version >= '3.11' and extra == 'grpc'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  - grpcio-status>=1.41.0,<2.0.0 ; extra == 'grpc'
+  - grpcio-status>=1.49.1,<2.0.0 ; python_full_version >= '3.11' and extra == 'grpc'
+  - grpcio-status>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
   name: nodeenv
   version: 1.10.0
   sha256: 5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*'
+- pypi: https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl
+  name: grpc-google-iam-v1
+  version: 0.14.4
+  sha256: 412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964
+  requires_dist:
+  - grpcio>=1.44.0,<2.0.0
+  - googleapis-common-protos[grpc]>=1.63.2,<2.0.0
+  - protobuf>=4.25.8,<8.0.0
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl
   name: pyarrow
   version: 23.0.1
@@ -2402,11 +2712,31 @@ packages:
   version: 1.8.0
   sha256: 4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl
+  name: opentelemetry-api
+  version: 1.42.1
+  sha256: 51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714
+  requires_dist:
+  - typing-extensions>=4.5.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl
   name: immutabledict
   version: 4.3.1
   sha256: c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf
   requires_python: '>=3.8,<4.0'
+- pypi: https://files.pythonhosted.org/packages/a5/b3/4eeb9f59c4e7e07e1f08704b6508249eea5760878810014e636026300416/google_cloud_appengine_logging-1.10.0-py3-none-any.whl
+  name: google-cloud-appengine-logging
+  version: 1.10.0
+  sha256: 193675caaf062c41688a3e2c744b73614db82408bc7fb060353b6878d7134492
+  requires_dist:
+  - google-api-core[grpc]>=2.17.1,<3.0.0
+  - google-auth>=2.14.1,!=2.24.0,!=2.25.0,<3.0.0
+  - grpcio>=1.59.0,<2.0.0
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14'
+  - proto-plus>=1.22.3,<2.0.0
+  - proto-plus>=1.25.0,<2.0.0 ; python_full_version >= '3.13'
+  - protobuf>=4.25.8,<8.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: frozenlist
   version: 1.8.0
@@ -2526,11 +2856,38 @@ packages:
   - notebook ; extra == 'test'
   - pytest ; extra == 'test'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl
+  name: durationpy
+  version: '0.10'
+  sha256: 3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+- pypi: https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl
+  name: google-resumable-media
+  version: 2.10.0
+  sha256: 88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c
+  requires_dist:
+  - google-crc32c>=1.0.0,<2.0.0
+  - requests>=2.18.0,<3.0.0 ; extra == 'requests'
+  - aiohttp>=3.6.2,<4.0.0 ; extra == 'aiohttp'
+  - google-auth>=1.22.0,<2.0.0 ; extra == 'aiohttp'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
   name: jupyterlab-pygments
   version: 0.3.0
   sha256: 841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/b1/e8/9c25ca0598ee7029f8febe5a67367c14751ce45d869d857dd5d9a089f602/google_cloud_batch-0.22.0-py3-none-any.whl
+  name: google-cloud-batch
+  version: 0.22.0
+  sha256: fe6665fb3eae6b214febe44b6a7f5d11da137b47ad9ffe7a770322f7f0605e04
+  requires_dist:
+  - google-api-core[grpc]>=2.17.1,<3.0.0
+  - google-auth>=2.14.1,!=2.24.0,!=2.25.0,<3.0.0
+  - grpcio>=1.59.0,<2.0.0
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14'
+  - proto-plus>=1.22.3,<2.0.0
+  - proto-plus>=1.25.0,<2.0.0 ; python_full_version >= '3.13'
+  - protobuf>=4.25.8,<8.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl
   name: botocore
   version: 1.42.91
@@ -2756,6 +3113,14 @@ packages:
   version: '16.0'
   sha256: fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/bc/99/27c70286bfa3503e43f845578ed5c2ab30c0cc68e525c168286f05f9a51c/google_cloud_audit_log-0.6.0-py3-none-any.whl
+  name: google-cloud-audit-log
+  version: 0.6.0
+  sha256: 8c5ecbc341ad3b3daf776981f6d7fd7ab5ff5a29c5dce3172c669b570e0f6717
+  requires_dist:
+  - protobuf>=4.25.8,<8.0.0
+  - googleapis-common-protos>=1.56.2,<2.0.0
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: aiohttp
   version: 3.13.5
@@ -2774,6 +3139,16 @@ packages:
   - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
   - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and extra == 'speedups'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl
+  name: oauthlib
+  version: 3.3.1
+  sha256: 88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+  requires_dist:
+  - cryptography>=3.0.0 ; extra == 'rsa'
+  - cryptography>=3.0.0 ; extra == 'signedtoken'
+  - pyjwt>=2.0.0,<3 ; extra == 'signedtoken'
+  - blinker>=1.4.0 ; extra == 'signals'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
   name: jedi
   version: 0.19.2
@@ -3136,6 +3511,15 @@ packages:
   version: 1.8.20
   sha256: 5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl
+  name: grpcio-status
+  version: 1.81.1
+  sha256: 08072fa9995f4a95c647fc6f4f85e2411573d00087bcabdf30f260114338f232
+  requires_dist:
+  - protobuf>=6.33.5,<8.0.0
+  - grpcio>=1.81.1
+  - googleapis-common-protos>=1.5.5
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
   name: tinycss2
   version: 1.4.0
@@ -3147,6 +3531,14 @@ packages:
   - pytest ; extra == 'test'
   - ruff ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl
+  name: googleapis-common-protos
+  version: 1.75.0
+  sha256: 961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed
+  requires_dist:
+  - protobuf>=4.25.8,<8.0.0
+  - grpcio>=1.44.0,<2.0.0 ; extra == 'grpc'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
   name: jupyter-core
   version: 5.9.1
@@ -3330,6 +3722,24 @@ packages:
   - pytest ; extra == 'testing'
   - pytest-cov ; extra == 'testing'
   - pytest-regressions ; extra == 'testing'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fb/d5/91035dd77e0033dfb00d52b2bcad1e4f7408eb931981f86a1584301670a8/google_cloud_logging-3.16.0-py3-none-any.whl
+  name: google-cloud-logging
+  version: 3.16.0
+  sha256: 9e5bfbdfe7b5315ece00e1703a2ea25fe42ca35e0b4750127b019f50d069b01b
+  requires_dist:
+  - google-api-core[grpc]>=2.17.1,<3.0.0
+  - google-auth>=2.14.1,!=2.24.0,!=2.25.0,<3.0.0
+  - google-cloud-appengine-logging>=0.1.3,<2.0.0
+  - google-cloud-audit-log>=0.3.1,<1.0.0
+  - google-cloud-core>=2.0.0,<3.0.0
+  - grpc-google-iam-v1>=0.12.4,<1.0.0
+  - opentelemetry-api>=1.16.0
+  - grpcio>=1.59.0,<2.0.0
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14'
+  - proto-plus>=1.22.3,<2.0.0
+  - proto-plus>=1.25.0,<2.0.0 ; python_full_version >= '3.13'
+  - protobuf>=4.25.8,<8.0.0
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: multidict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ channels = ["conda-forge"]
 platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.pypi-dependencies]
-ginkgo = { path = ".", editable = true, extras = ["notebooks"] }
+ginkgo = { path = ".", editable = true, extras = ["notebooks", "cloud"] }
 fsspec = ">=2024.10.0"
 jinja2 = ">=3.1"
 numpy = ">=2.0"

--- a/tests/_vw_support.py
+++ b/tests/_vw_support.py
@@ -1,0 +1,118 @@
+"""Shared helpers for the VW (validation-walkthrough) scenario tests.
+
+The VW tests prove ordering, concurrency, and resource-contention properties
+by having tasks record what they did to disk, then reading those records back.
+These helpers centralise that record-and-replay machinery so each VW file only
+contains its scenario, not a private copy of the plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def append_line(path: str, line: str) -> None:
+    """Append ``line`` (plus a newline) to the text file at ``path``."""
+    with Path(path).open("a", encoding="utf-8") as handle:
+        handle.write(f"{line}\n")
+
+
+def write_interval(
+    events_dir: str,
+    name: str,
+    *,
+    started_at: float,
+    ended_at: float,
+    **dimensions: float | bool,
+) -> None:
+    """Record one task's execution interval as a JSON file.
+
+    Parameters
+    ----------
+    events_dir : str
+        Directory to hold the per-task JSON records; created if absent.
+    name : str
+        Unique record name; also the file stem (``{name}.json``).
+    started_at, ended_at : float
+        Wall-clock start/end timestamps for the interval.
+    **dimensions : float | bool
+        Optional named resource dimensions (e.g. ``threads``, ``memory_gb``,
+        ``heavy``) to fold into the record for peak computation.
+    """
+    Path(events_dir).mkdir(parents=True, exist_ok=True)
+    payload = {"name": name, "start": started_at, "end": ended_at, **dimensions}
+    Path(events_dir, f"{name}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def load_intervals(events_dir: str, *, prefix: str | None = None) -> list[dict]:
+    """Load interval records from ``events_dir``.
+
+    Parameters
+    ----------
+    events_dir : str
+        Directory previously populated by :func:`write_interval`.
+    prefix : str | None
+        When given, only records whose name starts ``{prefix}-`` are returned.
+
+    Returns
+    -------
+    list[dict]
+        One payload dict per record, each with ``name``, ``start``, ``end``,
+        and any recorded dimensions. Sorted by name for determinism.
+    """
+    pattern = f"{prefix}-*.json" if prefix is not None else "*.json"
+    paths = sorted(Path(events_dir).glob(pattern))
+    return [json.loads(path.read_text(encoding="utf-8")) for path in paths]
+
+
+def compute_peaks(
+    intervals: Iterable[Mapping[str, Any]],
+    *,
+    dimensions: Sequence[str] = (),
+) -> dict[str, int]:
+    """Return the peak concurrent load over a set of intervals.
+
+    A sweep line counts how many intervals are simultaneously active. Intervals
+    that merely touch (one ends exactly as another starts) are not treated as
+    overlapping.
+
+    Parameters
+    ----------
+    intervals : iterable of mapping
+        Records with ``start``/``end`` and any dimensions named in *dimensions*.
+    dimensions : sequence of str
+        Extra per-interval quantities to sum across active intervals (bools are
+        counted as 1). For example ``("threads", "memory_gb")``.
+
+    Returns
+    -------
+    dict[str, int]
+        ``{"tasks": peak_concurrent_count, <dim>: peak_summed_value, ...}``.
+    """
+    keys = ("tasks", *dimensions)
+    points: list[tuple[float, int, dict[str, int]]] = []
+    for interval in intervals:
+        contribution = {"tasks": 1}
+        for dim in dimensions:
+            contribution[dim] = int(interval[dim])
+        points.append((float(interval["start"]), 1, contribution))
+        points.append((float(interval["end"]), -1, {k: -v for k, v in contribution.items()}))
+
+    # Sort by (time, sign) only; ends (-1) precede starts (+1) at equal times.
+    points.sort(key=lambda item: (item[0], item[1]))
+
+    active = dict.fromkeys(keys, 0)
+    peak = dict.fromkeys(keys, 0)
+    for _, _, contribution in points:
+        for key, delta in contribution.items():
+            active[key] += delta
+            peak[key] = max(peak[key], active[key])
+    return peak
+
+
+def peak_concurrency(intervals: Iterable[Mapping[str, Any]]) -> int:
+    """Return the peak number of simultaneously active intervals."""
+    return compute_peaks(intervals)["tasks"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
+from ginkgo.remote.backend import RemoteObjectMeta
 from ginkgo.runtime.events import (
     EventBus,
     GinkgoEvent,
@@ -15,6 +17,35 @@ from ginkgo.runtime.events import (
     TaskStaging,
     TaskStarted,
 )
+
+
+def make_download_backend(*, content: bytes = b"hello world", etag: str = "etag1") -> MagicMock:
+    """Return a mock ``RemoteStorageBackend`` whose download writes fixed bytes.
+
+    ``download`` writes ``content`` to the requested ``dest_path`` and ``head``
+    reports the matching size/etag — enough to drive the staging cache and the
+    evaluator's remote-input path without touching a real object store.
+
+    Parameters
+    ----------
+    content : bytes
+        Bytes written by ``download`` and reported as the object size.
+    etag : str
+        ETag returned by both ``download`` and ``head``.
+    """
+    backend = MagicMock()
+
+    def _download(*, bucket: str, key: str, dest_path: Path) -> RemoteObjectMeta:
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(content)
+        return RemoteObjectMeta(uri=f"s3://{bucket}/{key}", size=len(content), etag=etag)
+
+    def _head(*, bucket: str, key: str) -> RemoteObjectMeta:
+        return RemoteObjectMeta(uri=f"s3://{bucket}/{key}", size=len(content), etag=etag)
+
+    backend.download.side_effect = _download
+    backend.head.side_effect = _head
+    return backend
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_asset_store.py
+++ b/tests/test_asset_store.py
@@ -20,17 +20,24 @@ def _asset_ref(*, key: AssetKey, version_id: str) -> AssetRef:
     )
 
 
+def _make_version(*, name: str, suffix: str, run_id: str, producer: str):
+    key = AssetKey(namespace="file", name=name)
+    version = make_asset_version(
+        key=key,
+        kind="file",
+        artifact_id=f"artifact-{suffix}",
+        content_hash=f"hash-{suffix}",
+        run_id=run_id,
+        producer_task=producer,
+    )
+    return key, version
+
+
 class TestAssetStore:
-    def test_register_alias_and_lineage(self, tmp_path: Path) -> None:
+    def test_register_and_resolve_alias(self, tmp_path: Path) -> None:
         store = AssetStore(root=tmp_path / ".ginkgo" / "assets")
-        key = AssetKey(namespace="file", name="prepared_data")
-        version = make_asset_version(
-            key=key,
-            kind="file",
-            artifact_id="artifact-1",
-            content_hash="hash-1",
-            run_id="run-1",
-            producer_task="tests.writer",
+        key, version = _make_version(
+            name="prepared_data", suffix="1", run_id="run-1", producer="tests.writer"
         )
 
         store.register_version(version=version)
@@ -44,21 +51,22 @@ class TestAssetStore:
         assert latest.version_id == version.version_id
         assert store.list_asset_keys() == [key]
 
-        child_key = AssetKey(namespace="file", name="transformed_data")
-        child_version = make_asset_version(
-            key=child_key,
-            kind="file",
-            artifact_id="artifact-2",
-            content_hash="hash-2",
-            run_id="run-2",
-            producer_task="tests.transformer",
+    def test_record_lineage(self, tmp_path: Path) -> None:
+        store = AssetStore(root=tmp_path / ".ginkgo" / "assets")
+        parent_key, parent_version = _make_version(
+            name="prepared_data", suffix="1", run_id="run-1", producer="tests.writer"
         )
+        child_key, child_version = _make_version(
+            name="transformed_data", suffix="2", run_id="run-2", producer="tests.transformer"
+        )
+        store.register_version(version=parent_version)
         store.register_version(version=child_version)
-        child_ref = _asset_ref(key=child_key, version_id=child_version.version_id)
-        parent_ref = _asset_ref(key=key, version_id=version.version_id)
 
-        store.record_lineage(child=child_ref, parents=[parent_ref])
+        store.record_lineage(
+            child=_asset_ref(key=child_key, version_id=child_version.version_id),
+            parents=[_asset_ref(key=parent_key, version_id=parent_version.version_id)],
+        )
 
         lineage = store.lineage_for(key=child_key, version_id=child_version.version_id)
         assert lineage is not None
-        assert [parent.version_id for parent in lineage.parents] == [version.version_id]
+        assert [parent.version_id for parent in lineage.parents] == [parent_version.version_id]

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -390,13 +390,12 @@ class TestEvaluatorIntegration:
             ginkgo.evaluate(make_duplicate_names_task())
         assert "duplicate wrapped asset name" in str(excinfo.value)
 
-        # No asset version should have been registered.
+        # The error is raised before registration, so no version for the
+        # offending name may exist. Assert this unconditionally — an empty
+        # store is the expected outcome, not a reason to skip the check.
         asset_dir = tmp_path / ".ginkgo" / "assets"
-        if asset_dir.is_dir():
-            store = AssetStore(root=asset_dir)
-            keys = store.list_asset_keys()
-            for key in keys:
-                assert key.namespace != "table" or "dup" not in key.name
+        keys = AssetStore(root=asset_dir).list_asset_keys() if asset_dir.is_dir() else []
+        assert not any(key.namespace == "table" and key.name == "dup" for key in keys)
 
     def test_cache_hit_reuses_artifact_id(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_cache_integrity.py
+++ b/tests/test_cache_integrity.py
@@ -1,11 +1,13 @@
 """Integration tests for cache integrity and working-tree materialization."""
 
+import stat
 import textwrap
 from pathlib import Path
 
 import pytest
 
 from ginkgo import evaluate, file, folder, shell, task
+from ginkgo.cli.commands.cache import _safe_rmtree
 from ginkgo.core.task import TaskDef
 from tests.conftest import EventCollector
 
@@ -226,22 +228,24 @@ class TestWritableFolderOutputs:
 
 
 class TestCachePruneReadOnly:
-    def test_prune_handles_read_only_artifacts(self, tmp_path):
-        """Pruning cache entries with read-only artifacts should not raise."""
+    def test_prune_handles_read_only_artifacts(self, tmp_path: Path) -> None:
+        """The prune helper must remove a read-only entry tree without raising."""
         output = tmp_path / "prunable.txt"
         evaluate(write_file_task(output_path=str(output)))
 
         cache_root = Path(".ginkgo") / "cache"
-        assert cache_root.exists()
+        entries = [entry for entry in cache_root.iterdir() if entry.is_dir()]
+        assert entries, "expected at least one cache entry to prune"
 
-        # Prune everything by removing all entries directly.
-        import shutil
-        from ginkgo.runtime.artifacts.artifact_store import make_writable_recursive
+        # Strip the write bit from every directory and file so a naive
+        # shutil.rmtree would fail with PermissionError; the production helper
+        # must restore permissions and complete the removal.
+        for entry in entries:
+            for child in entry.rglob("*"):
+                child.chmod(stat.S_IRUSR | stat.S_IXUSR if child.is_dir() else stat.S_IRUSR)
+            entry.chmod(stat.S_IRUSR | stat.S_IXUSR)
 
-        for entry in cache_root.iterdir():
-            if entry.is_dir():
-                try:
-                    shutil.rmtree(entry)
-                except PermissionError:
-                    make_writable_recursive(entry)
-                    shutil.rmtree(entry)
+        for entry in entries:
+            _safe_rmtree(entry)
+
+        assert not any(child.is_dir() for child in cache_root.iterdir())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 from rich.console import Console
 
@@ -66,6 +67,46 @@ def _seed_asset(*, cwd: Path, name: str, text: str, run_id: str, alias: str | No
     return version.version_id
 
 
+def _seed_cache_entry(
+    *,
+    cache_root: Path,
+    name: str,
+    age_days: int,
+    function: str = "demo.x",
+    payload: str = "{}",
+) -> Path:
+    """Create a cache-entry directory aged ``age_days`` days, for prune tests."""
+    entry = cache_root / name
+    entry.mkdir(parents=True)
+    ts = (datetime.now(timezone.utc) - timedelta(days=age_days)).isoformat()
+    (entry / "meta.json").write_text(
+        json.dumps({"function": function, "timestamp": ts}), encoding="utf-8"
+    )
+    (entry / "output.json").write_text(payload, encoding="utf-8")
+    return entry
+
+
+def _run_trivial_workflow_cache_key(cwd: Path) -> str:
+    """Run a one-task workflow and return that task's cache key."""
+    Path(cwd / "workflow.py").write_text(
+        "from pathlib import Path\n"
+        "from ginkgo import flow, task\n\n"
+        "@task()\n"
+        "def write_message(output_path: str) -> str:\n"
+        "    Path(output_path).write_text('hi', encoding='utf-8')\n"
+        "    return output_path\n\n"
+        "@flow\n"
+        "def main():\n"
+        "    return write_message(output_path='result.txt')\n",
+        encoding="utf-8",
+    )
+    result = _run_cli("run", "workflow.py", cwd=cwd)
+    assert result.returncode == 0, result.stderr
+    run_dir = _extract_run_dir(result.stdout)
+    manifest = yaml.safe_load((run_dir / "manifest.yaml").read_text(encoding="utf-8"))
+    return next(iter(manifest["tasks"].values()))["cache_key"]
+
+
 def test_version_flag_reports_pyproject_version() -> None:
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     expected = pyproject["project"]["version"]
@@ -116,16 +157,11 @@ def main():
             r"🌿 ginkgo run workflow\.py \([0-9]{8}_[0-9]{6}_[0-9]{6}_[0-9a-f]{8}\)",
             first.stdout,
         )
-        assert "📦 Loading workflow...  done" in first.stdout
-        assert "🌱 Building expression tree...  1 tasks" in first.stdout
+        # Load-bearing content only — decorative spinner/clock lines are not pinned.
         assert re.search(r"Running locally on \d+ Cores", first.stdout)
         assert "write_message" in first.stdout
-        assert "Environment" in first.stdout
-        assert "local" in first.stdout
-        assert "Time" in first.stdout
-        assert "✓ succeeded" in first.stdout
+        assert "succeeded" in first.stdout
         assert "1/1 complete" in first.stdout
-        assert "⏱ Completed in " in first.stdout
         assert "Run Summary" not in first.stdout
         assert '{"status":' not in first.stdout
 
@@ -160,12 +196,14 @@ def main():
         )
         second_task = next(iter(second_manifest["tasks"].values()))
 
-        assert "↺ cached" in second.stdout
+        assert "cached" in second.stdout
         assert "1/1 complete" in second.stdout
         assert second_task["status"] == "cached"
         assert second_task["cached"] is True
 
-        cache_key = second_task["cache_key"]
+    def test_cache_ls_lists_entry(self) -> None:
+        cache_key = _run_trivial_workflow_cache_key(Path.cwd())
+
         listed = _run_cli("cache", "ls", cwd=Path.cwd())
         assert listed.returncode == 0
         assert "Cache Key" in listed.stdout
@@ -174,10 +212,12 @@ def main():
         assert "Age" in listed.stdout
         assert cache_key in listed.stdout.replace("\n", "")
 
+    def test_cache_clear_removes_entry(self) -> None:
+        cache_key = _run_trivial_workflow_cache_key(Path.cwd())
+
         cleared = _run_cli("cache", "clear", cache_key, cwd=Path.cwd())
         assert cleared.returncode == 0
-        assert "🌿 ginkgo cache clear" in cleared.stdout
-        assert f"✓ Removed cache entry {cache_key}" in cleared.stdout
+        assert f"Removed cache entry {cache_key}" in cleared.stdout
         assert not (Path(".ginkgo") / "cache" / cache_key).exists()
 
     def test_run_notebook_reports_managed_ipykernel_install(self) -> None:
@@ -247,57 +287,34 @@ def main():
         assert task["attempt"] == 2
         assert task["attempts"] == 2
 
-    def test_cache_prune_dry_run_reports_old_entries_without_deleting(self) -> None:
+    @pytest.mark.parametrize(
+        ("dry_run", "old_survives"),
+        [(True, True), (False, False)],
+        ids=["dry-run-keeps-all", "real-removes-old"],
+    )
+    def test_cache_prune_older_than(self, dry_run: bool, old_survives: bool) -> None:
         cache_root = Path(".ginkgo") / "cache"
-        old_entry = cache_root / "old123"
-        fresh_entry = cache_root / "fresh456"
-        old_entry.mkdir(parents=True)
-        fresh_entry.mkdir(parents=True)
-        now = datetime.now(timezone.utc)
-        old_ts = (now - timedelta(days=100)).isoformat()
-        fresh_ts = (now - timedelta(days=5)).isoformat()
-        (old_entry / "meta.json").write_text(
-            f'{{"function":"demo.old","timestamp":"{old_ts}"}}',
-            encoding="utf-8",
+        old_entry = _seed_cache_entry(
+            cache_root=cache_root, name="old123", age_days=100, function="demo.old"
         )
-        (fresh_entry / "meta.json").write_text(
-            f'{{"function":"demo.fresh","timestamp":"{fresh_ts}"}}',
-            encoding="utf-8",
+        fresh_entry = _seed_cache_entry(
+            cache_root=cache_root, name="fresh456", age_days=5, function="demo.fresh"
         )
-        (old_entry / "output.json").write_text("{}", encoding="utf-8")
-        (fresh_entry / "output.json").write_text("{}", encoding="utf-8")
 
-        result = _run_cli("cache", "prune", "--older-than", "30d", "--dry-run", cwd=Path.cwd())
+        args = ["cache", "prune", "--older-than", "30d"]
+        if dry_run:
+            args.append("--dry-run")
+        result = _run_cli(*args, cwd=Path.cwd())
+
         assert result.returncode == 0, result.stderr
         assert "🌿 ginkgo cache prune" in result.stdout
-        assert "would be removed" in result.stdout
-        assert "old123" in result.stdout
-        assert old_entry.exists()
-        assert fresh_entry.exists()
-
-    def test_cache_prune_removes_only_entries_older_than_cutoff(self) -> None:
-        cache_root = Path(".ginkgo") / "cache"
-        old_entry = cache_root / "old123"
-        fresh_entry = cache_root / "fresh456"
-        old_entry.mkdir(parents=True)
-        fresh_entry.mkdir(parents=True)
-        now = datetime.now(timezone.utc)
-        old_ts = (now - timedelta(days=100)).isoformat()
-        fresh_ts = (now - timedelta(days=5)).isoformat()
-        (old_entry / "meta.json").write_text(
-            f'{{"function":"demo.old","timestamp":"{old_ts}"}}',
-            encoding="utf-8",
-        )
-        (fresh_entry / "meta.json").write_text(
-            f'{{"function":"demo.fresh","timestamp":"{fresh_ts}"}}',
-            encoding="utf-8",
-        )
-
-        result = _run_cli("cache", "prune", "--older-than", "30d", cwd=Path.cwd())
-        assert result.returncode == 0, result.stderr
-        assert "Removed" in result.stdout
-        assert not old_entry.exists()
-        assert fresh_entry.exists()
+        assert fresh_entry.exists()  # fresh entry always survives
+        assert old_entry.exists() is old_survives
+        if dry_run:
+            assert "would be removed" in result.stdout
+            assert "old123" in result.stdout
+        else:
+            assert "Removed" in result.stdout
 
     def test_cache_prune_rejects_invalid_duration(self) -> None:
         result = _run_cli("cache", "prune", "--older-than", "bad", cwd=Path.cwd())
@@ -312,18 +329,10 @@ def main():
 
     def test_cache_prune_by_max_entries_removes_oldest(self) -> None:
         cache_root = Path(".ginkgo") / "cache"
-        now = datetime.now(timezone.utc)
-        entries = []
-        for index, age_days in enumerate([100, 60, 30, 5]):
-            entry = cache_root / f"entry{index}"
-            entry.mkdir(parents=True)
-            ts = (now - timedelta(days=age_days)).isoformat()
-            (entry / "meta.json").write_text(
-                f'{{"function":"demo.x","timestamp":"{ts}"}}',
-                encoding="utf-8",
-            )
-            (entry / "output.json").write_text("{}", encoding="utf-8")
-            entries.append(entry)
+        entries = [
+            _seed_cache_entry(cache_root=cache_root, name=f"entry{index}", age_days=age_days)
+            for index, age_days in enumerate([100, 60, 30, 5])
+        ]
 
         result = _run_cli("cache", "prune", "--max-entries", "2", cwd=Path.cwd())
         assert result.returncode == 0, result.stderr
@@ -334,21 +343,15 @@ def main():
 
     def test_cache_prune_by_max_size_removes_oldest_until_under_budget(self) -> None:
         cache_root = Path(".ginkgo") / "cache"
-        now = datetime.now(timezone.utc)
-        entries = []
-        payload = "x" * 1024
-        for index, age_days in enumerate([100, 60, 5]):
-            entry = cache_root / f"sz{index}"
-            entry.mkdir(parents=True)
-            ts = (now - timedelta(days=age_days)).isoformat()
-            (entry / "meta.json").write_text(
-                f'{{"function":"demo.x","timestamp":"{ts}"}}',
-                encoding="utf-8",
+        payload = "x" * 1024  # each entry holds ~1KB
+        entries = [
+            _seed_cache_entry(
+                cache_root=cache_root, name=f"sz{index}", age_days=age_days, payload=payload
             )
-            (entry / "output.json").write_text(payload, encoding="utf-8")
-            entries.append(entry)
+            for index, age_days in enumerate([100, 60, 5])
+        ]
 
-        # Each entry holds ~1KB; cap total at 3KB so only the oldest must drop.
+        # Cap total at 3KB so only the oldest must drop.
         result = _run_cli("cache", "prune", "--max-size", "3KB", cwd=Path.cwd())
         assert result.returncode == 0, result.stderr
         assert not entries[0].exists()

--- a/tests/test_code_bundle.py
+++ b/tests/test_code_bundle.py
@@ -41,29 +41,34 @@ def _make_package(tmp_path: Path) -> Path:
 class TestShouldExclude:
     """Tests for the _should_exclude filter."""
 
-    def test_excludes_pycache(self) -> None:
-        info = tarfile.TarInfo(name="my_workflow/__pycache__/foo.pyc")
-        assert _should_exclude(info, excludes=_DEFAULT_EXCLUDES)
+    @pytest.mark.parametrize(
+        ("name", "excluded"),
+        [
+            ("my_workflow/__pycache__/foo.pyc", True),
+            ("my_workflow/tasks.pyc", True),
+            ("my_workflow/.git/config", True),
+            ("my_workflow/foo.egg-info/PKG-INFO", True),
+            ("my_workflow/tasks.py", False),
+            ("my_workflow/sub/helpers.py", False),
+        ],
+    )
+    def test_default_excludes(self, name: str, excluded: bool) -> None:
+        info = tarfile.TarInfo(name=name)
+        assert _should_exclude(info, excludes=_DEFAULT_EXCLUDES) is excluded
 
-    def test_excludes_pyc_extension(self) -> None:
-        info = tarfile.TarInfo(name="my_workflow/tasks.pyc")
-        assert _should_exclude(info, excludes=_DEFAULT_EXCLUDES)
+    def test_gitignore_spec_excludes_matched_files(self) -> None:
+        class _Spec:
+            def __init__(self, ignored: set[str]) -> None:
+                self._ignored = ignored
 
-    def test_excludes_git(self) -> None:
-        info = tarfile.TarInfo(name="my_workflow/.git/config")
-        assert _should_exclude(info, excludes=_DEFAULT_EXCLUDES)
+            def match_file(self, path: str) -> bool:
+                return path in self._ignored
 
-    def test_includes_normal_py(self) -> None:
-        info = tarfile.TarInfo(name="my_workflow/tasks.py")
-        assert not _should_exclude(info, excludes=_DEFAULT_EXCLUDES)
-
-    def test_includes_subpackage(self) -> None:
-        info = tarfile.TarInfo(name="my_workflow/sub/helpers.py")
-        assert not _should_exclude(info, excludes=_DEFAULT_EXCLUDES)
-
-    def test_excludes_egg_info(self) -> None:
-        info = tarfile.TarInfo(name="my_workflow/foo.egg-info/PKG-INFO")
-        assert _should_exclude(info, excludes=_DEFAULT_EXCLUDES)
+        spec = _Spec({"my_workflow/secret.txt"})
+        ignored = tarfile.TarInfo(name="my_workflow/secret.txt")
+        kept = tarfile.TarInfo(name="my_workflow/tasks.py")
+        assert _should_exclude(ignored, excludes=_DEFAULT_EXCLUDES, gitignore_spec=spec)
+        assert not _should_exclude(kept, excludes=_DEFAULT_EXCLUDES, gitignore_spec=spec)
 
 
 class TestCreateCodeBundle:
@@ -106,15 +111,6 @@ class TestCreateCodeBundle:
             assert pycache_entries == []
         finally:
             tarball_path.unlink()
-
-    def test_deterministic_digest(self, tmp_path: Path) -> None:
-        pkg = _make_package(tmp_path)
-        _, digest1 = create_code_bundle(package_path=pkg)
-        _, digest2 = create_code_bundle(package_path=pkg)
-
-        # Digests may differ due to mtime in tar — but both should be valid.
-        assert len(digest1) == 64
-        assert len(digest2) == 64
 
     def test_missing_package_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="Package directory not found"):

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -267,10 +267,8 @@ class TestContainerKindRestriction:
         with pytest.raises(TypeError, match="only support driver tasks"):
             evaluate(python_in_container(x=1))
 
-    def test_shell_task_with_container_env_passes_validation(self, tmp_path: Path):
+    def test_shell_task_with_container_env_passes_validation(self, tmp_path: Path) -> None:
         from ginkgo.runtime.evaluator import ConcurrentEvaluator
-
-        from ginkgo import shell, task
 
         @task(kind="shell", env="docker://myimg:latest")
         def shell_in_container(output_path: str) -> str:
@@ -278,22 +276,15 @@ class TestContainerKindRestriction:
 
         output = str(tmp_path / "out.txt")
 
-        # Validation should pass — the container env is valid for shell tasks.
-        # We only need to check that _validate_declared_envs doesn't raise
-        # TypeError.  The backend.validate_envs call will fail because Docker
-        # isn't available, but that's a different error.
         backend = ContainerBackend(project_root=tmp_path)
         evaluator = ConcurrentEvaluator(backend=backend)
         evaluator._root_template = shell_in_container(output_path=output)
         evaluator._root_dependency_ids = evaluator._register_value(evaluator._root_template)
 
-        # This should not raise TypeError (container kind restriction).
-        # It may raise ContainerRuntimeNotFoundError from validate_envs
-        # if docker is not installed — that's expected and fine.
-        try:
+        # A shell task with a container env is valid: it must pass the kind
+        # restriction (no TypeError) and env validation once a runtime is found.
+        with patch("ginkgo.envs.container.shutil.which", return_value="/usr/bin/docker"):
             evaluator._validator.validate_declared_envs(nodes=evaluator._nodes.values())
-        except ContainerRuntimeNotFoundError:
-            pass  # Expected when docker is not on PATH.
 
 
 # ------------------------------------------------------------------
@@ -469,28 +460,27 @@ class TestContainerShellE2E:
         assert task_entry["backend"] == "container"
         assert task_entry["container_image_digest"] == "sha256:deadbeef1234"
 
-    def test_container_cache_uses_image_digest(self, tmp_path: Path):
-        """Cache key incorporates the container image digest."""
+    def test_container_cache_uses_image_digest(self, tmp_path: Path) -> None:
+        """The cache key changes when the container image digest changes."""
         from ginkgo.runtime.caching.cache import CacheStore
 
-        container_backend = ContainerBackend(
-            project_root=tmp_path,
-            pull_policy="never",
+        @task(kind="shell", env="docker://myimg:latest")
+        def shell_task(output_path: str) -> str:
+            return shell(cmd=f"echo ok > {output_path}", output=output_path)
+
+        store = CacheStore(
+            backend=CompositeBackend(
+                local=LocalBackend(pixi_registry=PixiRegistry(project_root=tmp_path)),
+                container=ContainerBackend(project_root=tmp_path, pull_policy="never"),
+            )
         )
+        resolved_args = {"output_path": str(tmp_path / "out.txt")}
 
-        with patch("ginkgo.envs.container.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=0, stdout="sha256:abc123\n", stderr=""
-            )
+        def key_for(digest: str) -> str:
+            with patch.object(ContainerBackend, "env_identity", return_value=digest):
+                key, _ = store.build_cache_key(task_def=shell_task, resolved_args=resolved_args)
+            return key
 
-            store = CacheStore(
-                backend=CompositeBackend(
-                    local=LocalBackend(
-                        pixi_registry=PixiRegistry(project_root=tmp_path),
-                    ),
-                    container=container_backend,
-                )
-            )
-
-            digest = store.backend.env_identity(env="docker://myimg:latest")
-            assert digest == "sha256:abc123"
+        # A changed image digest must invalidate the key; an unchanged one must not.
+        assert key_for("sha256:abc123") != key_for("sha256:def456")
+        assert key_for("sha256:abc123") == key_for("sha256:abc123")

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -38,11 +38,67 @@ from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.runtime.events import EventBus, TaskNotice
 from ginkgo.runtime.caching.provenance import RunProvenanceRecorder, load_manifest, make_run_id
 from ginkgo.runtime.environment.secrets import build_secret_resolver
+from tests._vw_support import append_line
 
 
-def _append_line(path: str, line: str) -> None:
-    with Path(path).open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+def _notebook_subprocess_stub(
+    *,
+    tmp_path: Path,
+    run_dir: Path,
+    calls: list[str] | None = None,
+    declared_output: Path | None = None,
+):
+    """Build a fake ``_run_subprocess`` for a single-task ipynb notebook run.
+
+    Handles the four commands a notebook task issues — the ipykernel probe,
+    kernel install, papermill execution, and nbconvert render — materialising
+    the expected ``task_0000`` outputs under ``run_dir / 'notebooks'``.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Test temp dir; the managed Jupyter kernel is installed beneath it.
+    run_dir : Path
+        Provenance run directory; ``task_0000.ipynb`` / ``.html`` land here.
+    calls : list[str] | None
+        When given, every issued command line is appended to it.
+    declared_output : Path | None
+        When given, the papermill branch also writes this declared output file.
+    """
+
+    def fake_run_subprocess(
+        *,
+        argv: str | list[str],
+        use_shell: bool,
+        on_stdout: Any = None,
+        on_stderr: Any = None,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        command = " ".join(argv) if isinstance(argv, list) else str(argv)
+        if calls is not None:
+            calls.append(command)
+        if "import ipykernel" in command:
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        if "ipykernel install" in command:
+            kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
+            kernel_name = command.split("--name", 1)[1].strip().split()[0]
+            kernel_dir = kernel_root / kernel_name
+            kernel_dir.mkdir(parents=True, exist_ok=True)
+            (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        if "papermill" in command:
+            (run_dir / "notebooks" / "task_0000.ipynb").write_text("executed", encoding="utf-8")
+            if declared_output is not None:
+                declared_output.write_text("declared output", encoding="utf-8")
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        if "nbconvert" in command:
+            (run_dir / "notebooks" / "task_0000.html").write_text(
+                "<html>report</html>", encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        raise AssertionError(command)
+
+    return fake_run_subprocess
 
 
 @task("notebook")
@@ -82,7 +138,7 @@ def add_one_task(x: int) -> int:
 
 @task()
 def logged_work_task(x: int, log_path: str) -> int:
-    _append_line(log_path, f"work:{x}")
+    append_line(log_path, f"work:{x}")
     return x + 1
 
 
@@ -93,7 +149,7 @@ def sum_keyword_pair_task(*, left: int, right: int) -> int:
 
 @task(retries=2)
 def flaky_retry_task(marker_path: str, log_path: str) -> str:
-    _append_line(log_path, "attempt")
+    append_line(log_path, "attempt")
     marker = Path(marker_path)
     failures = int(marker.read_text(encoding="utf-8")) if marker.exists() else 0
     if failures < 1:
@@ -104,19 +160,19 @@ def flaky_retry_task(marker_path: str, log_path: str) -> str:
 
 @task(retries=2)
 def always_fail_retry_task(log_path: str) -> str:
-    _append_line(log_path, "attempt")
+    append_line(log_path, "attempt")
     raise RuntimeError("still broken")
 
 
 @task()
 def always_fail_once_task(log_path: str) -> str:
-    _append_line(log_path, "attempt")
+    append_line(log_path, "attempt")
     raise RuntimeError("no retry configured")
 
 
 @task(retries=2, retry_on=IOError)
 def retry_only_ioerror_task(log_path: str, kind: str) -> str:
-    _append_line(log_path, "attempt")
+    append_line(log_path, "attempt")
     if kind == "ioerror":
         raise IOError("transient io")
     raise ValueError("unexpected value")
@@ -126,7 +182,7 @@ def retry_only_ioerror_task(log_path: str, kind: str) -> str:
 def flaky_with_backoff_task(marker_path: str, log_path: str) -> str:
     import time as _time
 
-    _append_line(log_path, f"attempt:{_time.monotonic():.6f}")
+    append_line(log_path, f"attempt:{_time.monotonic():.6f}")
     marker = Path(marker_path)
     failures = int(marker.read_text(encoding="utf-8")) if marker.exists() else 0
     if failures < 2:
@@ -297,7 +353,7 @@ def sum_array_task(values: object) -> int:
 
 @task()
 def dataframe_task(log_path: str, start: int) -> object:
-    _append_line(log_path, f"df:{start}")
+    append_line(log_path, f"df:{start}")
     return pd.DataFrame({"sample": [start, start + 1], "value": [start * 2, start * 2 + 1]})
 
 
@@ -463,41 +519,9 @@ class TestEvaluate:
         )
 
         calls: list[str] = []
-
-        def fake_run_subprocess(
-            *,
-            argv: str | list[str],
-            use_shell: bool,
-            on_stdout: Any = None,
-            on_stderr: Any = None,
-            **kwargs: Any,
-        ) -> subprocess.CompletedProcess[str]:
-            command = " ".join(argv) if isinstance(argv, list) else str(argv)
-            calls.append(command)
-            if "import ipykernel" in command:
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "ipykernel install" in command:
-                kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
-                kernel_name = command.split("--name", 1)[1].strip().split()[0]
-                kernel_dir = kernel_root / kernel_name
-                kernel_dir.mkdir(parents=True, exist_ok=True)
-                (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
-                return subprocess.CompletedProcess(
-                    args=argv, returncode=0, stdout="install ok\n", stderr=""
-                )
-            if "papermill" in command:
-                output_path = recorder.run_dir / "notebooks" / "task_0000.ipynb"
-                output_path.write_text("executed", encoding="utf-8")
-                return subprocess.CompletedProcess(
-                    args=argv, returncode=0, stdout="papermill ok\n", stderr=""
-                )
-            if "nbconvert" in command:
-                html_path = recorder.run_dir / "notebooks" / "task_0000.html"
-                html_path.write_text("<html>report</html>", encoding="utf-8")
-                return subprocess.CompletedProcess(
-                    args=argv, returncode=0, stdout="render ok\n", stderr=""
-                )
-            raise AssertionError(command)
+        fake_run_subprocess = _notebook_subprocess_stub(
+            tmp_path=tmp_path, run_dir=recorder.run_dir, calls=calls
+        )
 
         evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
@@ -547,35 +571,9 @@ class TestEvaluate:
             cores=1,
         )
 
-        def fake_run_subprocess(
-            *,
-            argv: str | list[str],
-            use_shell: bool,
-            on_stdout: Any = None,
-            on_stderr: Any = None,
-            **kwargs: Any,
-        ) -> subprocess.CompletedProcess[str]:
-            command = " ".join(argv) if isinstance(argv, list) else str(argv)
-            if "import ipykernel" in command:
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "ipykernel install" in command:
-                kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
-                kernel_name = command.split("--name", 1)[1].strip().split()[0]
-                kernel_dir = kernel_root / kernel_name
-                kernel_dir.mkdir(parents=True, exist_ok=True)
-                (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "papermill" in command:
-                executed = first_recorder.run_dir / "notebooks" / "task_0000.ipynb"
-                executed.write_text("executed", encoding="utf-8")
-                # Honour the declared output by creating it during execution.
-                output_path.write_text("declared output", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "nbconvert" in command:
-                html = first_recorder.run_dir / "notebooks" / "task_0000.html"
-                html.write_text("<html>report</html>", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            raise AssertionError(command)
+        fake_run_subprocess = _notebook_subprocess_stub(
+            tmp_path=tmp_path, run_dir=first_recorder.run_dir, declared_output=output_path
+        )
 
         first_evaluator = ConcurrentEvaluator(provenance=first_recorder, jobs=1, cores=1)
         monkeypatch.setattr(first_evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
@@ -646,35 +644,9 @@ class TestEvaluate:
         )
 
         calls: list[str] = []
-
-        def fake_run_subprocess(
-            *,
-            argv: str | list[str],
-            use_shell: bool,
-            on_stdout: Any = None,
-            on_stderr: Any = None,
-            **kwargs: Any,
-        ) -> subprocess.CompletedProcess[str]:
-            command = " ".join(argv) if isinstance(argv, list) else str(argv)
-            calls.append(command)
-            if "import ipykernel" in command:
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "ipykernel install" in command:
-                kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
-                kernel_name = command.split("--name", 1)[1].strip().split()[0]
-                kernel_dir = kernel_root / kernel_name
-                kernel_dir.mkdir(parents=True, exist_ok=True)
-                (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "papermill" in command:
-                output_path = recorder.run_dir / "notebooks" / "task_0000.ipynb"
-                output_path.write_text("executed", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "nbconvert" in command:
-                html_path = recorder.run_dir / "notebooks" / "task_0000.html"
-                html_path.write_text("<html>report</html>", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            raise AssertionError(command)
+        fake_run_subprocess = _notebook_subprocess_stub(
+            tmp_path=tmp_path, run_dir=recorder.run_dir, calls=calls
+        )
 
         evaluator = ConcurrentEvaluator(
             provenance=recorder,
@@ -712,33 +684,9 @@ class TestEvaluate:
         bus = EventBus()
         bus.subscribe(events.append)
 
-        def fake_run_subprocess(
-            *,
-            argv: str | list[str],
-            use_shell: bool,
-            on_stdout: Any = None,
-            on_stderr: Any = None,
-            **kwargs: Any,
-        ) -> subprocess.CompletedProcess[str]:
-            command = " ".join(argv) if isinstance(argv, list) else str(argv)
-            if "import ipykernel" in command:
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "ipykernel install" in command:
-                kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
-                kernel_name = command.split("--name", 1)[1].strip().split()[0]
-                kernel_dir = kernel_root / kernel_name
-                kernel_dir.mkdir(parents=True, exist_ok=True)
-                (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "papermill" in command:
-                output_path = recorder.run_dir / "notebooks" / "task_0000.ipynb"
-                output_path.write_text("executed", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            if "nbconvert" in command:
-                html_path = recorder.run_dir / "notebooks" / "task_0000.html"
-                html_path.write_text("<html>report</html>", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
-            raise AssertionError(command)
+        fake_run_subprocess = _notebook_subprocess_stub(
+            tmp_path=tmp_path, run_dir=recorder.run_dir
+        )
 
         evaluator = ConcurrentEvaluator(provenance=recorder, jobs=1, cores=1, event_bus=bus)
         monkeypatch.setattr(evaluator._shell_runner, "_run_subprocess", fake_run_subprocess)
@@ -937,77 +885,39 @@ class TestEvaluate:
         assert Path(result).is_file()
 
     def test_notebook_cache_invalidates_when_source_changes(self, tmp_path: Path) -> None:
+        from ginkgo.core.notebook import notebook as make_notebook
+        from ginkgo.runtime.caching.cache import CacheStore
+
         nb_path = tmp_path / "nb.ipynb"
         nb_path.write_text(
             '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}', encoding="utf-8"
         )
-        expr_v1 = notebook_ipynb_task(notebook_path=str(nb_path), value=1)
-
-        def fake_subprocess_ok(
-            *,
-            argv: str | list[str],
-            use_shell: bool,
-            on_stdout: Any = None,
-            on_stderr: Any = None,
-            **kwargs: Any,
-        ) -> subprocess.CompletedProcess[str]:
-            command = " ".join(argv) if isinstance(argv, list) else str(argv)
-            if "import ipykernel" in command:
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
-            if "ipykernel install" in command:
-                kernel_root = tmp_path / ".ginkgo" / "jupyter" / "share" / "jupyter" / "kernels"
-                kernel_name = command.split("--name", 1)[1].strip().split()[0]
-                kernel_dir = kernel_root / kernel_name
-                kernel_dir.mkdir(parents=True, exist_ok=True)
-                (kernel_dir / "kernel.json").write_text("{}", encoding="utf-8")
-                return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
-            if "papermill" in command:
-                (tmp_path / "task_0000.ipynb").write_text("x", encoding="utf-8")
-                # Write to the actual notebook artifacts dir.
-                for p in [tmp_path / ".ginkgo" / "notebooks"]:
-                    p.mkdir(parents=True, exist_ok=True)
-                    (p / "task_0000.ipynb").write_text("x", encoding="utf-8")
-            if "nbconvert" in command:
-                for p in [tmp_path / ".ginkgo" / "notebooks"]:
-                    (p / "task_0000.html").write_text("<html/>", encoding="utf-8")
-            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
-
-        ev1 = ConcurrentEvaluator(jobs=1, cores=1)
-        monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(ev1._shell_runner, "_run_subprocess", fake_subprocess_ok)
-        try:
-            ev1.evaluate(expr_v1)
-        finally:
-            monkeypatch.undo()
-
-        # Modify notebook source — cache key must differ.
-        nb_path.write_text(
-            '{"cells": [{"source": "changed"}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
-            encoding="utf-8",
-        )
-        # The cache keys should differ because the notebook source changed.
-        from ginkgo.runtime.caching.cache import CacheStore
-        from pathlib import Path as _Path
-
-        cache = CacheStore(root=_Path(".ginkgo") / "cache")
-        key_v1, _ = cache.build_cache_key(
-            task_def=expr_v1.task_def,
-            resolved_args={"notebook_path": str(nb_path), "value": 1},
-        )
-        # Recompute v1's key inline to compare — both keys are the same task_def
-        # so the difference comes from the source hash stored in the directive.
-        from ginkgo.core.notebook import notebook as make_notebook
-
-        nb_path.write_text(
-            '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}', encoding="utf-8"
-        )
         directive_v1 = make_notebook(str(nb_path))
+
         nb_path.write_text(
             '{"cells": [{"source": "changed"}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
             encoding="utf-8",
         )
         directive_v2 = make_notebook(str(nb_path))
+
+        # Editing the notebook changes its source hash, which the evaluator
+        # folds into the task's cache key via ``extra_source_hash`` — so the
+        # two source hashes, and the resulting cache keys, must differ.
         assert directive_v1.source_hash != directive_v2.source_hash
+
+        cache = CacheStore(root=tmp_path / ".ginkgo" / "cache")
+        resolved_args = {"notebook_path": str(nb_path), "value": 1}
+        key_v1, _ = cache.build_cache_key(
+            task_def=notebook_ipynb_task,
+            resolved_args=resolved_args,
+            extra_source_hash=directive_v1.source_hash,
+        )
+        key_v2, _ = cache.build_cache_key(
+            task_def=notebook_ipynb_task,
+            resolved_args=resolved_args,
+            extra_source_hash=directive_v2.source_hash,
+        )
+        assert key_v1 != key_v2
 
     def test_local_task_fails_immediately_at_runtime(self):
         @task()

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -1,5 +1,7 @@
 """Unit tests for Expr, ExprList, and related expression tree primitives."""
 
+import dataclasses
+
 import pytest
 
 from ginkgo import Expr, ExprList, task
@@ -25,11 +27,8 @@ class TestExpr:
 
     def test_expr_is_frozen(self):
         expr = dummy(x=10)
-        try:
+        with pytest.raises(dataclasses.FrozenInstanceError):
             expr.args = {}  # type: ignore[misc]
-            assert False, "Should have raised"
-        except AttributeError:
-            pass
 
     def test_expr_repr_with_concrete_args(self):
         expr = dummy(x=42)

--- a/tests/test_fs_share.py
+++ b/tests/test_fs_share.py
@@ -121,6 +121,7 @@ class TestArtifactStoreIntegration:
         assert record_default.digest_hex == record_readonly.digest_hex
         assert record_default.size == record_readonly.size
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX semantics")
     def test_store_with_readonly_hint_shares_inode_on_posix(self, tmp_path: Path) -> None:
         """When reflink is refused, ``src_is_readonly=True`` should hardlink."""
         src = tmp_path / "src.bin"
@@ -132,8 +133,7 @@ class TestArtifactStoreIntegration:
 
         blob_path = tmp_path / "artifacts" / "blobs" / record.digest_hex
         # Same inode only if hardlink was used.
-        if sys.platform != "win32":
-            assert blob_path.stat().st_ino == src.stat().st_ino
+        assert blob_path.stat().st_ino == src.stat().st_ino
 
     def test_store_without_hint_never_shares_inode(self, tmp_path: Path) -> None:
         src = tmp_path / "src.bin"

--- a/tests/test_kubernetes_executor.py
+++ b/tests/test_kubernetes_executor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from ginkgo.remote.kubernetes import (
     KubernetesExecutor,
     KubernetesJobHandle,
@@ -79,28 +81,45 @@ class TestKubernetesExecutor:
         base.update(overrides)
         return base
 
-    @patch("ginkgo.remote.kubernetes.k8s_client", create=True)
-    def test_submit_creates_job(self, mock_k8s_client: MagicMock) -> None:
+    def test_submit_creates_job(self) -> None:
+        import base64
+
         executor = self._make_executor()
         attempt = self._make_attempt()
 
-        # Mock the kubernetes.client module imports inside submit().
-        with patch.dict(
-            "sys.modules", {"kubernetes": MagicMock(), "kubernetes.client": MagicMock()}
-        ):
-            from unittest.mock import MagicMock as MM
+        # Only the API round-trip is mocked; submit() builds a real V1Job from
+        # the installed kubernetes client, so we can assert on its actual spec.
+        created_job = MagicMock()
+        created_job.metadata.name = _generate_job_name(attempt)
+        executor._batch_api.create_namespaced_job.return_value = created_job
 
-            # Mock the create response.
-            created_job = MM()
-            created_job.metadata.name = "ginkgo-test-run-task-001-1"
-            executor._batch_api.create_namespaced_job.return_value = created_job
+        handle = executor.submit(attempt=attempt)
+        assert handle.job_name == created_job.metadata.name
 
-            handle = executor.submit(attempt=attempt)
+        call = executor._batch_api.create_namespaced_job.call_args
+        assert call.kwargs["namespace"] == "ginkgo"
 
-            assert executor._batch_api.create_namespaced_job.called
-            call_kwargs = executor._batch_api.create_namespaced_job.call_args
-            assert call_kwargs.kwargs["namespace"] == "ginkgo"
-            assert handle.job_name == "ginkgo-test-run-task-001-1"
+        job = call.kwargs["body"]
+        assert job.metadata.namespace == "ginkgo"
+        assert job.metadata.labels["ginkgo/task-id"] == "task_001"
+        assert job.metadata.labels["ginkgo/run-id"] == "test-run"
+        assert job.spec.ttl_seconds_after_finished == 600
+
+        pod_spec = job.spec.template.spec
+        assert pod_spec.restart_policy == "Never"
+        assert pod_spec.service_account_name == "ginkgo-worker"
+
+        container = pod_spec.containers[0]
+        assert container.image == "my-image:latest"
+        assert container.resources.requests["cpu"] == "2"
+        assert container.resources.limits["cpu"] == "2"
+        assert container.resources.requests["memory"] == "4Gi"
+        assert container.resources.limits["memory"] == "4Gi"
+
+        payload_env = next(e for e in container.env if e.name == "GINKGO_WORKER_PAYLOAD")
+        decoded = json.loads(base64.b64decode(payload_env.value))
+        assert decoded["task_id"] == "task_001"
+        assert decoded["resources"]["threads"] == 2
 
     def test_satisfies_remote_executor_protocol(self) -> None:
         executor = self._make_executor()
@@ -240,23 +259,7 @@ class TestRefreshingApi:
         factory = MagicMock()
         api = _RefreshingApi(inner=inner, factory=factory)
 
-        try:
+        with pytest.raises(Exception, match="api error") as exc_info:
             api.read_namespaced_job(name="x")
-        except Exception as exc:
-            assert getattr(exc, "status", None) == 500
-        else:
-            raise AssertionError("expected exception")
+        assert getattr(exc_info.value, "status", None) == 500
         factory.assert_not_called()
-
-
-class TestRemoteExecutorProtocol:
-    """Verify protocol conformance."""
-
-    def test_kubernetes_executor_is_remote_executor(self) -> None:
-        executor = KubernetesExecutor(
-            namespace="default",
-            image="test:latest",
-        )
-        executor._batch_api = MagicMock()
-        executor._core_api = MagicMock()
-        assert isinstance(executor, RemoteExecutor)

--- a/tests/test_kubernetes_executor.py
+++ b/tests/test_kubernetes_executor.py
@@ -84,6 +84,11 @@ class TestKubernetesExecutor:
     def test_submit_creates_job(self) -> None:
         import base64
 
+        # submit() builds a real V1Job; the kubernetes client lives in the
+        # optional ``cloud`` extra (installed in CI). Guard so the test still
+        # degrades gracefully in a minimal install without that extra.
+        pytest.importorskip("kubernetes")
+
         executor = self._make_executor()
         attempt = self._make_attempt()
 

--- a/tests/test_max_concurrent.py
+++ b/tests/test_max_concurrent.py
@@ -71,7 +71,7 @@ def _record_interval(item: str) -> dict[str, float]:
     started = time.perf_counter()
     time.sleep(0.1)
     ended = time.perf_counter()
-    return {"item": float(hash(item) % 1000), "start": started, "end": ended}
+    return {"start": started, "end": ended}
 
 
 @flow

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from ginkgo import file, secret, task
@@ -20,18 +21,19 @@ def fake_output_task(output_path: str) -> file:
 
 class TestRunProvenanceRecorder:
     def test_make_run_id_remains_unique_under_fixed_clock(
-        self, monkeypatch, tmp_path: Path
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        # Freeze the clock so both ids share a timestamp. Uniqueness must then
+        # come from the real random discriminator, not from the clock — so
+        # token_hex is deliberately left unpatched.
         real_datetime = provenance_module.datetime
 
         class _FixedDatetime:
             @classmethod
-            def now(cls, tz=None):
+            def now(cls, tz=None):  # noqa: ANN001, ANN206
                 return real_datetime(2026, 4, 1, 12, 0, 0, 123456, tzinfo=tz)
 
-        tokens = iter(["aaaaaaaa", "bbbbbbbb"])
         monkeypatch.setattr(provenance_module, "datetime", _FixedDatetime)
-        monkeypatch.setattr(provenance_module.secrets, "token_hex", lambda _: next(tokens))
 
         workflow_path = tmp_path / "workflow.py"
         first = make_run_id(workflow_path=workflow_path)

--- a/tests/test_remote_evaluator.py
+++ b/tests/test_remote_evaluator.py
@@ -10,7 +10,7 @@ from ginkgo import evaluate, file, task
 from ginkgo.core.remote import remote_file
 from ginkgo.remote.backend import RemoteObjectMeta
 from ginkgo.remote.staging import StagingCache
-from tests.conftest import EventCollector
+from tests.conftest import EventCollector, make_download_backend
 
 
 @task()
@@ -32,28 +32,9 @@ def count_file_bytes(*, path: file) -> int:
 
 
 def _make_mock_staging_cache(tmp_path: Path, content: bytes = b"staged content"):
-    """Create a real staging cache with a mocked backend."""
+    """Create a real staging cache paired with a mocked download backend."""
     cache = StagingCache(root=tmp_path / "staging")
-    backend = MagicMock()
-
-    def _download(*, bucket, key, dest_path):
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        dest_path.write_bytes(content)
-        return RemoteObjectMeta(
-            uri=f"s3://{bucket}/{key}",
-            size=len(content),
-            etag="test-etag",
-        )
-
-    def _head(*, bucket, key):
-        return RemoteObjectMeta(
-            uri=f"s3://{bucket}/{key}",
-            size=len(content),
-            etag="test-etag",
-        )
-
-    backend.download.side_effect = _download
-    backend.head.side_effect = _head
+    backend = make_download_backend(content=content, etag="test-etag")
     return cache, backend
 
 

--- a/tests/test_remote_provenance.py
+++ b/tests/test_remote_provenance.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from ginkgo.runtime.events import (
     TaskCompleted,
@@ -215,27 +219,58 @@ class TestInspectRunRemoteFields:
 
 
 class TestWorkerCodeBundle:
-    """Tests for worker code bundle installation."""
+    """Tests for worker payload preparation in worker.main."""
 
-    def test_worker_pops_code_bundle_from_payload(self) -> None:
-        """Verify that the worker removes code_bundle from the payload."""
-        # This is a unit-level check that the pop happens correctly.
+    def test_main_strips_remote_only_keys_and_installs_bundle(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """worker.main installs the code bundle and strips remote-only keys."""
+        import ginkgo.runtime.worker as runtime_worker
+        from ginkgo.remote import worker
+
+        code_bundle = {
+            "scheme": "gs",
+            "bucket": "test-bucket",
+            "key": "artifacts/code-bundles/abc.tar.gz",
+            "digest": "abc",
+        }
         payload = {
             "args": {},
             "module": "test",
             "binding_name": "fn",
             "resources": {"threads": 1, "memory_gb": 0},
-            "code_bundle": {
-                "scheme": "gs",
-                "bucket": "test-bucket",
-                "key": "artifacts/code-bundles/abc.tar.gz",
-                "digest": "abc",
-            },
+            "code_bundle": code_bundle,
         }
-        payload.pop("resources", None)
-        code_bundle = payload.pop("code_bundle", None)
+        monkeypatch.setenv(
+            "GINKGO_WORKER_PAYLOAD",
+            base64.b64encode(json.dumps(payload).encode()).decode(),
+        )
 
-        assert code_bundle is not None
-        assert code_bundle["scheme"] == "gs"
-        assert "code_bundle" not in payload
-        assert "resources" not in payload
+        # Stub the side effects of bundle installation so no download happens.
+        installed: list[dict] = []
+        monkeypatch.setattr(
+            worker, "_install_code_bundle", lambda cb: installed.append(cb) or tmp_path
+        )
+        monkeypatch.setattr(worker, "_rewrite_module_file", lambda *a, **k: None)
+
+        # Capture the payload that the worker actually hands to run_task.
+        captured: dict[str, Any] = {}
+
+        def fake_run_task(received: dict[str, Any]) -> dict[str, Any]:
+            captured["payload"] = received
+            return {"ok": True, "result_encoding": "inline", "result": None}
+
+        monkeypatch.setattr(runtime_worker, "run_task", fake_run_task)
+
+        with pytest.raises(SystemExit) as exc_info:
+            worker.main()
+        assert exc_info.value.code == 0
+
+        # The real code bundle reached _install_code_bundle, and run_task saw a
+        # payload with every remote-only key removed.
+        assert installed == [code_bundle]
+        run_payload = captured["payload"]
+        assert "code_bundle" not in run_payload
+        assert "resources" not in run_payload
+        assert "remote_artifact_store" not in run_payload
+        assert run_payload["module"] == "test"

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -29,9 +29,8 @@ def _make_run(
     tmp_path: Path,
     run_id: str,
     fail: bool,
-    with_asset: bool = True,
 ) -> Path:
-    """Build a minimal terminal run directory with optional failure and asset."""
+    """Build a minimal terminal run directory with a registered asset."""
     workflow_path = tmp_path / "workflow.py"
     workflow_path.write_text("# demo workflow\n@flow\ndef main():\n    pass\n", encoding="utf-8")
     recorder = RunProvenanceRecorder(
@@ -103,8 +102,7 @@ def _make_run(
     )
     recorder.finalize(status="failed" if fail else "succeeded", error="boom" if fail else None)
 
-    if with_asset:
-        _register_asset(tmp_path=tmp_path, run_id=run_id, run_dir=recorder.run_dir)
+    _register_asset(tmp_path=tmp_path, run_id=run_id, run_dir=recorder.run_dir)
 
     return recorder.run_dir
 
@@ -322,31 +320,26 @@ class TestExport:
         for needle in ("https://fonts.googleapis.com", "https://fonts.gstatic.com"):
             assert needle not in html
 
-    def test_deterministic_reexport(self, tmp_path: Path) -> None:
+    def test_deterministic_reexport(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         run_dir = _make_run(tmp_path=tmp_path, run_id="run-ok", fail=False)
+
+        # Freeze the only non-deterministic input — the generated-at timestamp
+        # that build_report_data stamps via ``datetime.now`` — so two runs of
+        # the real export_report pipeline must produce byte-identical HTML.
+        import ginkgo.reporting.model as model_module
+
         frozen_ts = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)
 
-        # Build two ReportData instances with the same generated_at and render
-        # them directly so we bypass the one non-deterministic moment.
-        from ginkgo.reporting.model import build_report_data
-        from ginkgo.reporting.render import _jinja_env  # type: ignore
+        class _FixedDatetime:
+            @classmethod
+            def now(cls, tz=None):  # noqa: ANN001, ANN206
+                return frozen_ts
 
-        report_a = build_report_data(run_dir=run_dir, generated_at=frozen_ts)
-        report_b = build_report_data(run_dir=run_dir, generated_at=frozen_ts)
+        monkeypatch.setattr(model_module, "datetime", _FixedDatetime)
 
-        env = _jinja_env()
-        template = env.get_template("index.html.j2")
-        kwargs = {
-            "css_href": "assets/report.css",
-            "islands_src": "assets/islands.js",
-            "inline_css": None,
-            "inline_islands": None,
-            "image_inliner": None,
-            "log_inliner": None,
-        }
-        html_a = template.render(report=report_a, **kwargs)
-        html_b = template.render(report=report_b, **kwargs)
-        assert html_a == html_b
+        first = export_report(run_dir=run_dir, out_dir=tmp_path / "a")
+        second = export_report(run_dir=run_dir, out_dir=tmp_path / "b")
+        assert first.index_path.read_bytes() == second.index_path.read_bytes()
 
     def test_refuses_to_overwrite_without_flag(self, tmp_path: Path) -> None:
         run_dir = _make_run(tmp_path=tmp_path, run_id="run-ok", fail=False)

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -7,31 +7,7 @@ from unittest.mock import MagicMock
 from ginkgo.core.remote import remote_file, remote_folder
 from ginkgo.remote.backend import RemoteObjectMeta
 from ginkgo.remote.staging import StagingCache, StagingEntry
-
-
-def _make_mock_backend(*, content: bytes = b"hello world", etag: str = "etag1"):
-    """Create a mock backend that writes fixed content on download."""
-    backend = MagicMock()
-
-    def _download(*, bucket, key, dest_path):
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        dest_path.write_bytes(content)
-        return RemoteObjectMeta(
-            uri=f"s3://{bucket}/{key}",
-            size=len(content),
-            etag=etag,
-        )
-
-    def _head(*, bucket, key):
-        return RemoteObjectMeta(
-            uri=f"s3://{bucket}/{key}",
-            size=len(content),
-            etag=etag,
-        )
-
-    backend.download.side_effect = _download
-    backend.head.side_effect = _head
-    return backend
+from tests.conftest import make_download_backend as _make_mock_backend
 
 
 class TestStageFile:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,7 +1,5 @@
 """Unit tests for @task decorator, TaskDef, and PartialCall."""
 
-from pathlib import Path
-
 import pytest
 
 from ginkgo import Expr, ExprList, PartialCall, TaskDef, task, tmp_dir
@@ -47,29 +45,14 @@ class TestTaskDecorator:
             def my_fn(x: int) -> int:
                 return x
 
-    def test_task_positional_kind_shell(self):
-        @task("shell")
-        def run_cmd(x: int) -> int:
+    @pytest.mark.parametrize("kind", ["shell", "notebook", "script"])
+    def test_task_positional_kind(self, kind: str) -> None:
+        @task(kind)
+        def run(x: int) -> int:
             return x
 
-        assert isinstance(run_cmd, TaskDef)
-        assert run_cmd.kind == "shell"
-
-    def test_task_positional_kind_notebook(self):
-        @task("notebook")
-        def render(sample_id: str) -> Path:
-            return Path(sample_id)
-
-        assert isinstance(render, TaskDef)
-        assert render.kind == "notebook"
-
-    def test_task_positional_kind_script(self):
-        @task("script")
-        def run_script(data: str) -> Path:
-            return Path(data)
-
-        assert isinstance(run_script, TaskDef)
-        assert run_script.kind == "script"
+        assert isinstance(run, TaskDef)
+        assert run.kind == kind
 
     def test_task_positional_kind_and_keyword_differ_raises(self):
         with pytest.raises(ValueError, match="kind specified twice"):
@@ -85,15 +68,9 @@ class TestTaskDecorator:
 
         assert consistent.kind == "shell"
 
-    def test_notebook_kind_execution_mode_is_driver(self):
-        @task("notebook")
-        def render(x: str) -> str:
-            return x
-
-        assert render.execution_mode == "driver"
-
-    def test_script_kind_execution_mode_is_driver(self):
-        @task("script")
+    @pytest.mark.parametrize("kind", ["notebook", "script"])
+    def test_driver_kind_execution_mode_is_driver(self, kind: str) -> None:
+        @task(kind)
         def run(x: str) -> str:
             return x
 
@@ -134,6 +111,7 @@ class TestTaskDefCall:
         # Only x is required; providing just x should be a full call
         result = process(x=5)
         assert isinstance(result, Expr)
+        assert result.args["x"] == 5
 
     def test_full_call_overrides_defaults(self):
         @task()

--- a/tests/test_task_memory.py
+++ b/tests/test_task_memory.py
@@ -8,55 +8,37 @@ from ginkgo.core.task import _parse_memory, task
 class TestParseMemory:
     """Unit tests for the _parse_memory helper."""
 
-    def test_none_returns_zero(self) -> None:
-        assert _parse_memory(None) == 0
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            (None, 0),
+            ("4Gi", 4),
+            ("2.5Gi", 3),  # binary Gi, rounds up
+            ("512Mi", 1),  # rounds up to one
+            ("4096Mi", 4),
+            ("128Mi", 1),  # small, rounds to one
+            ("1Ti", 1024),
+            ("8G", 8),  # decimal G
+            ("1000M", 1),  # decimal M
+            ("1048576Ki", 1),  # 1048576 Ki == 1 Gi
+            ("  4Gi  ", 4),  # surrounding whitespace stripped
+        ],
+    )
+    def test_parse_memory_valid(self, spec: str | None, expected: int) -> None:
+        assert _parse_memory(spec) == expected
 
-    def test_gi_integer(self) -> None:
-        assert _parse_memory("4Gi") == 4
-
-    def test_gi_float(self) -> None:
-        assert _parse_memory("2.5Gi") == 3
-
-    def test_mi_rounds_up(self) -> None:
-        assert _parse_memory("512Mi") == 1
-
-    def test_mi_large(self) -> None:
-        assert _parse_memory("4096Mi") == 4
-
-    def test_mi_small_rounds_to_one(self) -> None:
-        assert _parse_memory("128Mi") == 1
-
-    def test_ti(self) -> None:
-        assert _parse_memory("1Ti") == 1024
-
-    def test_g_decimal(self) -> None:
-        assert _parse_memory("8G") == 8
-
-    def test_m_decimal(self) -> None:
-        assert _parse_memory("1000M") == 1
-
-    def test_ki(self) -> None:
-        # 1048576 Ki = 1 Gi
-        assert _parse_memory("1048576Ki") == 1
-
-    def test_whitespace_stripped(self) -> None:
-        assert _parse_memory("  4Gi  ") == 4
-
-    def test_invalid_unit_raises(self) -> None:
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "4Tb",  # invalid unit
+            "4096",  # bare number, no unit
+            "",  # empty
+            "-4Gi",  # negative
+        ],
+    )
+    def test_parse_memory_invalid_raises(self, spec: str) -> None:
         with pytest.raises(ValueError, match="Invalid memory specification"):
-            _parse_memory("4Tb")
-
-    def test_bare_number_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid memory specification"):
-            _parse_memory("4096")
-
-    def test_empty_string_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid memory specification"):
-            _parse_memory("")
-
-    def test_negative_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid memory specification"):
-            _parse_memory("-4Gi")
+            _parse_memory(spec)
 
 
 class TestTaskDefMemory:
@@ -77,13 +59,6 @@ class TestTaskDefMemory:
 
         assert my_task.memory == "4Gi"
         assert my_task.memory_gb == 4
-
-    def test_memory_512mi(self) -> None:
-        @task(memory="512Mi")
-        def my_task(x: int) -> int:
-            return x
-
-        assert my_task.memory_gb == 1
 
     def test_memory_with_threads(self) -> None:
         @task(threads=4, memory="8Gi")

--- a/tests/test_task_threads.py
+++ b/tests/test_task_threads.py
@@ -82,9 +82,10 @@ class TestShellSubprocessEnv:
         assert env["OPENBLAS_NUM_THREADS"] == "6"
         assert env["NUMEXPR_NUM_THREADS"] == "6"
 
-    def test_inherits_existing_environment(self) -> None:
+    def test_inherits_existing_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GINKGO_TEST_SENTINEL", "sentinel-value")
         env = build_shell_subprocess_env(task_def=_shell_step_inherit)
-        assert "PATH" in env or "HOME" in env
+        assert env["GINKGO_TEST_SENTINEL"] == "sentinel-value"
 
 
 class TestShellTaskPropagatesThreads:

--- a/tests/test_vw1_linear.py
+++ b/tests/test_vw1_linear.py
@@ -3,28 +3,24 @@
 from pathlib import Path
 
 from ginkgo import evaluate, flow, task
-
-
-def _append_line(path: str, line: str) -> None:
-    with Path(path).open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+from tests._vw_support import append_line
 
 
 @task()
 def step_a(x: int, log_path: str) -> int:
-    _append_line(log_path, "step_a")
+    append_line(log_path, "step_a")
     return x + 1
 
 
 @task()
 def step_b(x: int, log_path: str) -> int:
-    _append_line(log_path, "step_b")
+    append_line(log_path, "step_b")
     return x * 2
 
 
 @task()
 def step_c(x: int, log_path: str) -> int:
-    _append_line(log_path, "step_c")
+    append_line(log_path, "step_c")
     return x - 3
 
 
@@ -44,16 +40,9 @@ class TestVW1Evaluation:
     def test_tasks_execute_in_dependency_order(self):
         log_path = "events.log"
         evaluate(linear(start=8, log_path=log_path), jobs=1, cores=1)
+        # Exact-list equality already proves each step ran once, in order.
         assert Path(log_path).read_text(encoding="utf-8").splitlines() == [
             "step_a",
             "step_b",
             "step_c",
         ]
-
-    def test_no_task_runs_more_than_once(self):
-        log_path = "events.log"
-        evaluate(linear(start=2, log_path=log_path), jobs=1, cores=1)
-        events = Path(log_path).read_text(encoding="utf-8").splitlines()
-        assert events.count("step_a") == 1
-        assert events.count("step_b") == 1
-        assert events.count("step_c") == 1

--- a/tests/test_vw2_fanout.py
+++ b/tests/test_vw2_fanout.py
@@ -1,41 +1,9 @@
 """VW-2 — Fan-out / Fan-in: concurrent evaluation tests."""
 
-import json
 import time
-from pathlib import Path
 
 from ginkgo import evaluate, flow, task
-
-
-def _write_interval(events_dir: str, name: str, started_at: float, ended_at: float) -> None:
-    Path(events_dir).mkdir(parents=True, exist_ok=True)
-    Path(events_dir, f"{name}.json").write_text(
-        json.dumps({"end": ended_at, "start": started_at}),
-        encoding="utf-8",
-    )
-
-
-def _read_intervals(events_dir: str, prefix: str) -> dict[str, tuple[float, float]]:
-    intervals: dict[str, tuple[float, float]] = {}
-    for path in Path(events_dir).glob(f"{prefix}-*.json"):
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        intervals[path.stem] = (payload["start"], payload["end"])
-    return intervals
-
-
-def _peak_overlap(intervals: list[tuple[float, float]]) -> int:
-    points: list[tuple[float, int]] = []
-    for start, end in intervals:
-        points.append((start, 1))
-        points.append((end, -1))
-    points.sort(key=lambda item: (item[0], item[1]))
-
-    active = 0
-    peak = 0
-    for _, delta in points:
-        active += delta
-        peak = max(peak, active)
-    return peak
+from tests._vw_support import load_intervals, peak_concurrency, write_interval
 
 
 @task()
@@ -43,7 +11,7 @@ def process(item: str, multiplier: int, events_dir: str) -> str:
     started_at = time.time()
     time.sleep(0.3)
     ended_at = time.time()
-    _write_interval(events_dir, f"process-{item}", started_at, ended_at)
+    write_interval(events_dir, f"process-{item}", started_at=started_at, ended_at=ended_at)
     return item * multiplier
 
 
@@ -52,7 +20,7 @@ def merge(results: list[str], events_dir: str) -> str:
     started_at = time.time()
     output = ",".join(sorted(results))
     ended_at = time.time()
-    _write_interval(events_dir, "merge-run", started_at, ended_at)
+    write_interval(events_dir, "merge-run", started_at=started_at, ended_at=ended_at)
     return output
 
 
@@ -71,11 +39,13 @@ class TestVW2ConcurrentEvaluation:
             fan_pipeline(items=items, multiplier=2, events_dir=events_dir), jobs=10, cores=10
         )
 
-        intervals = list(_read_intervals(events_dir, "process").values())
-        process_makespan = max(end for _, end in intervals) - min(start for start, _ in intervals)
+        intervals = load_intervals(events_dir, prefix="process")
+        process_makespan = max(iv["end"] for iv in intervals) - min(
+            iv["start"] for iv in intervals
+        )
         assert result == ",".join(sorted(item * 2 for item in items))
         assert len(intervals) == 10
-        assert _peak_overlap(intervals) >= 5
+        assert peak_concurrency(intervals) >= 5
         assert process_makespan < 1.5
 
     def test_merge_receives_resolved_results(self):
@@ -90,7 +60,7 @@ class TestVW2ConcurrentEvaluation:
         events_dir = "events"
         evaluate(fan_pipeline(items=items, multiplier=2, events_dir=events_dir), jobs=3, cores=3)
 
-        process_intervals = _read_intervals(events_dir, "process")
-        merge_interval = _read_intervals(events_dir, "merge")["merge-run"]
-        latest_process_end = max(end for _, end in process_intervals.values())
-        assert merge_interval[0] >= latest_process_end
+        process_intervals = load_intervals(events_dir, prefix="process")
+        merge_interval = load_intervals(events_dir, prefix="merge")[0]
+        latest_process_end = max(iv["end"] for iv in process_intervals)
+        assert merge_interval["start"] >= latest_process_end

--- a/tests/test_vw3_conditional.py
+++ b/tests/test_vw3_conditional.py
@@ -4,34 +4,30 @@ from collections import Counter
 from pathlib import Path
 
 from ginkgo import evaluate, flow, task
-
-
-def _append_line(path: str, line: str) -> None:
-    with Path(path).open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+from tests._vw_support import append_line
 
 
 @task()
 def categorise(value: int, log_path: str) -> str:
-    _append_line(log_path, "categorise")
+    append_line(log_path, "categorise")
     return "high" if value > 50 else "low"
 
 
 @task()
 def process_high(value: int, log_path: str) -> str:
-    _append_line(log_path, "process_high")
+    append_line(log_path, "process_high")
     return f"high:{value}"
 
 
 @task()
 def process_low(value: int, log_path: str) -> str:
-    _append_line(log_path, "process_low")
+    append_line(log_path, "process_low")
     return f"low:{value}"
 
 
 @task()
 def route(value: int, category: str, log_path: str):
-    _append_line(log_path, f"route:{category}")
+    append_line(log_path, f"route:{category}")
     if category == "high":
         return process_high(value=value, log_path=log_path)
     return process_low(value=value, log_path=log_path)
@@ -39,7 +35,7 @@ def route(value: int, category: str, log_path: str):
 
 @task()
 def unrelated(seed: int, log_path: str) -> str:
-    _append_line(log_path, "unrelated")
+    append_line(log_path, "unrelated")
     return f"unrelated:{seed}"
 
 

--- a/tests/test_vw4_mixed.py
+++ b/tests/test_vw4_mixed.py
@@ -3,22 +3,18 @@
 from pathlib import Path
 
 from ginkgo import evaluate, flow, task
-
-
-def _append_line(path: str, line: str) -> None:
-    with Path(path).open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+from tests._vw_support import append_line
 
 
 @task()
 def process_high(value: int, log_path: str) -> str:
-    _append_line(log_path, f"process_high:{value}")
+    append_line(log_path, f"process_high:{value}")
     return f"high:{value}"
 
 
 @task()
 def filter_or_process(item: str, log_path: str) -> str | None:
-    _append_line(log_path, f"filter:{item}")
+    append_line(log_path, f"filter:{item}")
     if item.startswith("skip_"):
         return None
     return process_high(value=len(item), log_path=log_path)

--- a/tests/test_vw5_cache.py
+++ b/tests/test_vw5_cache.py
@@ -4,22 +4,18 @@ from collections import Counter
 from pathlib import Path
 
 from ginkgo import evaluate, flow, task
-
-
-def _append_line(path: str, line: str) -> None:
-    with Path(path).open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+from tests._vw_support import append_line
 
 
 @task()
 def process(item: str, multiplier: int, log_path: str) -> str:
-    _append_line(log_path, f"process:{item}")
+    append_line(log_path, f"process:{item}")
     return item * multiplier
 
 
 @task()
 def merge(results: list[str], log_path: str) -> str:
-    _append_line(log_path, "merge")
+    append_line(log_path, "merge")
     return ",".join(sorted(results))
 
 
@@ -30,7 +26,7 @@ def fan_pipeline(items: list[str], multiplier: int, log_path: str):
 
 
 class TestVW5SelectiveInvalidation:
-    def test_only_changed_branch_and_merge_are_recomputed(self):
+    def test_identical_rerun_is_fully_cached(self):
         log_path = "events.log"
         items = ["a", "b", "c", "d", "e"]
 
@@ -41,10 +37,33 @@ class TestVW5SelectiveInvalidation:
         result2 = evaluate(fan_pipeline(items=items, multiplier=2, log_path=log_path))
         assert result2 == result1
 
-        updated_items = ["a", "b", "changed", "d", "e"]
-        result3 = evaluate(fan_pipeline(items=updated_items, multiplier=2, log_path=log_path))
-        assert result3 == "aa,bb,changedchanged,dd,ee"
+        # The identical second run is served entirely from cache, so no task
+        # body re-executes: each event appears exactly once.
+        counts = Counter(Path(log_path).read_text(encoding="utf-8").splitlines())
+        assert counts == Counter(
+            {
+                "process:a": 1,
+                "process:b": 1,
+                "process:c": 1,
+                "process:d": 1,
+                "process:e": 1,
+                "merge": 1,
+            }
+        )
 
+    def test_changed_branch_triggers_selective_recompute(self):
+        log_path = "events.log"
+        items = ["a", "b", "c", "d", "e"]
+
+        result1 = evaluate(fan_pipeline(items=items, multiplier=2, log_path=log_path))
+        assert result1 == "aa,bb,cc,dd,ee"
+
+        updated_items = ["a", "b", "changed", "d", "e"]
+        result2 = evaluate(fan_pipeline(items=updated_items, multiplier=2, log_path=log_path))
+        assert result2 == "aa,bb,changedchanged,dd,ee"
+
+        # Only the changed branch re-runs; the merge re-runs because its inputs
+        # changed. The unchanged branches stay cached (one event each).
         counts = Counter(Path(log_path).read_text(encoding="utf-8").splitlines())
         assert counts == Counter(
             {

--- a/tests/test_vw6_failure.py
+++ b/tests/test_vw6_failure.py
@@ -6,23 +6,19 @@ import time
 import pytest
 
 from ginkgo import evaluate, flow, task
-
-
-def _append_line(path: str, line: str) -> None:
-    with Path(path).open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+from tests._vw_support import append_line
 
 
 @task()
 def may_fail_transient(item: str, log_path: str) -> str:
-    _append_line(log_path, f"start:{item}")
+    append_line(log_path, f"start:{item}")
     marker = Path(f".transient-{item}")
     if item == "item_3" and not marker.exists():
         marker.write_text("failed once", encoding="utf-8")
         raise RuntimeError(f"transient failure on {item}")
 
     result = f"ok:{item}"
-    _append_line(log_path, result)
+    append_line(log_path, result)
     return result
 
 
@@ -33,14 +29,14 @@ def failure_pipeline_transient(items: list[str], log_path: str):
 
 @task()
 def may_fail(item: str, log_path: str) -> str:
-    _append_line(log_path, f"start:{item}")
+    append_line(log_path, f"start:{item}")
 
     if item == "item_0":
         time.sleep(0.05)
         raise RuntimeError("deliberate failure on item_0")
 
     time.sleep(0.15)
-    _append_line(log_path, f"finish:{item}")
+    append_line(log_path, f"finish:{item}")
     return f"ok:{item}"
 
 

--- a/tests/test_vw7_resources.py
+++ b/tests/test_vw7_resources.py
@@ -1,66 +1,9 @@
 """VW-7 — Resource contention tests."""
 
-import json
 import time
-from pathlib import Path
 
 from ginkgo import evaluate, flow, task
-
-
-def _write_interval(
-    events_dir: str,
-    name: str,
-    *,
-    started_at: float,
-    ended_at: float,
-    threads: int,
-    heavy: bool,
-) -> None:
-    Path(events_dir).mkdir(parents=True, exist_ok=True)
-    Path(events_dir, f"{name}.json").write_text(
-        json.dumps(
-            {
-                "end": ended_at,
-                "heavy": heavy,
-                "start": started_at,
-                "threads": threads,
-            }
-        ),
-        encoding="utf-8",
-    )
-
-
-def _load_intervals(events_dir: str) -> list[dict[str, object]]:
-    return [
-        json.loads(path.read_text(encoding="utf-8")) for path in Path(events_dir).glob("*.json")
-    ]
-
-
-def _compute_peaks(intervals: list[dict[str, object]]) -> tuple[int, int, int]:
-    points: list[tuple[float, int, int, int]] = []
-    for interval in intervals:
-        threads = int(interval["threads"])
-        heavy = 1 if interval["heavy"] else 0
-        points.append((float(interval["start"]), 1, threads, heavy))
-        points.append((float(interval["end"]), -1, -threads, -heavy))
-
-    points.sort(key=lambda item: (item[0], item[1]))
-
-    active_tasks = 0
-    active_cores = 0
-    active_heavy = 0
-    peak_tasks = 0
-    peak_cores = 0
-    peak_heavy = 0
-    for _, task_delta, core_delta, heavy_delta in points:
-        active_tasks += task_delta
-        active_cores += core_delta
-        active_heavy += heavy_delta
-        peak_tasks = max(peak_tasks, active_tasks)
-        peak_cores = max(peak_cores, active_cores)
-        peak_heavy = max(peak_heavy, active_heavy)
-
-    return peak_tasks, peak_cores, peak_heavy
+from tests._vw_support import compute_peaks, load_intervals, write_interval
 
 
 @task(threads=8)
@@ -68,7 +11,7 @@ def heavy(item: str, events_dir: str, threads: int = 8) -> str:
     started_at = time.time()
     time.sleep(0.15)
     ended_at = time.time()
-    _write_interval(
+    write_interval(
         events_dir,
         f"heavy-{item}",
         started_at=started_at,
@@ -84,7 +27,7 @@ def light(item: str, events_dir: str, threads: int = 1) -> str:
     started_at = time.time()
     time.sleep(0.15)
     ended_at = time.time()
-    _write_interval(
+    write_interval(
         events_dir,
         f"light-{item}",
         started_at=started_at,
@@ -113,9 +56,9 @@ class TestVW7ResourceContention:
             cores=16,
         )
 
-        peak_tasks, peak_cores, peak_heavy = _compute_peaks(_load_intervals(events_dir))
+        peaks = compute_peaks(load_intervals(events_dir), dimensions=("threads", "heavy"))
         assert heavy_results == [f"heavy:{item}" for item in items[:5]]
         assert light_results == [f"light:{item}" for item in items[5:]]
-        assert peak_heavy <= 2
-        assert peak_tasks <= 10
-        assert peak_cores <= 16
+        assert peaks["heavy"] <= 2
+        assert peaks["tasks"] <= 10
+        assert peaks["threads"] <= 16

--- a/tests/test_vw8_memory.py
+++ b/tests/test_vw8_memory.py
@@ -2,76 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import time
 from pathlib import Path
 
 import pytest
 
 from ginkgo import evaluate, flow, task
-
-
-def _write_interval(
-    events_dir: str,
-    name: str,
-    *,
-    started_at: float,
-    ended_at: float,
-    threads: int,
-    memory_gb: int,
-    high_memory: bool,
-) -> None:
-    Path(events_dir).mkdir(parents=True, exist_ok=True)
-    Path(events_dir, f"{name}.json").write_text(
-        json.dumps(
-            {
-                "end": ended_at,
-                "high_memory": high_memory,
-                "memory_gb": memory_gb,
-                "start": started_at,
-                "threads": threads,
-            }
-        ),
-        encoding="utf-8",
-    )
-
-
-def _load_intervals(events_dir: str) -> list[dict[str, object]]:
-    return [
-        json.loads(path.read_text(encoding="utf-8")) for path in Path(events_dir).glob("*.json")
-    ]
-
-
-def _compute_peaks(intervals: list[dict[str, object]]) -> tuple[int, int, int, int]:
-    points: list[tuple[float, int, int, int, int]] = []
-    for interval in intervals:
-        threads = int(interval["threads"])
-        memory_gb = int(interval["memory_gb"])
-        high_memory = 1 if interval["high_memory"] else 0
-        points.append((float(interval["start"]), 1, threads, memory_gb, high_memory))
-        points.append((float(interval["end"]), -1, -threads, -memory_gb, -high_memory))
-
-    points.sort(key=lambda item: (item[0], item[1]))
-
-    active_tasks = 0
-    active_cores = 0
-    active_memory = 0
-    active_high_memory = 0
-    peak_tasks = 0
-    peak_cores = 0
-    peak_memory = 0
-    peak_high_memory = 0
-    for _, task_delta, core_delta, memory_delta, high_memory_delta in points:
-        active_tasks += task_delta
-        active_cores += core_delta
-        active_memory += memory_delta
-        active_high_memory += high_memory_delta
-        peak_tasks = max(peak_tasks, active_tasks)
-        peak_cores = max(peak_cores, active_cores)
-        peak_memory = max(peak_memory, active_memory)
-        peak_high_memory = max(peak_high_memory, active_high_memory)
-
-    return peak_tasks, peak_cores, peak_memory, peak_high_memory
+from tests._vw_support import compute_peaks, load_intervals, write_interval
 
 
 @task(threads=2)
@@ -79,7 +16,7 @@ def high_mem(item: str, events_dir: str, threads: int = 2, memory_gb: int = 16) 
     started_at = time.time()
     time.sleep(0.15)
     ended_at = time.time()
-    _write_interval(
+    write_interval(
         events_dir,
         f"high-{item}",
         started_at=started_at,
@@ -96,7 +33,7 @@ def low_mem(item: str, events_dir: str, threads: int = 1, memory_gb: int = 4) ->
     started_at = time.time()
     time.sleep(0.15)
     ended_at = time.time()
-    _write_interval(
+    write_interval(
         events_dir,
         f"low-{item}",
         started_at=started_at,
@@ -133,15 +70,16 @@ class TestVW8MemoryContention:
             memory=32,
         )
 
-        peak_tasks, peak_cores, peak_memory, peak_high_memory = _compute_peaks(
-            _load_intervals(events_dir)
+        peaks = compute_peaks(
+            load_intervals(events_dir),
+            dimensions=("threads", "memory_gb", "high_memory"),
         )
         assert high_results == [f"high:{item}" for item in items[:3]]
         assert low_results == [f"low:{item}" for item in items[3:]]
-        assert peak_high_memory <= 2
-        assert peak_tasks <= 6
-        assert peak_cores <= 8
-        assert peak_memory <= 32
+        assert peaks["high_memory"] <= 2
+        assert peaks["tasks"] <= 6
+        assert peaks["threads"] <= 8
+        assert peaks["memory_gb"] <= 32
 
     def test_task_larger_than_budget_fails_before_dispatch(self) -> None:
         marker_path = "too-large.marker"

--- a/tests/test_vw_pixi.py
+++ b/tests/test_vw_pixi.py
@@ -38,7 +38,7 @@ _TESTS_DIR = Path(__file__).parent
 _TEST_ENV_NAME = "test_env"
 
 
-def _make_registry(tmp_path: Path) -> PixiRegistry:
+def _make_registry() -> PixiRegistry:
     """Return a PixiRegistry pointing at the real test envs directory."""
     return PixiRegistry(project_root=_TESTS_DIR)
 
@@ -275,7 +275,7 @@ class TestPixiShellTask:
     @pixi_required
     def test_shell_task_runs_in_pixi_env(self, tmp_path: Path) -> None:
         output = str(tmp_path / "sentinel.txt")
-        registry = _make_registry(tmp_path)
+        registry = _make_registry()
         result = _evaluate(shell_touch(output_path=output), registry=registry)
         assert result == output
         assert Path(output).read_text().strip() == "pixi_ran"
@@ -288,7 +288,7 @@ class TestPixiShellTask:
         from ginkgo.runtime.events import EventBus, TaskCacheHit
 
         output = str(tmp_path / "sentinel.txt")
-        registry = _make_registry(tmp_path)
+        registry = _make_registry()
 
         # Run 1 — shell command executes, result cached.
         _evaluate(shell_touch(output_path=output), registry=registry)
@@ -331,7 +331,7 @@ def shell_only(output_path: str) -> str:
 
         module = load_module_from_path(workflow_path)
         output = tmp_path / "shell-only.txt"
-        registry = _make_registry(tmp_path)
+        registry = _make_registry()
 
         result = _evaluate(module.shell_only(output_path=str(output)), registry=registry)
 
@@ -356,7 +356,7 @@ def needs_foreign_env(x: int) -> int:
         )
 
         module = load_module_from_path(workflow_path)
-        registry = _make_registry(tmp_path)
+        registry = _make_registry()
 
         with pytest.raises(TypeError, match="Foreign environments only support driver tasks"):
             _evaluate(module.needs_foreign_env(x=1), registry=registry)

--- a/tests/test_warm_run_optimizations.py
+++ b/tests/test_warm_run_optimizations.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from ginkgo import evaluate, file, task
 from ginkgo.core.remote import remote_file
@@ -208,18 +208,34 @@ class TestWarmRunIntegration:
         # On warm run, both tasks should be cached.
         from ginkgo.runtime.events import TaskCacheHit
 
+        # The DAG has exactly two tasks; both must be cache hits (no more).
         cache_hits = [e for e in collector.events if isinstance(e, TaskCacheHit)]
-        assert len(cache_hits) >= 2
+        assert len(cache_hits) == 2
 
     def test_file_hash_memoization_reduces_reads(self, tmp_path: Path) -> None:
-        """When a file is consumed by multiple tasks, it should be hashed once."""
-        output = tmp_path / "shared.txt"
+        """A file consumed by multiple tasks is hashed from disk only once."""
+        import ginkgo.runtime.caching.hash_memo as hash_memo_module
 
+        output = tmp_path / "shared.txt"
         shared = make_shared(output_path=str(output))
-        result = evaluate((reader_a(input_file=shared), reader_b(input_file=shared)))
+
+        # Spy on the raw disk-hashing primitive that HashMemo invokes only on a
+        # cache miss. Two readers share one input, so memoization must collapse
+        # the work to a single read of that path.
+        real_hash_file = hash_memo_module.hash_file
+        hashed_paths: list[str] = []
+
+        def recording_hash_file(path: Path) -> str:
+            hashed_paths.append(str(Path(path).resolve()))
+            return real_hash_file(path)
+
+        with patch.object(hash_memo_module, "hash_file", side_effect=recording_hash_file):
+            result = evaluate((reader_a(input_file=shared), reader_b(input_file=shared)))
 
         assert result[0] == 11  # len("shared data")
         assert result[1] == 22
+        shared_reads = sum(1 for p in hashed_paths if p.endswith("shared.txt"))
+        assert shared_reads == 1
 
     def test_warm_run_completes_cached_dag_before_dispatch(self, tmp_path: Path) -> None:
         """A fully cached DAG should not enter task execution on the warm run."""


### PR DESCRIPTION
Addresses all findings from #89 — a diagnostic audit of the ~50-file test suite.

## Verification
- Full suite: **678 passed, 5 skipped** (pre-existing pixi/platform skips)
- `ruff check` + `ruff format` clean; pre-commit hooks pass
- ty diagnostics on `tests/` reduced **66 → 56** (none introduced; new shared modules are ty-clean)
- Net **−253 lines** plus one new shared helper module

## 1. Incoherent tests — now exercise real behaviour
These previously passed regardless of whether the code under test worked.
- **cache-prune read-only** — calls the real `_safe_rmtree`, deterministically forces the read-only branch, asserts removal
- **container shell-env validation** — dropped the swallowed `ContainerRuntimeNotFoundError`; patches `shutil.which` so validation runs
- **container cache digest** — asserts two image digests yield different `build_cache_key` results
- **assets duplicate-names** — negative assertion is now unconditional (no vacuous pass)
- **hash memoization** — spies on the raw `hash_file`, asserts the shared file is read exactly once
- **k8s submit** — un-mocked `kubernetes.client`; asserts the real `V1Job` spec (caught a hidden `ephemeral_storage` default)
- **worker code bundle** — drives the real `worker.main`, asserts `run_task` receives a stripped payload
- **deterministic digest** — deleted (genuinely non-deterministic, already covered)
- **run-id uniqueness** — relies on real randomness rather than faked `token_hex`

## 2. Guarded-assertion anti-pattern
`pytest.raises` / `skipif` now used in `test_expr`, `test_kubernetes_executor`, `test_fs_share`.

## 3. Duplication & over-complication
- New `tests/_vw_support.py`: shared `append_line` (was copy-pasted in 5+ files) + one parameterized interval/peak toolkit (was 3 variants)
- New `make_download_backend` in `conftest.py` (was hand-rolled in staging + remote-evaluator)
- Notebook-subprocess factory in `test_evaluator.py` (~250 lines of duplicated fakes → one helper)
- Notebook cache-invalidation test now uses the real `extra_source_hash` → cache-key path
- Parametrized: task kind/exec-mode, `_parse_memory`, `_should_exclude` (+ added missing gitignore-branch test), cli cache-prune (+ `_seed_cache_entry`); deleted duplicate k8s protocol & redundant vw1 tests
- Split overloaded cli / vw5 / asset-store tests
- `test_deterministic_reexport` now goes through the real `export_report`
- Trimmed brittle emoji/whitespace CLI assertions

## 4. Minor / dead code
Removed unused params/fields (`vw_pixi`, `max_concurrent`, `reporting`); made the env-inherit thread test deterministic with a sentinel; confirmed `load_wrapped_ref` is a valid import alias.

## Two deliberate judgment calls
- **EventCollector in vw tests** — kept file-logging (verifies real on-disk side-effects/ordering, stronger than asserting events fired); the duplication debt is resolved via shared helpers.
- **`test_examples` exact task counts** — kept as a deliberate smoke check paired with per-group structural assertions.

Closes #89.