### PR TITLE
Add grouped and captioned asset report sections

### DIFF
--- a/docs/architecture/assets.md
+++ b/docs/architecture/assets.md
@@ -23,9 +23,10 @@ The current asset model supports:
 
 - a single `AssetResult` sentinel with a `kind` discriminator (one of
   `file`, `table`, `array`, `fig`, `text`, `model`)
-- `asset(payload, kind=..., name=..., group=..., metadata=...,
-  **kind_fields)` as the canonical constructor, with `table`, `array`,
-  `fig`, `text`, and `model` as kind-preset shorthand factories
+- `asset(payload, kind=..., name=..., group=..., caption=...,
+  metadata=..., **kind_fields)` as the canonical constructor, with
+  `table`, `array`, `fig`, `text`, and `model` as kind-preset shorthand
+  factories
 - immutable `AssetVersion` records keyed by logical `AssetKey`
 - resolved `AssetRef` values passed to downstream tasks
 - alias pointers and version history in `.ginkgo/assets/`
@@ -68,17 +69,19 @@ downstream behaviour.
   `asset(path, ...)`.
 - **`table`** — pandas, polars (eager or lazy), pyarrow Table/Dataset,
   DuckDB relation, or CSV/TSV path. Stored as Parquet. Shorthand:
-  `table(payload, name=..., group=..., metadata=...)`.
+  `table(payload, name=..., group=..., caption=..., metadata=...)`.
 - **`array`** — numpy, xarray, zarr, or dask. Stored as a zipped zarr
   store when the `zarr` package is installed, or as a `.npy` blob
   otherwise for numpy-only inputs. Non-numpy backends require `zarr`.
-  Shorthand: `array(payload, name=..., group=..., metadata=...)`.
+  Shorthand: `array(payload, name=..., group=..., caption=...,
+  metadata=...)`.
 - **`fig`** — matplotlib (PNG), plotly (HTML), bokeh (HTML), or a path
   to an existing PNG/SVG/HTML file. Shorthand:
-  `fig(payload, name=..., group=..., metadata=...)`.
+  `fig(payload, name=..., group=..., caption=..., metadata=...)`.
 - **`text`** — string, dict (stored as JSON), or a `Path` to a text
   document. Format is `{plain, markdown, json}`. Shorthand:
-  `text(payload, name=..., group=..., format=..., metadata=...)`.
+  `text(payload, name=..., group=..., caption=..., format=...,
+  metadata=...)`.
 - **`model`** — trained ML models. Supports scikit-learn estimators,
   xgboost/lightgbm sklearn wrappers (via `joblib`), PyTorch
   `nn.Module` (via `torch.save`), and Keras/TensorFlow (via the native
@@ -87,8 +90,8 @@ downstream behaviour.
   render training metrics without walking free-form metadata. All ML
   backends are user-managed dependencies, lazy-imported at
   serialisation/load time. Shorthand:
-  `model(payload, name=..., group=..., framework=..., metrics=...,
-  metadata=...)`.
+  `model(payload, name=..., group=..., caption=..., framework=...,
+  metrics=..., metadata=...)`.
 
 `file` is not a peer of the semantic kinds — it is the fallback kind
 for typed-unknown bytes. The semantic kinds can all be file-backed at
@@ -117,6 +120,10 @@ arguments (`format=` for `text`, `framework=` / `metrics=` for
 - `group` — optional report section label. It is persisted on the version
   metadata as `ginkgo_group`, affects presentation only, and is not part
   of `AssetKey`.
+- `caption` — optional human-readable annotation shown in reports and
+  asset inspection output. It is persisted on the version metadata as
+  `ginkgo_caption`, affects presentation only, and is not part of
+  `AssetKey`.
 - `metadata` — free-form user metadata persisted on the version.
 - `kind_fields` — a `dict[str, Any]` bag carrying kind-specific
   construction-time fields (`format` for `text`, `framework` and

--- a/docs/architecture/assets.md
+++ b/docs/architecture/assets.md
@@ -23,9 +23,9 @@ The current asset model supports:
 
 - a single `AssetResult` sentinel with a `kind` discriminator (one of
   `file`, `table`, `array`, `fig`, `text`, `model`)
-- `asset(payload, kind=..., name=..., metadata=..., **kind_fields)` as
-  the canonical constructor, with `table`, `array`, `fig`, `text`, and
-  `model` as kind-preset shorthand factories
+- `asset(payload, kind=..., name=..., group=..., metadata=...,
+  **kind_fields)` as the canonical constructor, with `table`, `array`,
+  `fig`, `text`, and `model` as kind-preset shorthand factories
 - immutable `AssetVersion` records keyed by logical `AssetKey`
 - resolved `AssetRef` values passed to downstream tasks
 - alias pointers and version history in `.ginkgo/assets/`
@@ -68,17 +68,17 @@ downstream behaviour.
   `asset(path, ...)`.
 - **`table`** — pandas, polars (eager or lazy), pyarrow Table/Dataset,
   DuckDB relation, or CSV/TSV path. Stored as Parquet. Shorthand:
-  `table(payload, name=..., metadata=...)`.
+  `table(payload, name=..., group=..., metadata=...)`.
 - **`array`** — numpy, xarray, zarr, or dask. Stored as a zipped zarr
   store when the `zarr` package is installed, or as a `.npy` blob
   otherwise for numpy-only inputs. Non-numpy backends require `zarr`.
-  Shorthand: `array(payload, name=..., metadata=...)`.
+  Shorthand: `array(payload, name=..., group=..., metadata=...)`.
 - **`fig`** — matplotlib (PNG), plotly (HTML), bokeh (HTML), or a path
   to an existing PNG/SVG/HTML file. Shorthand:
-  `fig(payload, name=..., metadata=...)`.
+  `fig(payload, name=..., group=..., metadata=...)`.
 - **`text`** — string, dict (stored as JSON), or a `Path` to a text
   document. Format is `{plain, markdown, json}`. Shorthand:
-  `text(payload, name=..., format=..., metadata=...)`.
+  `text(payload, name=..., group=..., format=..., metadata=...)`.
 - **`model`** — trained ML models. Supports scikit-learn estimators,
   xgboost/lightgbm sklearn wrappers (via `joblib`), PyTorch
   `nn.Module` (via `torch.save`), and Keras/TensorFlow (via the native
@@ -87,7 +87,8 @@ downstream behaviour.
   render training metrics without walking free-form metadata. All ML
   backends are user-managed dependencies, lazy-imported at
   serialisation/load time. Shorthand:
-  `model(payload, name=..., framework=..., metrics=..., metadata=...)`.
+  `model(payload, name=..., group=..., framework=..., metrics=...,
+  metadata=...)`.
 
 `file` is not a peer of the semantic kinds — it is the fallback kind
 for typed-unknown bytes. The semantic kinds can all be file-backed at
@@ -113,6 +114,9 @@ arguments (`format=` for `text`, `framework=` / `metrics=` for
 - `sub_kind` — the detected backend (`"pandas"`, `"matplotlib"`,
   `"sklearn"`, …); `None` for `file`.
 - `name` — optional explicit local asset name.
+- `group` — optional report section label. It is persisted on the version
+  metadata as `ginkgo_group`, affects presentation only, and is not part
+  of `AssetKey`.
 - `metadata` — free-form user metadata persisted on the version.
 - `kind_fields` — a `dict[str, Any]` bag carrying kind-specific
   construction-time fields (`format` for `text`, `framework` and

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -54,6 +54,7 @@ Each topic file below is self-contained. Load only the pages relevant to your ta
 - [Task Model](task-model.md) — Python, shell, notebook, and script task kinds; path-oriented special types.
 - [Caching](caching.md) — cache keying, hashing, artifact store, and cache maintenance.
 - [Assets](assets.md) — asset catalog, wrapped asset sentinels (`table`/`array`/`fig`/`text`/`model`), and live-payload rehydration.
+- [Reporting](reporting.md) — static HTML report export, typed report data, asset previews, and bundle layout.
 - [Value Transport](value-transport.md) — codec layer for cross-process task inputs/outputs.
 - [Configuration and Secrets](config-secrets.md) — secret references, resolvers, and redaction.
 - [Provenance and Run State](provenance.md) — on-disk run layout and manifest contents.

--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -87,6 +87,13 @@ Assets without a non-empty group are rendered under "Ungrouped assets".
 Grouping is presentation-only and does not affect `AssetKey.namespace`,
 asset names, cache keys, or artifact identity.
 
+Asset captions are read from the asset version metadata key
+`ginkgo_caption`, populated by `asset(..., caption=...)` and the shorthand
+factories. Captions become `AssetCard.caption` and render beneath the asset
+name in the card header; they are also surfaced by `ginkgo asset show`.
+Like groups, captions are presentation-only and do not affect identity or
+cache behaviour.
+
 ## Bundle layout
 
 ```

--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -80,6 +80,13 @@ for asset resolution. The UI server continues to build its own payloads
 from the same `RunSummary`; the two presentation layers diverge cleanly
 without duplicating parsing logic.
 
+Asset cards are grouped into `AssetSection` objects before rendering. The
+section title comes from the asset version metadata key `ginkgo_group`,
+which is populated by `asset(..., group=...)` and the shorthand factories.
+Assets without a non-empty group are rendered under "Ungrouped assets".
+Grouping is presentation-only and does not affect `AssetKey.namespace`,
+asset names, cache keys, or artifact identity.
+
 ## Bundle layout
 
 ```
@@ -203,7 +210,8 @@ ordering hooks worth knowing about:
 
 - Tasks are ordered by `node_id` ascending (already true for
   `RunSummary.tasks`).
-- Asset cards are sorted by `(namespace, name)`.
+- Asset sections are ordered by first referenced asset version in the run
+  manifest; cards inside each section are sorted by `(namespace, name)`.
 - Graph columns are keyed by longest-path level, with nodes inside each
   column ordered by `node_id`.
 

--- a/docs/site/guide/assets.md
+++ b/docs/site/guide/assets.md
@@ -35,8 +35,9 @@ The typed helpers each map to an asset **kind**:
 | `text(payload)` | `text` | plain, markdown, or JSON text |
 | `model(payload)` | `model` | a trained model object |
 
-Each helper accepts a `name` (the asset key, written `namespace/name`) and a
-`metadata` dict. `model()` also takes `framework` and `metrics`:
+Each helper accepts a `name` (the asset key, written `namespace/name`), a
+`group` label for report sections, and a `metadata` dict. `model()` also takes
+`framework` and `metrics`:
 
 ```python
 from ginkgo import model, task
@@ -45,8 +46,16 @@ from ginkgo import model, task
 @task()
 def train_classifier(features: file) -> file:
     clf = fit_model(features)
-    return model(clf, name="models/classifier", metrics={"auc": 0.93})
+    return model(
+        clf,
+        name="models/classifier",
+        group="Model outputs",
+        metrics={"auc": 0.93},
+    )
 ```
+
+Assets with the same `group` are rendered together under a named heading in
+HTML reports. Assets without a group appear under "Ungrouped assets".
 
 Assets are content-addressed and stored under `.ginkgo/assets/`. Re-running a
 task that produces the same content adds a new *version* pointing at the same

--- a/docs/site/guide/assets.md
+++ b/docs/site/guide/assets.md
@@ -36,8 +36,8 @@ The typed helpers each map to an asset **kind**:
 | `model(payload)` | `model` | a trained model object |
 
 Each helper accepts a `name` (the asset key, written `namespace/name`), a
-`group` label for report sections, and a `metadata` dict. `model()` also takes
-`framework` and `metrics`:
+`group` label for report sections, a `caption` shown beneath the asset name,
+and a `metadata` dict. `model()` also takes `framework` and `metrics`:
 
 ```python
 from ginkgo import model, task
@@ -50,12 +50,15 @@ def train_classifier(features: file) -> file:
         clf,
         name="models/classifier",
         group="Model outputs",
+        caption="Classifier trained on the filtered feature matrix.",
         metrics={"auc": 0.93},
     )
 ```
 
 Assets with the same `group` are rendered together under a named heading in
-HTML reports. Assets without a group appear under "Ungrouped assets".
+HTML reports. Assets without a group appear under "Ungrouped assets". Captions
+are rendered as short subtitles on each asset card and are also shown by
+`ginkgo asset show`.
 
 Assets are content-addressed and stored under `.ginkgo/assets/`. Re-running a
 task that produces the same content adds a new *version* pointing at the same

--- a/src/ginkgo/cli/commands/asset.py
+++ b/src/ginkgo/cli/commands/asset.py
@@ -9,6 +9,7 @@ from rich import box
 from rich.table import Table
 
 from ginkgo.cli.common import ASSETS_ROOT, console
+from ginkgo.runtime.artifacts.asset_registration import ASSET_CAPTION_METADATA_KEY
 from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
 from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.core.asset import AssetKey
@@ -178,6 +179,9 @@ def render_asset_show(*, console, version) -> int:
     console.print(f"Kind: {version.kind}")
     console.print(f"Sub-kind: {metadata.get('sub_kind', '-')}")
     console.print(f"Artifact ID: {version.artifact_id}")
+    caption = metadata.get(ASSET_CAPTION_METADATA_KEY)
+    if isinstance(caption, str) and caption.strip():
+        console.print(f"Caption: {caption.strip()}")
 
     if namespace == "table":
         _render_table_metadata(console=console, metadata=metadata)

--- a/src/ginkgo/core/asset.py
+++ b/src/ginkgo/core/asset.py
@@ -163,6 +163,10 @@ class AssetResult:
     group : str | None
         Optional report grouping label. This affects presentation only and
         does not participate in asset identity.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output. This affects presentation only and does not
+        participate in asset identity.
     metadata : dict[str, Any]
         Optional user-supplied metadata stored on the asset version.
     kind_fields : dict[str, Any]
@@ -178,6 +182,7 @@ class AssetResult:
     sub_kind: str | None = None
     name: str | None = None
     group: str | None = None
+    caption: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     kind_fields: dict[str, Any] = field(default_factory=dict)
 
@@ -294,6 +299,7 @@ def asset(
     kind: AssetKind = "file",
     name: str | None = None,
     group: str | None = None,
+    caption: str | None = None,
     metadata: dict[str, Any] | None = None,
     **kind_fields: Any,
 ) -> AssetResult:
@@ -319,6 +325,10 @@ def asset(
     group : str | None
         Optional report grouping label. Grouping is persisted with the asset
         version but does not affect the stable asset key.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output. Captions are persisted with the asset version but
+        do not affect the stable asset key.
     metadata : dict[str, Any] | None
         Optional user-supplied metadata persisted on the asset version.
     **kind_fields : Any
@@ -347,6 +357,7 @@ def asset(
         sub_kind=sub_kind,
         name=name,
         group=group.strip() if isinstance(group, str) and group.strip() else None,
+        caption=caption.strip() if isinstance(caption, str) and caption.strip() else None,
         metadata=dict(metadata or {}),
         kind_fields=extra_kind_fields,
     )
@@ -357,6 +368,7 @@ def table(
     *,
     name: str | None = None,
     group: str | None = None,
+    caption: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
     """Wrap a tabular value as an asset return.
@@ -371,6 +383,9 @@ def table(
         Optional explicit local asset name.
     group : str | None
         Optional report grouping label.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
 
@@ -378,7 +393,7 @@ def table(
     -------
     AssetResult
     """
-    return asset(payload, kind="table", name=name, group=group, metadata=metadata)
+    return asset(payload, kind="table", name=name, group=group, caption=caption, metadata=metadata)
 
 
 def array(
@@ -386,6 +401,7 @@ def array(
     *,
     name: str | None = None,
     group: str | None = None,
+    caption: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
     """Wrap an n-dimensional array value as an asset return.
@@ -399,6 +415,9 @@ def array(
         Optional explicit local asset name.
     group : str | None
         Optional report grouping label.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
 
@@ -406,7 +425,7 @@ def array(
     -------
     AssetResult
     """
-    return asset(payload, kind="array", name=name, group=group, metadata=metadata)
+    return asset(payload, kind="array", name=name, group=group, caption=caption, metadata=metadata)
 
 
 def fig(
@@ -414,6 +433,7 @@ def fig(
     *,
     name: str | None = None,
     group: str | None = None,
+    caption: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
     """Wrap a figure or plot value as an asset return.
@@ -427,6 +447,9 @@ def fig(
         Optional explicit local asset name.
     group : str | None
         Optional report grouping label.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
 
@@ -434,7 +457,7 @@ def fig(
     -------
     AssetResult
     """
-    return asset(payload, kind="fig", name=name, group=group, metadata=metadata)
+    return asset(payload, kind="fig", name=name, group=group, caption=caption, metadata=metadata)
 
 
 def text(
@@ -442,6 +465,7 @@ def text(
     *,
     name: str | None = None,
     group: str | None = None,
+    caption: str | None = None,
     format: Literal["plain", "markdown", "json"] | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
@@ -456,6 +480,9 @@ def text(
         Optional explicit local asset name.
     group : str | None
         Optional report grouping label.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output.
     format : {"plain", "markdown", "json"} | None
         Document format. Auto-detected from the payload when omitted.
     metadata : dict[str, Any] | None
@@ -465,7 +492,15 @@ def text(
     -------
     AssetResult
     """
-    return asset(payload, kind="text", name=name, group=group, metadata=metadata, format=format)
+    return asset(
+        payload,
+        kind="text",
+        name=name,
+        group=group,
+        caption=caption,
+        metadata=metadata,
+        format=format,
+    )
 
 
 def model(
@@ -473,6 +508,7 @@ def model(
     *,
     name: str | None = None,
     group: str | None = None,
+    caption: str | None = None,
     framework: str | None = None,
     metrics: dict[str, float] | None = None,
     metadata: dict[str, Any] | None = None,
@@ -489,6 +525,9 @@ def model(
         Optional explicit local asset name.
     group : str | None
         Optional report grouping label.
+    caption : str | None
+        Optional human-readable annotation shown in reports and asset
+        inspection output.
     framework : str | None
         Optional explicit framework override, bypassing module-based
         detection. Must be one of ``"sklearn"``, ``"xgboost"``,
@@ -509,6 +548,7 @@ def model(
         kind="model",
         name=name,
         group=group,
+        caption=caption,
         metadata=metadata,
         framework=framework,
         metrics=metrics,

--- a/src/ginkgo/core/asset.py
+++ b/src/ginkgo/core/asset.py
@@ -160,6 +160,9 @@ class AssetResult:
     name : str | None
         Optional explicit local asset name. When omitted, the evaluator
         assigns a name based on the producing task function.
+    group : str | None
+        Optional report grouping label. This affects presentation only and
+        does not participate in asset identity.
     metadata : dict[str, Any]
         Optional user-supplied metadata stored on the asset version.
     kind_fields : dict[str, Any]
@@ -174,6 +177,7 @@ class AssetResult:
     kind: AssetKind = "file"
     sub_kind: str | None = None
     name: str | None = None
+    group: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     kind_fields: dict[str, Any] = field(default_factory=dict)
 
@@ -289,6 +293,7 @@ def asset(
     *,
     kind: AssetKind = "file",
     name: str | None = None,
+    group: str | None = None,
     metadata: dict[str, Any] | None = None,
     **kind_fields: Any,
 ) -> AssetResult:
@@ -311,6 +316,9 @@ def asset(
         /``model``).
     name : str | None
         Optional explicit local asset name.
+    group : str | None
+        Optional report grouping label. Grouping is persisted with the asset
+        version but does not affect the stable asset key.
     metadata : dict[str, Any] | None
         Optional user-supplied metadata persisted on the asset version.
     **kind_fields : Any
@@ -338,6 +346,7 @@ def asset(
         kind=kind,
         sub_kind=sub_kind,
         name=name,
+        group=group.strip() if isinstance(group, str) and group.strip() else None,
         metadata=dict(metadata or {}),
         kind_fields=extra_kind_fields,
     )
@@ -347,6 +356,7 @@ def table(
     payload: Any,
     *,
     name: str | None = None,
+    group: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
     """Wrap a tabular value as an asset return.
@@ -359,6 +369,8 @@ def table(
         a path to a CSV/TSV file.
     name : str | None
         Optional explicit local asset name.
+    group : str | None
+        Optional report grouping label.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
 
@@ -366,13 +378,14 @@ def table(
     -------
     AssetResult
     """
-    return asset(payload, kind="table", name=name, metadata=metadata)
+    return asset(payload, kind="table", name=name, group=group, metadata=metadata)
 
 
 def array(
     payload: Any,
     *,
     name: str | None = None,
+    group: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
     """Wrap an n-dimensional array value as an asset return.
@@ -384,6 +397,8 @@ def array(
         DataArray/Dataset, zarr array/group, and dask array.
     name : str | None
         Optional explicit local asset name.
+    group : str | None
+        Optional report grouping label.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
 
@@ -391,13 +406,14 @@ def array(
     -------
     AssetResult
     """
-    return asset(payload, kind="array", name=name, metadata=metadata)
+    return asset(payload, kind="array", name=name, group=group, metadata=metadata)
 
 
 def fig(
     payload: Any,
     *,
     name: str | None = None,
+    group: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
     """Wrap a figure or plot value as an asset return.
@@ -409,6 +425,8 @@ def fig(
         bokeh Figure, or a path to an existing PNG/SVG/HTML file.
     name : str | None
         Optional explicit local asset name.
+    group : str | None
+        Optional report grouping label.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
 
@@ -416,13 +434,14 @@ def fig(
     -------
     AssetResult
     """
-    return asset(payload, kind="fig", name=name, metadata=metadata)
+    return asset(payload, kind="fig", name=name, group=group, metadata=metadata)
 
 
 def text(
     payload: Any,
     *,
     name: str | None = None,
+    group: str | None = None,
     format: Literal["plain", "markdown", "json"] | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> AssetResult:
@@ -435,6 +454,8 @@ def text(
         serialised as JSON; strings are stored as the requested format.
     name : str | None
         Optional explicit local asset name.
+    group : str | None
+        Optional report grouping label.
     format : {"plain", "markdown", "json"} | None
         Document format. Auto-detected from the payload when omitted.
     metadata : dict[str, Any] | None
@@ -444,13 +465,14 @@ def text(
     -------
     AssetResult
     """
-    return asset(payload, kind="text", name=name, metadata=metadata, format=format)
+    return asset(payload, kind="text", name=name, group=group, metadata=metadata, format=format)
 
 
 def model(
     payload: Any,
     *,
     name: str | None = None,
+    group: str | None = None,
     framework: str | None = None,
     metrics: dict[str, float] | None = None,
     metadata: dict[str, Any] | None = None,
@@ -465,6 +487,8 @@ def model(
         ``nn.Module`` instances, and Keras/TensorFlow models.
     name : str | None
         Optional explicit local asset name.
+    group : str | None
+        Optional report grouping label.
     framework : str | None
         Optional explicit framework override, bypassing module-based
         detection. Must be one of ``"sklearn"``, ``"xgboost"``,
@@ -484,6 +508,7 @@ def model(
         payload,
         kind="model",
         name=name,
+        group=group,
         metadata=metadata,
         framework=framework,
         metrics=metrics,

--- a/src/ginkgo/reporting/model.py
+++ b/src/ginkgo/reporting/model.py
@@ -17,7 +17,10 @@ from typing import Any
 from ginkgo.core.asset import AssetKey, AssetVersion
 from ginkgo.runtime.artifacts.artifact_model import ArtifactRecord
 from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
-from ginkgo.runtime.artifacts.asset_registration import ASSET_GROUP_METADATA_KEY
+from ginkgo.runtime.artifacts.asset_registration import (
+    ASSET_CAPTION_METADATA_KEY,
+    ASSET_GROUP_METADATA_KEY,
+)
 from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.runtime.run_summary import RunSummary, TaskSummary
 
@@ -187,6 +190,7 @@ class AssetCard:
 
     asset_key: str
     name: str
+    caption: str | None
     namespace: str
     kind_label: str
     kind_tone: str
@@ -807,6 +811,7 @@ def _build_asset_card(
     return AssetCard(
         asset_key=str(version.key),
         name=version.key.name,
+        caption=_asset_caption(metadata=version.metadata),
         namespace=namespace,
         kind_label=namespace,
         kind_tone=kind_tone,
@@ -1046,6 +1051,14 @@ def _asset_group_title(*, metadata: Mapping[str, Any]) -> str:
     if isinstance(group, str) and group.strip():
         return group.strip()
     return _DEFAULT_ASSET_SECTION_TITLE
+
+
+def _asset_caption(*, metadata: Mapping[str, Any]) -> str | None:
+    """Return the report caption for one asset version."""
+    caption = metadata.get(ASSET_CAPTION_METADATA_KEY)
+    if isinstance(caption, str) and caption.strip():
+        return caption.strip()
+    return None
 
 
 def _parse_asset_key(text: str) -> AssetKey:

--- a/src/ginkgo/reporting/model.py
+++ b/src/ginkgo/reporting/model.py
@@ -15,9 +15,10 @@ from pathlib import Path
 from typing import Any
 
 from ginkgo.core.asset import AssetKey, AssetVersion
-from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
-from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.runtime.artifacts.artifact_model import ArtifactRecord
+from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
+from ginkgo.runtime.artifacts.asset_registration import ASSET_GROUP_METADATA_KEY
+from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.runtime.run_summary import RunSummary, TaskSummary
 
 from .sizing import (
@@ -195,6 +196,14 @@ class AssetCard:
     preview: AssetPreview
 
 
+@dataclass(frozen=True, kw_only=True)
+class AssetSection:
+    """Named report section containing related asset cards."""
+
+    title: str
+    cards: tuple[AssetCard, ...]
+
+
 # ----- Notebook ----------------------------------------------------------
 
 
@@ -263,7 +272,7 @@ class ReportData:
     graph: Graph
     tasks: tuple[TaskRow, ...]
     failures: tuple[FailureCard, ...]
-    assets: tuple[AssetCard, ...]
+    assets: tuple[AssetSection, ...]
     notebooks: tuple[NotebookCard, ...]
     environment: tuple[KVEntry, ...]
 
@@ -523,6 +532,7 @@ _GRAPH_NODE_W = 150
 _GRAPH_NODE_H = 40
 _GRAPH_MARGIN_X = 24
 _GRAPH_MARGIN_Y = 24
+_DEFAULT_ASSET_SECTION_TITLE = "Ungrouped assets"
 
 
 def _build_graph(*, summary: RunSummary, failures: tuple[FailureCard, ...]) -> Graph:
@@ -717,7 +727,7 @@ def _build_assets(
     artifact_store: LocalArtifactStore | None,
     policy: SizingPolicy,
     artifact_copies: list[ArtifactCopy],
-) -> tuple[AssetCard, ...]:
+) -> tuple[AssetSection, ...]:
     """Build asset cards for every asset referenced by this run.
 
     A task reference cites ``(asset_key, version_id)``. Cached tasks replay
@@ -730,7 +740,7 @@ def _build_assets(
 
     store = AssetStore(root=assets_root)
     seen_version_ids: set[str] = set()
-    cards: list[AssetCard] = []
+    cards_by_section: dict[str, list[AssetCard]] = {}
 
     references: list[tuple[str, str]] = []
     for task in summary.tasks:
@@ -755,10 +765,14 @@ def _build_assets(
             artifact_copies=artifact_copies,
         )
         if card is not None:
-            cards.append(card)
+            section_title = _asset_group_title(metadata=version.metadata)
+            cards_by_section.setdefault(section_title, []).append(card)
 
-    cards.sort(key=lambda card: (card.namespace, card.name))
-    return tuple(cards)
+    sections: list[AssetSection] = []
+    for title, cards in cards_by_section.items():
+        cards.sort(key=lambda card: (card.namespace, card.name))
+        sections.append(AssetSection(title=title, cards=tuple(cards)))
+    return tuple(sections)
 
 
 def _build_asset_card(
@@ -1026,6 +1040,14 @@ def _model_stats(*, metadata: Mapping[str, Any]) -> tuple[AssetStat, ...]:
     return tuple(stats)
 
 
+def _asset_group_title(*, metadata: Mapping[str, Any]) -> str:
+    """Return the report section title for one asset version."""
+    group = metadata.get(ASSET_GROUP_METADATA_KEY)
+    if isinstance(group, str) and group.strip():
+        return group.strip()
+    return _DEFAULT_ASSET_SECTION_TITLE
+
+
 def _parse_asset_key(text: str) -> AssetKey:
     """Parse ``namespace:name`` into an :class:`AssetKey`."""
     namespace, sep, name = text.partition(":")
@@ -1101,7 +1123,7 @@ def _build_notebooks(
 
 
 def _build_summary_cards(
-    *, summary: RunSummary, assets: tuple[AssetCard, ...]
+    *, summary: RunSummary, assets: tuple[AssetSection, ...]
 ) -> tuple[StatCard, ...]:
     """Headline stats shown above the fold."""
     total_tasks = summary.task_count
@@ -1118,8 +1140,11 @@ def _build_summary_cards(
     tasks_sub = " · ".join(tasks_sub_parts) or "no tasks"
 
     asset_namespaces: dict[str, int] = defaultdict(int)
-    for card in assets:
-        asset_namespaces[card.namespace] += 1
+    asset_count = 0
+    for section in assets:
+        for card in section.cards:
+            asset_count += 1
+            asset_namespaces[card.namespace] += 1
     assets_sub = (
         " · ".join(
             f"{count} {name}"
@@ -1151,7 +1176,7 @@ def _build_summary_cards(
         ),
         StatCard(
             label="Assets",
-            value=format_int(len(assets)),
+            value=format_int(asset_count),
             sub=assets_sub,
             tone="neutral",
         ),

--- a/src/ginkgo/reporting/static/report.css
+++ b/src/ginkgo/reporting/static/report.css
@@ -756,6 +756,14 @@ pre.log {
   color: var(--ink);
 }
 
+.asset-head .caption {
+  max-width: 680px;
+  margin: 6px 0 0 0;
+  color: var(--ink-soft);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .asset-head .meta {
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;

--- a/src/ginkgo/reporting/static/report.css
+++ b/src/ginkgo/reporting/static/report.css
@@ -717,6 +717,19 @@ pre.log {
 
 /* ========== Asset cards ========== */
 
+.asset-section {
+  margin: 22px 0 30px;
+}
+
+.asset-section h3 {
+  margin: 0 0 12px;
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 18, "WONK" 1;
+  font-size: 22px;
+  font-weight: 550;
+  color: var(--ink);
+}
+
 .asset {
   background: var(--paper-raised);
   border: 1px solid var(--rule);

--- a/src/ginkgo/reporting/templates/_assets.html.j2
+++ b/src/ginkgo/reporting/templates/_assets.html.j2
@@ -9,6 +9,9 @@
     <div>
       <span class="kind-badge kind-{{ card.kind_tone }}">{{ card.kind_label }}</span>
       <span class="name">{{ card.name }}</span>
+      {% if card.caption %}
+      <div class="caption">{{ card.caption }}</div>
+      {% endif %}
     </div>
     <div class="meta">{{ card.meta_line }}</div>
   </div>

--- a/src/ginkgo/reporting/templates/_assets.html.j2
+++ b/src/ginkgo/reporting/templates/_assets.html.j2
@@ -1,6 +1,9 @@
 <h2 id="assets"><span class="num">06</span>Assets</h2>
 {% if report.assets %}
-  {% for card in report.assets %}
+  {% for section in report.assets %}
+<section class="asset-section">
+  <h3>{{ section.title }}</h3>
+    {% for card in section.cards %}
 <div class="asset">
   <div class="asset-head">
     <div>
@@ -66,6 +69,8 @@
     {% endif %}
   </div>
 </div>
+    {% endfor %}
+</section>
   {% endfor %}
 {% else %}
 <p class="empty">No assets produced by this run.</p>

--- a/src/ginkgo/runtime/artifacts/asset_registration.py
+++ b/src/ginkgo/runtime/artifacts/asset_registration.py
@@ -39,6 +39,7 @@ from ginkgo.runtime.caching.cache import CacheStore
 
 
 ASSET_GROUP_METADATA_KEY = "ginkgo_group"
+ASSET_CAPTION_METADATA_KEY = "ginkgo_caption"
 
 
 def asset_key_for_result(*, name: str, kind: str) -> AssetKey:
@@ -332,16 +333,20 @@ def _current_index_for(
 
 
 def _metadata_with_group(*, metadata: dict[str, Any], result: AssetResult) -> dict[str, Any]:
-    """Return version metadata including any report grouping label."""
+    """Return version metadata including report presentation labels."""
     version_metadata = dict(metadata)
     if result.group is not None:
         version_metadata[ASSET_GROUP_METADATA_KEY] = result.group
+    if result.caption is not None:
+        version_metadata[ASSET_CAPTION_METADATA_KEY] = result.caption
     return version_metadata
 
 
 # Re-export for callers that used to import from asset_registration.
 __all__ = [
     "AssetRegistrar",
+    "ASSET_CAPTION_METADATA_KEY",
+    "ASSET_GROUP_METADATA_KEY",
     "AssetSerializationError",
     "asset_index_for",
     "asset_key_for_result",

--- a/src/ginkgo/runtime/artifacts/asset_registration.py
+++ b/src/ginkgo/runtime/artifacts/asset_registration.py
@@ -38,6 +38,9 @@ from ginkgo.runtime.artifacts.live_payloads import LivePayloadRegistry
 from ginkgo.runtime.caching.cache import CacheStore
 
 
+ASSET_GROUP_METADATA_KEY = "ginkgo_group"
+
+
 def asset_key_for_result(*, name: str, kind: str) -> AssetKey:
     """Build one asset key for a supported asset result.
 
@@ -246,7 +249,7 @@ class AssetRegistrar:
         # 1. Resolve the local asset name using the kind's strategy.
         if spec.default_name_strategy == "task_name":
             asset_name = result.name or task_fn_name
-            version_metadata = dict(result.metadata)
+            version_metadata = _metadata_with_group(metadata=result.metadata, result=result)
             # File assets carry no serializer; the registrar copies bytes
             # directly from the declared source path.
             record = self._store_file_content(node=node, result=result)
@@ -258,7 +261,7 @@ class AssetRegistrar:
                 data=serialized.data,
                 extension=serialized.extension,
             )
-            version_metadata = dict(serialized.metadata)
+            version_metadata = _metadata_with_group(metadata=serialized.metadata, result=result)
 
         # 2. Build and register the immutable version record.
         version = make_asset_version(
@@ -326,6 +329,14 @@ def _current_index_for(
     if result.name is not None:
         return -1
     return max(0, state.kind_counters.get(result.kind, 1) - 1)
+
+
+def _metadata_with_group(*, metadata: dict[str, Any], result: AssetResult) -> dict[str, Any]:
+    """Return version metadata including any report grouping label."""
+    version_metadata = dict(metadata)
+    if result.group is not None:
+        version_metadata[ASSET_GROUP_METADATA_KEY] = result.group
+    return version_metadata
 
 
 # Re-export for callers that used to import from asset_registration.

--- a/src/ginkgo/runtime/artifacts/value_codec.py
+++ b/src/ginkgo/runtime/artifacts/value_codec.py
@@ -91,6 +91,7 @@ def encode_value(
             "__ginkgo_type__": "asset_result",
             "name": value.name,
             "group": value.group,
+            "caption": value.caption,
             "kind": value.kind,
             "sub_kind": value.sub_kind,
             "metadata": dict(value.metadata),
@@ -211,6 +212,7 @@ def decode_value(
             payload=decoded_payload,
             name=payload.get("name"),
             group=payload.get("group"),
+            caption=payload.get("caption"),
             kind=cast(AssetKind, payload.get("kind", "file")),
             sub_kind=payload.get("sub_kind"),
             metadata=dict(payload.get("metadata", {})),
@@ -271,6 +273,7 @@ def summarise_value(value: Any) -> Any:
             "kind": value.kind,
             "name": value.name,
             "group": value.group,
+            "caption": value.caption,
         }
     if isinstance(value, list):
         return {

--- a/src/ginkgo/runtime/artifacts/value_codec.py
+++ b/src/ginkgo/runtime/artifacts/value_codec.py
@@ -7,12 +7,12 @@ import io
 import logging
 import pickle
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
 
-from ginkgo.core.asset import AssetRef, AssetResult
+from ginkgo.core.asset import AssetKind, AssetRef, AssetResult
 from ginkgo.core.types import file, folder, tmp_dir
 
 if TYPE_CHECKING:
@@ -90,6 +90,7 @@ def encode_value(
         return {
             "__ginkgo_type__": "asset_result",
             "name": value.name,
+            "group": value.group,
             "kind": value.kind,
             "sub_kind": value.sub_kind,
             "metadata": dict(value.metadata),
@@ -209,7 +210,8 @@ def decode_value(
         return AssetResult(
             payload=decoded_payload,
             name=payload.get("name"),
-            kind=str(payload.get("kind", "file")),
+            group=payload.get("group"),
+            kind=cast(AssetKind, payload.get("kind", "file")),
             sub_kind=payload.get("sub_kind"),
             metadata=dict(payload.get("metadata", {})),
             kind_fields=dict(payload.get("kind_fields", {})),
@@ -268,6 +270,7 @@ def summarise_value(value: Any) -> Any:
             "type": "asset_result",
             "kind": value.kind,
             "name": value.name,
+            "group": value.group,
         }
     if isinstance(value, list):
         return {

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -43,11 +43,18 @@ class TestFactories:
 
     def test_asset_table_equivalent_to_table_factory(self) -> None:
         frame = pd.DataFrame({"a": [1, 2]})
-        via_asset = ginkgo.asset(frame, kind="table", name="features")
-        via_shorthand = table(frame, name="features")
+        via_asset = ginkgo.asset(frame, kind="table", name="features", group="QC metrics")
+        via_shorthand = table(frame, name="features", group="QC metrics")
         assert via_asset.kind == via_shorthand.kind == "table"
         assert via_asset.sub_kind == via_shorthand.sub_kind == "pandas"
         assert via_asset.name == via_shorthand.name == "features"
+        assert via_asset.group == via_shorthand.group == "QC metrics"
+
+    def test_group_label_is_normalized(self) -> None:
+        grouped = table(pd.DataFrame({"a": [1]}), group="  QC metrics  ")
+        ungrouped = table(pd.DataFrame({"a": [1]}), group="  ")
+        assert grouped.group == "QC metrics"
+        assert ungrouped.group is None
 
     def test_table_csv_path_detection(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "data.csv"
@@ -286,6 +293,15 @@ def make_table_task() -> object:
 
 
 @task()
+def make_grouped_table_task() -> object:
+    return table(
+        pd.DataFrame({"a": [1]}),
+        name="features",
+        group="QC metrics",
+    )
+
+
+@task()
 def make_positional_tables_task() -> object:
     return [
         table(pd.DataFrame({"x": [1]})),
@@ -340,6 +356,16 @@ class TestEvaluatorIntegration:
         assert result.key.namespace == "table"
         assert result.key.name == "make_table_task.features"
         assert result.metadata["row_count"] == 2
+
+    def test_grouped_asset_persists_group_metadata(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = ginkgo.evaluate(make_grouped_table_task())
+        assert isinstance(result, AssetRef)
+        assert result.key.namespace == "table"
+        assert result.key.name == "make_grouped_table_task.features"
+        assert result.metadata["ginkgo_group"] == "QC metrics"
 
     def test_positional_tables_index_per_kind(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -43,18 +43,36 @@ class TestFactories:
 
     def test_asset_table_equivalent_to_table_factory(self) -> None:
         frame = pd.DataFrame({"a": [1, 2]})
-        via_asset = ginkgo.asset(frame, kind="table", name="features", group="QC metrics")
-        via_shorthand = table(frame, name="features", group="QC metrics")
+        via_asset = ginkgo.asset(
+            frame,
+            kind="table",
+            name="features",
+            group="QC metrics",
+            caption="Variant counts after QC filtering",
+        )
+        via_shorthand = table(
+            frame,
+            name="features",
+            group="QC metrics",
+            caption="Variant counts after QC filtering",
+        )
         assert via_asset.kind == via_shorthand.kind == "table"
         assert via_asset.sub_kind == via_shorthand.sub_kind == "pandas"
         assert via_asset.name == via_shorthand.name == "features"
         assert via_asset.group == via_shorthand.group == "QC metrics"
+        assert via_asset.caption == via_shorthand.caption == "Variant counts after QC filtering"
 
-    def test_group_label_is_normalized(self) -> None:
-        grouped = table(pd.DataFrame({"a": [1]}), group="  QC metrics  ")
-        ungrouped = table(pd.DataFrame({"a": [1]}), group="  ")
+    def test_presentation_labels_are_normalized(self) -> None:
+        grouped = table(
+            pd.DataFrame({"a": [1]}),
+            group="  QC metrics  ",
+            caption="  Variant counts after QC filtering  ",
+        )
+        ungrouped = table(pd.DataFrame({"a": [1]}), group="  ", caption="  ")
         assert grouped.group == "QC metrics"
+        assert grouped.caption == "Variant counts after QC filtering"
         assert ungrouped.group is None
+        assert ungrouped.caption is None
 
     def test_table_csv_path_detection(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "data.csv"
@@ -298,6 +316,7 @@ def make_grouped_table_task() -> object:
         pd.DataFrame({"a": [1]}),
         name="features",
         group="QC metrics",
+        caption="Variant counts after QC filtering",
     )
 
 
@@ -366,6 +385,7 @@ class TestEvaluatorIntegration:
         assert result.key.namespace == "table"
         assert result.key.name == "make_grouped_table_task.features"
         assert result.metadata["ginkgo_group"] == "QC metrics"
+        assert result.metadata["ginkgo_caption"] == "Variant counts after QC filtering"
 
     def test_positional_tables_index_per_kind(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -487,6 +507,27 @@ class TestAssetShow:
         assert "make_table_task.features" in output
         assert "Row count" in output
         assert "Column" in output  # schema table header
+
+    def test_show_renders_caption(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        ginkgo.evaluate(make_grouped_table_task())
+
+        from ginkgo.cli.app import main
+
+        rc = main(
+            [
+                "asset",
+                "show",
+                "table:make_grouped_table_task.features",
+            ]
+        )
+
+        assert rc == 0
+        output = capsys.readouterr().out
+        assert "Caption:" in output
+        assert "Variant counts after QC filtering" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -115,6 +115,7 @@ def _register_asset(
     name: str = "demo/output",
     text: str = "alpha\nbeta\ngamma\n",
     group: str | None = None,
+    caption: str | None = None,
     append: bool = False,
 ) -> None:
     """Register a file asset and patch the manifest to reference it."""
@@ -126,6 +127,8 @@ def _register_asset(
     metadata = {"stage": "demo"}
     if group is not None:
         metadata["ginkgo_group"] = group
+    if caption is not None:
+        metadata["ginkgo_caption"] = caption
     version = make_asset_version(
         key=AssetKey(namespace="file", name=name),
         kind="file",
@@ -264,6 +267,7 @@ class TestReportData:
             name="demo/qc-a",
             text="qc a\n",
             group="QC metrics",
+            caption="Variant counts after QC filtering",
             append=True,
         )
         _register_asset(
@@ -286,6 +290,8 @@ class TestReportData:
             "file:demo/qc-a",
             "file:demo/qc-b",
         ]
+        assert report.assets[1].cards[0].caption == "Variant counts after QC filtering"
+        assert report.assets[1].cards[1].caption is None
         asset_card = next(card for card in report.summary_cards if card.label == "Assets")
         assert asset_card.value == "3"
 
@@ -343,6 +349,7 @@ class TestExport:
             name="demo/qc",
             text="qc\n",
             group="QC metrics",
+            caption="Variant counts after QC filtering",
             append=True,
         )
         result = export_report(run_dir=run_dir, out_dir=tmp_path / "out")
@@ -350,6 +357,7 @@ class TestExport:
         html = result.index_path.read_text(encoding="utf-8")
         assert "<h3>Ungrouped assets</h3>" in html
         assert "<h3>QC metrics</h3>" in html
+        assert "Variant counts after QC filtering" in html
 
     def test_failure_section_present_only_when_failures_exist(self, tmp_path: Path) -> None:
         ok_run = _make_run(tmp_path=tmp_path, run_id="run-ok", fail=False)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -107,38 +107,50 @@ def _make_run(
     return recorder.run_dir
 
 
-def _register_asset(*, tmp_path: Path, run_id: str, run_dir: Path) -> None:
+def _register_asset(
+    *,
+    tmp_path: Path,
+    run_id: str,
+    run_dir: Path,
+    name: str = "demo/output",
+    text: str = "alpha\nbeta\ngamma\n",
+    group: str | None = None,
+    append: bool = False,
+) -> None:
     """Register a file asset and patch the manifest to reference it."""
     asset_store = AssetStore(root=tmp_path / ".ginkgo" / "assets")
     artifact_store = LocalArtifactStore(root=tmp_path / ".ginkgo" / "artifacts")
-    source = tmp_path / "a.txt"
-    source.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    source = tmp_path / f"{name.replace('/', '_')}.txt"
+    source.write_text(text, encoding="utf-8")
     record = artifact_store.store(src_path=source)
+    metadata = {"stage": "demo"}
+    if group is not None:
+        metadata["ginkgo_group"] = group
     version = make_asset_version(
-        key=AssetKey(namespace="file", name="demo/output"),
+        key=AssetKey(namespace="file", name=name),
         kind="file",
         artifact_id=record.artifact_id,
         content_hash=record.digest_hex,
         run_id=run_id,
         producer_task="demo.first",
-        metadata={"stage": "demo"},
+        metadata=metadata,
     )
     asset_store.register_version(version=version)
 
     manifest_path = run_dir / "manifest.yaml"
     manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
     task_0 = manifest["tasks"]["task_0000"]
-    task_0["assets"] = [
-        {
-            "asset_key": str(version.key),
-            "version_id": version.version_id,
-            "artifact_id": version.artifact_id,
-            "name": version.key.name,
-            "namespace": version.key.namespace,
-            "kind": "file",
-            "metadata": dict(version.metadata),
-        }
-    ]
+    rendered = {
+        "asset_key": str(version.key),
+        "version_id": version.version_id,
+        "artifact_id": version.artifact_id,
+        "name": version.key.name,
+        "namespace": version.key.namespace,
+        "kind": "file",
+        "metadata": dict(version.metadata),
+    }
+    existing = task_0.get("assets", []) if append else []
+    task_0["assets"] = [*existing, rendered]
     manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
 
 
@@ -237,10 +249,45 @@ class TestReportData:
         assert labels == ["Tasks", "Failures", "Assets", "Cache hits"]
         # Asset card surfaced.
         assert len(report.assets) == 1
-        assert report.assets[0].asset_key == "file:demo/output"
+        assert report.assets[0].title == "Ungrouped assets"
+        assert report.assets[0].cards[0].asset_key == "file:demo/output"
         # Masthead KV includes the status pill row.
         status_entries = [kv for kv in report.masthead_kv if kv.key == "status"]
         assert len(status_entries) == 1
+
+    def test_grouped_assets_render_in_named_sections(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path=tmp_path, run_id="run-assets", fail=False)
+        _register_asset(
+            tmp_path=tmp_path,
+            run_id="run-assets",
+            run_dir=run_dir,
+            name="demo/qc-a",
+            text="qc a\n",
+            group="QC metrics",
+            append=True,
+        )
+        _register_asset(
+            tmp_path=tmp_path,
+            run_id="run-assets",
+            run_dir=run_dir,
+            name="demo/qc-b",
+            text="qc b\n",
+            group="QC metrics",
+            append=True,
+        )
+
+        report = build_report_data(run_dir=run_dir)
+
+        assert [section.title for section in report.assets] == [
+            "Ungrouped assets",
+            "QC metrics",
+        ]
+        assert [card.asset_key for card in report.assets[1].cards] == [
+            "file:demo/qc-a",
+            "file:demo/qc-b",
+        ]
+        asset_card = next(card for card in report.summary_cards if card.label == "Assets")
+        assert asset_card.value == "3"
 
     def test_failed_run_produces_failure_card(self, tmp_path: Path) -> None:
         run_dir = _make_run(tmp_path=tmp_path, run_id="run-fail", fail=True)
@@ -285,6 +332,24 @@ class TestExport:
         assert "01</span>Summary" in html
         assert "first" in html
         assert "second" in html
+        assert "<h3>Ungrouped assets</h3>" in html
+
+    def test_bundle_mode_renders_grouped_asset_sections(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path=tmp_path, run_id="run-assets", fail=False)
+        _register_asset(
+            tmp_path=tmp_path,
+            run_id="run-assets",
+            run_dir=run_dir,
+            name="demo/qc",
+            text="qc\n",
+            group="QC metrics",
+            append=True,
+        )
+        result = export_report(run_dir=run_dir, out_dir=tmp_path / "out")
+
+        html = result.index_path.read_text(encoding="utf-8")
+        assert "<h3>Ungrouped assets</h3>" in html
+        assert "<h3>QC metrics</h3>" in html
 
     def test_failure_section_present_only_when_failures_exist(self, tmp_path: Path) -> None:
         ok_run = _make_run(tmp_path=tmp_path, run_id="run-ok", fail=False)

--- a/tests/test_value_codec.py
+++ b/tests/test_value_codec.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from ginkgo.core.asset import AssetKey, AssetRef
+from ginkgo.core.asset import AssetKey, AssetRef, table
 from ginkgo.runtime.artifacts.value_codec import decode_value, encode_value, hash_value_bytes
 
 
@@ -28,6 +28,16 @@ class TestHashValueBytes:
         assert codec_name == "ginkgo.asset_ref"
         assert digest
         assert decoded == value
+
+    def test_asset_result_roundtrip_preserves_group(self, tmp_path) -> None:
+        value = table(pd.DataFrame({"a": [1]}), name="features", group="QC metrics")
+
+        encoded = encode_value(value, base_dir=tmp_path)
+        decoded = decode_value(encoded, base_dir=tmp_path)
+
+        assert decoded.kind == "table"
+        assert decoded.name == "features"
+        assert decoded.group == "QC metrics"
 
     def test_numpy_hash_is_stable_for_equal_values_with_different_layouts(self) -> None:
         base = np.arange(12, dtype=np.int64).reshape(3, 4)

--- a/tests/test_value_codec.py
+++ b/tests/test_value_codec.py
@@ -30,7 +30,12 @@ class TestHashValueBytes:
         assert decoded == value
 
     def test_asset_result_roundtrip_preserves_group(self, tmp_path) -> None:
-        value = table(pd.DataFrame({"a": [1]}), name="features", group="QC metrics")
+        value = table(
+            pd.DataFrame({"a": [1]}),
+            name="features",
+            group="QC metrics",
+            caption="Variant counts after QC filtering",
+        )
 
         encoded = encode_value(value, base_dir=tmp_path)
         decoded = decode_value(encoded, base_dir=tmp_path)
@@ -38,6 +43,7 @@ class TestHashValueBytes:
         assert decoded.kind == "table"
         assert decoded.name == "features"
         assert decoded.group == "QC metrics"
+        assert decoded.caption == "Variant counts after QC filtering"
 
     def test_numpy_hash_is_stable_for_equal_values_with_different_layouts(self) -> None:
         base = np.arange(12, dtype=np.int64).reshape(3, 4)


### PR DESCRIPTION
## Summary

This PR adds two presentation features for assets in reports and CLI inspection:

- grouped asset sections for `ginkgo report` via `group=`
- human-readable asset captions/descriptions via `caption=`

Workflow authors can now annotate assets like this:

```python
return table(
    df,
    name="qc_metrics",
    group="QC metrics",
    caption="Variant counts after QC filtering.",
)
return fig(
    plot,
    name="pca",
    group="Population structure",
    caption="PCA of samples coloured by population.",
)
return model(
    clf,
    name="classifier",
    group="Model outputs",
    caption="Classifier trained on the filtered feature matrix.",
)
```

Assets with the same group are rendered together under a named heading in `ginkgo report`. Assets without a group are rendered under the default `Ungrouped assets` section. Captions render as subtitles beneath the asset name in each report card and are also shown by `ginkgo asset show`.

Fixes #72
Fixes #73

## User-facing API

The new keywords are available on the canonical constructor and all shorthand factories:

- `asset(payload, kind=..., name=..., group=..., caption=..., metadata=...)`
- `table(payload, name=..., group=..., caption=..., metadata=...)`
- `array(payload, name=..., group=..., caption=..., metadata=...)`
- `fig(payload, name=..., group=..., caption=..., metadata=...)`
- `text(payload, name=..., group=..., caption=..., format=..., metadata=...)`
- `model(payload, name=..., group=..., caption=..., framework=..., metrics=..., metadata=...)`

Both fields are presentation-only. They do not change `AssetKey`, asset namespace, asset name, cache keys, artifact identity, or lineage.

Blank or whitespace-only labels are normalized to `None`:

- blank `group` falls back to `Ungrouped assets`
- blank `caption` is omitted from reports and CLI output

## Example report output

A workflow returning assets like this:

```python
return {
    "qc": table(
        qc_df,
        name="qc_metrics",
        group="QC metrics",
        caption="Variant counts after QC filtering.",
    ),
    "missingness": fig(
        missingness_plot,
        name="missingness",
        group="QC metrics",
        caption="Missingness rate by sample.",
    ),
    "pca": fig(
        pca_plot,
        name="pca",
        group="Population structure",
        caption="PCA of samples coloured by population.",
    ),
    "notes": text(
        "run notes",
        name="notes",
        caption="Analyst notes for this run.",
    ),
}
```

will render the Assets section roughly like this:

```text
06 Assets

QC metrics
  [TABLE] qc_metrics
          Variant counts after QC filtering.
          1,240 rows · 8 columns

  [FIG]   missingness
          Missingness rate by sample.
          PNG · 128 KB

Population structure
  [FIG]   pca
          PCA of samples coloured by population.
          HTML figure · 420 KB

Ungrouped assets
  [TEXT]  notes
          Analyst notes for this run.
          plain text · 9 bytes
```

In the real HTML report, each group title is rendered as a subsection heading. Captions are rendered in the existing asset card header under the asset name, and the existing preview renderers remain unchanged: table previews, image previews, iframe figures, text previews, model metrics, truncation notices, and missing-artifact messages all continue to use the same card body.

## How it works

At construction time, `AssetResult` now carries optional `group` and `caption` fields. The value codec preserves both fields when task results cross process boundaries, so grouped/captioned assets work through the same execution path as ordinary assets.

At registration time, these fields are persisted into asset version metadata using reserved keys:

- `ginkgo_group`
- `ginkgo_caption`

Using reserved metadata keys avoids a catalog schema migration while keeping the fields attached to immutable asset versions. It also avoids colliding with user-owned metadata keys such as `group`, `stage`, `cohort`, or `caption`.

During report generation, `_build_assets()` resolves the asset versions referenced by the run manifest, builds normal `AssetCard` objects, then buckets them into `AssetSection` objects by `ginkgo_group`. Captions are lifted into `AssetCard.caption` from `ginkgo_caption`.

Section ordering follows first referenced asset version in the run manifest. Cards inside each section keep the existing deterministic sort by `(namespace, name)`. The report summary still counts individual assets, not sections.

`ginkgo asset show` now prints a `Caption:` line when `ginkgo_caption` is present.

## Documentation

Updated:

- `docs/architecture/assets.md`
- `docs/architecture/reporting.md`
- `docs/architecture/index.md`
- `docs/site/guide/assets.md`

## Tests

- `env -u VIRTUAL_ENV PYTHONPATH=src uv run pytest tests/test_assets.py tests/test_reporting.py tests/test_value_codec.py`
- `env -u VIRTUAL_ENV uv run ruff check src/ginkgo/cli/commands/asset.py src/ginkgo/core/asset.py src/ginkgo/runtime/artifacts/asset_registration.py src/ginkgo/runtime/artifacts/value_codec.py src/ginkgo/reporting/model.py tests/test_assets.py tests/test_reporting.py tests/test_value_codec.py`
- `pixi run ty check src/ginkgo/cli/commands/asset.py src/ginkgo/core/asset.py src/ginkgo/runtime/artifacts/asset_registration.py src/ginkgo/runtime/artifacts/value_codec.py src/ginkgo/reporting/model.py` reports the existing unrelated numpy `memoryview(ndarray)` diagnostics in `value_codec.py`
- pre-commit via `git commit` passed, including ruff, ty, and uncoded sync