### PR TITLE
Unify run-summary presentation on RunSummary + shared formatters (#79)

### DIFF
--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -38,7 +38,7 @@ out of scope.
 ginkgo/reporting/
 ├── __init__.py          # build_report_data, export_report, SizingPolicy
 ├── model.py             # ReportData dataclass + builder
-├── sizing.py            # per-kind caps, formatters, preview builders
+├── sizing.py            # per-kind caps and preview builders
 ├── render.py            # Jinja env, bundle writer, single-file writer
 ├── templates/
 │   ├── index.html.j2    # master document shell
@@ -79,6 +79,17 @@ UI server and CLI renderers) plus `AssetStore` and `LocalArtifactStore`
 for asset resolution. The UI server continues to build its own payloads
 from the same `RunSummary`; the two presentation layers diverge cleanly
 without duplicating parsing logic.
+
+`RunSummary` is the single source of truth for post-run derivation. The
+semantic transforms every read-only presenter needs — `failure_kind`,
+`kind_label`, `cache_label`, `attempts_label` — live as read-only
+properties on `TaskSummary` rather than being re-derived per consumer.
+Value-to-string formatting (`format_duration`, `format_bytes`,
+`format_timestamp`, `format_int`) is shared from `ginkgo/formatting.py`, so
+the CLI run-finish output and this report format identical values
+identically. Presentation *vocabulary* stays with each presenter: the CLI
+uses Rich styles and icons, the report uses tone tokens (`ok` / `fail` /
+`warn` / …); these legitimately differ and are not merged.
 
 Asset cards are grouped into `AssetSection` objects before rendering. The
 section title comes from the asset version metadata key `ginkgo_group`,

--- a/src/ginkgo/cli/commands/asset.py
+++ b/src/ginkgo/cli/commands/asset.py
@@ -134,16 +134,10 @@ def list_asset_rows(*, store: AssetStore) -> list[AssetListRow]:
 def parse_asset_key(value: str) -> AssetKey:
     """Parse a CLI asset key.
 
-    Accepts ``namespace:name`` or ``name``. Bare names default to ``file``.
+    Accepts ``namespace:name`` or ``name``. Bare names default to ``file``;
+    malformed input raises :class:`ValueError`.
     """
-    namespace, separator, name = value.partition(":")
-    if separator:
-        if not namespace or not name:
-            raise ValueError(f"Invalid asset key: {value!r}")
-        return AssetKey(namespace=namespace, name=name)
-    if not namespace:
-        raise ValueError(f"Invalid asset key: {value!r}")
-    return AssetKey(namespace="file", name=namespace)
+    return AssetKey.parse(value, strict=True)
 
 
 def parse_asset_selector(value: str) -> AssetSelector:

--- a/src/ginkgo/cli/commands/run.py
+++ b/src/ginkgo/cli/commands/run.py
@@ -14,7 +14,8 @@ from pathlib import Path
 from typing import Any
 
 from ginkgo.cli.common import RUNS_ROOT, RunMode, console
-from ginkgo.cli.renderers.common import environment_label, format_duration
+from ginkgo.cli.renderers.common import environment_label
+from ginkgo.formatting import format_duration
 from ginkgo.cli.renderers.dry_run import render_dry_run_plan
 from ginkgo.cli.renderers.jsonl import JsonlEventRenderer
 from ginkgo.cli.renderers.models import (

--- a/src/ginkgo/cli/renderers/common.py
+++ b/src/ginkgo/cli/renderers/common.py
@@ -10,6 +10,7 @@ from rich.console import Console, ConsoleOptions, RenderResult
 from rich.text import Text
 
 from ginkgo.cli.renderers.models import _TaskRow
+from ginkgo.formatting import format_duration
 
 
 def _status_style(status: str) -> str:
@@ -101,15 +102,6 @@ def _truncate_task_label(label: str, *, max_width: int) -> str:
     return f"{base[:head_width]}...{base[-tail_width:]}{suffix}"
 
 
-def format_duration(seconds: float) -> str:
-    """Return a compact human-readable duration string."""
-    if seconds < 1:
-        return f"{seconds:.2f}s"
-    if seconds < 10:
-        return f"{seconds:.1f}s"
-    return f"{seconds:.0f}s"
-
-
 def _time_of_day_spinner(now: datetime | None = None) -> str:
     """Return a day/night spinner name based on the local hour."""
     current = now if now is not None else datetime.now().astimezone()
@@ -187,22 +179,3 @@ class _MultiStateBar:
             text.append(_BAR_FILL_CHAR * w, style=_status_style(status))
 
         yield text
-
-
-def _format_bytes(value: int | float | None) -> str:
-    """Return a compact binary size string."""
-    if value is None:
-        return "--"
-
-    size = float(value)
-    units = ("B", "KiB", "MiB", "GiB", "TiB")
-    unit_index = 0
-    while size >= 1024 and unit_index < len(units) - 1:
-        size /= 1024
-        unit_index += 1
-
-    if unit_index == 0:
-        return f"{int(size)} {units[unit_index]}"
-    if size >= 10:
-        return f"{size:.0f} {units[unit_index]}"
-    return f"{size:.1f} {units[unit_index]}"

--- a/src/ginkgo/cli/renderers/run.py
+++ b/src/ginkgo/cli/renderers/run.py
@@ -19,10 +19,8 @@ from rich.text import Text
 
 from ginkgo.cli.renderers.common import (
     _MultiStateBar,
-    _format_bytes,
     _format_cpu_percent,
     _core_unit_label,
-    format_duration,
     _status_label,
     _status_text,
     task_base_name,
@@ -32,6 +30,7 @@ from ginkgo.cli.renderers.common import (
     _time_of_day_spinner,
     _truncate_task_label,
 )
+from ginkgo.formatting import format_bytes, format_duration
 from ginkgo.cli.renderers.models import (
     CliAssetSummary,
     FailureDetails,
@@ -368,7 +367,7 @@ class CliRunRenderer:
 
         return (
             f"CPU {_format_cpu_percent(_as_float(current.get('cpu_percent')))}   "
-            f"RSS {_format_bytes(_as_int(current.get('rss_bytes')))}   "
+            f"RSS {format_bytes(_as_int(current.get('rss_bytes')))}   "
             f"Procs {_format_count(current.get('process_count'))}"
         )
 
@@ -583,8 +582,8 @@ class CliRunRenderer:
 
         avg_cpu = _format_cpu_percent(_as_float(average.get("cpu_percent")))
         peak_cpu = _format_cpu_percent(_as_float(peak.get("cpu_percent")))
-        avg_rss = _format_bytes(_as_int(average.get("rss_bytes")))
-        peak_rss = _format_bytes(_as_int(peak.get("rss_bytes")))
+        avg_rss = format_bytes(_as_int(average.get("rss_bytes")))
+        peak_rss = format_bytes(_as_int(peak.get("rss_bytes")))
         return Text(
             f"CPU avg {avg_cpu}, peak {peak_cpu} | RSS avg {avg_rss}, peak {peak_rss}",
             style="dim",

--- a/src/ginkgo/core/asset.py
+++ b/src/ginkgo/core/asset.py
@@ -57,6 +57,37 @@ class AssetKey:
         """
         return cls(namespace=str(data["namespace"]), name=str(data["name"]))
 
+    @classmethod
+    def parse(cls, text: str, *, strict: bool = False) -> AssetKey:
+        """Parse a ``namespace:name`` (or bare ``name``) string.
+
+        Parameters
+        ----------
+        text : str
+            Key text. ``namespace:name`` yields an explicit key; a bare
+            ``name`` (no separator) defaults to the ``file`` namespace.
+        strict : bool
+            When True, malformed input (empty text, or a ``:`` with an empty
+            namespace or name) raises :class:`ValueError`. When False, such
+            input falls back to ``file:<text>``.
+
+        Returns
+        -------
+        AssetKey
+        """
+        namespace, separator, name = text.partition(":")
+        if separator:
+            if namespace and name:
+                return cls(namespace=namespace, name=name)
+            if strict:
+                raise ValueError(f"Invalid asset key: {text!r}")
+            return cls(namespace="file", name=text)
+        if namespace:
+            return cls(namespace="file", name=namespace)
+        if strict:
+            raise ValueError(f"Invalid asset key: {text!r}")
+        return cls(namespace="file", name=text)
+
     def __str__(self) -> str:
         """Render the canonical ``namespace:name`` string."""
         return f"{self.namespace}:{self.name}"

--- a/src/ginkgo/formatting.py
+++ b/src/ginkgo/formatting.py
@@ -1,0 +1,98 @@
+"""Canonical value formatters shared by every read-only presenter.
+
+The CLI run-finish output and the static HTML report both turn the same
+provenance values — durations, byte sizes, timestamps, counts — into
+strings. Keeping those transforms here means a formatting change happens in
+one place and cannot silently drift between the two surfaces.
+
+Presentation *vocabulary* (Rich styles and icons for the terminal, tone
+tokens for HTML) legitimately differs between presenters and stays with each
+one; only the value-to-string formatting is shared.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def format_duration(seconds: float | None) -> str:
+    """Return a compact duration label.
+
+    Parameters
+    ----------
+    seconds : float | None
+        Duration in seconds, or ``None`` for unknown.
+
+    Returns
+    -------
+    str
+        ``"4.2s"``, ``"2m 14s"``, ``"8h 03m 12s"``, or ``"—"`` when
+        ``seconds`` is ``None``.
+    """
+    if seconds is None:
+        return "—"
+    value = max(0.0, float(seconds))
+    if value < 60:
+        if value < 10:
+            return f"{value:.1f}s"
+        return f"{int(round(value))}s"
+    if value < 3600:
+        minutes = int(value // 60)
+        remaining = int(round(value - minutes * 60))
+        return f"{minutes}m {remaining:02d}s"
+    hours = int(value // 3600)
+    minutes = int((value - hours * 3600) // 60)
+    remaining = int(round(value - hours * 3600 - minutes * 60))
+    return f"{hours}h {minutes:02d}m {remaining:02d}s"
+
+
+def format_bytes(size_bytes: int | None) -> str:
+    """Return a compact byte-size label.
+
+    Parameters
+    ----------
+    size_bytes : int | None
+        Size in bytes, or ``None`` when unknown.
+
+    Returns
+    -------
+    str
+        Human-readable size (``"14.2 MB"``, ``"62 KB"``, ``"1.2 GB"``) or
+        ``"—"`` when the size is unknown.
+    """
+    if size_bytes is None:
+        return "—"
+    value = float(max(0, int(size_bytes)))
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{size_bytes} B"
+
+
+def format_timestamp(value: datetime | None) -> str:
+    """Return an ISO-like timestamp string in UTC.
+
+    Parameters
+    ----------
+    value : datetime | None
+        Timestamp to format, or ``None`` for unknown.
+
+    Returns
+    -------
+    str
+        ``"2026-04-18 14:32:07 UTC"`` or ``"—"``.
+    """
+    if value is None:
+        return "—"
+    aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return aware.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def format_int(value: int | None) -> str:
+    """Return an integer with thousands separators, or ``"—"``."""
+    if value is None:
+        return "—"
+    return f"{int(value):,}"

--- a/src/ginkgo/reporting/model.py
+++ b/src/ginkgo/reporting/model.py
@@ -22,6 +22,7 @@ from ginkgo.runtime.artifacts.asset_registration import (
     ASSET_GROUP_METADATA_KEY,
 )
 from ginkgo.runtime.artifacts.asset_store import AssetStore
+from ginkgo.formatting import format_bytes, format_duration, format_int, format_timestamp
 from ginkgo.runtime.run_summary import RunSummary, TaskSummary
 
 from .sizing import (
@@ -32,10 +33,6 @@ from .sizing import (
     build_log_tail,
     build_table_preview,
     build_text_preview,
-    format_bytes,
-    format_duration,
-    format_int,
-    format_timestamp,
 )
 
 
@@ -380,6 +377,7 @@ def build_report_data(
     assets_root = assets_root if assets_root is not None else workspace_root / "assets"
     artifacts_root = artifacts_root if artifacts_root is not None else workspace_root / "artifacts"
     workspace_label = workspace_label or workspace_root.parent.name
+    ginkgo_version = _resolve_ginkgo_version(ginkgo_version)
 
     artifact_store = LocalArtifactStore(root=artifacts_root) if artifacts_root.exists() else None
 
@@ -425,11 +423,9 @@ def build_report_data(
         workspace_label=workspace_label,
         status_label=status_label,
         status_tone=status_tone,
-        ginkgo_version=_resolve_ginkgo_version(ginkgo_version),
+        ginkgo_version=ginkgo_version,
     )
-    environment = _build_environment_kv(
-        summary=summary, ginkgo_version=_resolve_ginkgo_version(ginkgo_version)
-    )
+    environment = _build_environment_kv(summary=summary, ginkgo_version=ginkgo_version)
 
     return ReportData(
         run_id=summary.run_id,
@@ -456,7 +452,7 @@ def build_report_data(
         assets=assets,
         notebooks=notebooks,
         environment=environment,
-        ginkgo_version=_resolve_ginkgo_version(ginkgo_version),
+        ginkgo_version=ginkgo_version,
         generated_at_label=format_timestamp(generated_at or datetime.now(UTC)),
         artifact_copies=tuple(artifact_copies),
     )
@@ -469,62 +465,22 @@ def _build_task_rows(*, summary: RunSummary) -> tuple[TaskRow, ...]:
     """Build ordered task rows for the task ledger."""
     rows: list[TaskRow] = []
     for task in summary.tasks:
-        failed = task.status == "failed"
-        status_label = _STATUS_LABEL.get(task.status, task.status)
-        status_tone = _STATUS_TONE.get(task.status, "warn")
-        kind_label = _task_kind_label(task)
-        cache_label = _cache_label(task)
-        duration_label = format_duration(task.duration_s)
-        attempts_label = _attempts_label(task)
-
         rows.append(
             TaskRow(
                 task_key=task.task_key,
                 node_id=task.node_id,
                 name=task.name,
                 base_name=task.base_name,
-                kind_label=kind_label,
-                status_label=status_label,
-                status_tone=status_tone,
-                cache_label=cache_label,
-                duration_label=duration_label,
-                attempts_label=attempts_label,
-                failed=failed,
+                kind_label=task.kind_label,
+                status_label=_STATUS_LABEL.get(task.status, task.status),
+                status_tone=_STATUS_TONE.get(task.status, "warn"),
+                cache_label=task.cache_label,
+                duration_label=format_duration(task.duration_s),
+                attempts_label=task.attempts_label,
+                failed=task.status == "failed",
             )
         )
     return tuple(rows)
-
-
-def _task_kind_label(task: TaskSummary) -> str:
-    """Return a display label for the task kind."""
-    raw = task.raw.get("kind")
-    if isinstance(raw, str) and raw:
-        return raw
-    if task.task_type == "notebook":
-        return "notebook"
-    return "task"
-
-
-def _cache_label(task: TaskSummary) -> str:
-    """Return ``"hit"``, ``"miss"``, or ``"—"``."""
-    if task.cached or task.status == "cached":
-        return "hit"
-    if task.status in {"succeeded", "failed"}:
-        return "miss"
-    return "—"
-
-
-def _attempts_label(task: TaskSummary) -> str:
-    """Return ``"N"`` or ``"N / M"`` for attempts / max_attempts."""
-    attempts = task.raw.get("attempts")
-    max_attempts = task.raw.get("max_attempts")
-    if task.status == "cached":
-        return "—"
-    if isinstance(attempts, int) and isinstance(max_attempts, int) and max_attempts > 1:
-        return f"{attempts + 1} / {max_attempts}"
-    if isinstance(attempts, int):
-        return f"{attempts + 1}"
-    return "1"
 
 
 # ----- Graph --------------------------------------------------------------
@@ -681,11 +637,7 @@ def _build_failures(
     """Build one :class:`FailureCard` per failed task."""
     cards: list[FailureCard] = []
     for task in summary.failed_tasks:
-        category = None
-        if isinstance(task.failure, dict):
-            kind = task.failure.get("kind")
-            if isinstance(kind, str):
-                category = kind
+        category = task.failure_kind
 
         log_path = _first_log_path(task=task, run_dir=run_dir)
         log_tail = build_log_tail(path=log_path, policy=policy)
@@ -702,7 +654,7 @@ def _build_failures(
                 base_name=task.base_name,
                 category=category,
                 exit_code=task.exit_code,
-                attempts_label=_attempts_label(task),
+                attempts_label=task.attempts_label,
                 message=task.error,
                 log_tail=log_tail,
                 log_relpath=log_relpath,
@@ -759,7 +711,7 @@ def _build_assets(
             continue
         seen_version_ids.add(version_id)
         try:
-            version = store.get_version(key=_parse_asset_key(key_text), version_id=version_id)
+            version = store.get_version(key=AssetKey.parse(key_text), version_id=version_id)
         except FileNotFoundError:
             continue
         card = _build_asset_card(
@@ -886,6 +838,23 @@ def _build_preview(
     )
 
 
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
+
+
+def _image_preview(
+    *,
+    path: Path,
+    extension: str,
+    artifact_id: str,
+    artifact_copies: list[ArtifactCopy],
+    alt: str,
+) -> AssetPreview:
+    """Copy an image artifact into ``figures/`` and return an image preview."""
+    dest = f"figures/{artifact_id}{extension}"
+    artifact_copies.append(ArtifactCopy(source=path, dest_relpath=dest))
+    return AssetPreview(kind="image", image_relpath=dest, image_alt=alt)
+
+
 def _fig_preview(
     *,
     path: Path,
@@ -894,10 +863,14 @@ def _fig_preview(
     artifact_copies: list[ArtifactCopy],
 ) -> AssetPreview:
     """Build a figure preview (image or embedded HTML)."""
-    if extension in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}:
-        dest = f"figures/{artifact_id}{extension}"
-        artifact_copies.append(ArtifactCopy(source=path, dest_relpath=dest))
-        return AssetPreview(kind="image", image_relpath=dest, image_alt="figure")
+    if extension in _IMAGE_EXTENSIONS:
+        return _image_preview(
+            path=path,
+            extension=extension,
+            artifact_id=artifact_id,
+            artifact_copies=artifact_copies,
+            alt="figure",
+        )
     if extension == ".html":
         dest = f"figures/{artifact_id}.html"
         artifact_copies.append(ArtifactCopy(source=path, dest_relpath=dest))
@@ -914,10 +887,14 @@ def _file_preview(
     policy: SizingPolicy,
 ) -> AssetPreview:
     """Preview a generic file asset by extension."""
-    if extension in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}:
-        dest = f"figures/{artifact_id}{extension}"
-        artifact_copies.append(ArtifactCopy(source=path, dest_relpath=dest))
-        return AssetPreview(kind="image", image_relpath=dest, image_alt="image")
+    if extension in _IMAGE_EXTENSIONS:
+        return _image_preview(
+            path=path,
+            extension=extension,
+            artifact_id=artifact_id,
+            artifact_copies=artifact_copies,
+            alt="image",
+        )
     if extension in {".csv", ".tsv", ".parquet", ".json", ".jsonl", ".ndjson"}:
         preview = build_table_preview(path=path, extension=extension, policy=policy)
         if preview is not None:
@@ -1008,35 +985,33 @@ def _column_count(metadata: Mapping[str, Any]) -> int | None:
     return None
 
 
-def _array_stats(*, metadata: Mapping[str, Any]) -> tuple[AssetStat, ...]:
-    """Return a small stats grid for an array asset."""
+def _metadata_stats(*, metadata: Mapping[str, Any], keys: tuple[str, ...]) -> list[AssetStat]:
+    """Return stat rows for the given metadata keys, in order.
+
+    Missing or ``None`` values are skipped; ``byte_size`` is rendered via
+    :func:`format_bytes`, everything else via ``str``.
+    """
     stats: list[AssetStat] = []
-    for key in ("sub_kind", "shape", "dtype", "chunks", "coordinates", "byte_size"):
-        if key not in metadata:
-            continue
-        value = metadata[key]
+    for key in keys:
+        value = metadata.get(key)
         if value is None:
             continue
         if key == "byte_size" and isinstance(value, int):
             stats.append(AssetStat(key=key, value=format_bytes(value)))
         else:
             stats.append(AssetStat(key=key, value=str(value)))
-    return tuple(stats)
+    return stats
+
+
+def _array_stats(*, metadata: Mapping[str, Any]) -> tuple[AssetStat, ...]:
+    """Return a small stats grid for an array asset."""
+    keys = ("sub_kind", "shape", "dtype", "chunks", "coordinates", "byte_size")
+    return tuple(_metadata_stats(metadata=metadata, keys=keys))
 
 
 def _model_stats(*, metadata: Mapping[str, Any]) -> tuple[AssetStat, ...]:
-    """Return a small stats grid for a model asset."""
-    stats: list[AssetStat] = []
-    for key in ("sub_kind", "framework", "byte_size"):
-        if key not in metadata:
-            continue
-        value = metadata[key]
-        if value is None:
-            continue
-        if key == "byte_size" and isinstance(value, int):
-            stats.append(AssetStat(key=key, value=format_bytes(value)))
-        else:
-            stats.append(AssetStat(key=key, value=str(value)))
+    """Return a small stats grid for a model asset, including any metrics."""
+    stats = _metadata_stats(metadata=metadata, keys=("sub_kind", "framework", "byte_size"))
     metrics = metadata.get("metrics")
     if isinstance(metrics, dict):
         for name, value in metrics.items():
@@ -1059,14 +1034,6 @@ def _asset_caption(*, metadata: Mapping[str, Any]) -> str | None:
     if isinstance(caption, str) and caption.strip():
         return caption.strip()
     return None
-
-
-def _parse_asset_key(text: str) -> AssetKey:
-    """Parse ``namespace:name`` into an :class:`AssetKey`."""
-    namespace, sep, name = text.partition(":")
-    if sep and namespace and name:
-        return AssetKey(namespace=namespace, name=name)
-    return AssetKey(namespace="file", name=text)
 
 
 def _artifact_record(
@@ -1166,12 +1133,9 @@ def _build_summary_cards(
         or "—"
     )
 
-    failure_categories: list[str] = []
-    for task in summary.failed_tasks:
-        if isinstance(task.failure, dict):
-            kind = task.failure.get("kind")
-            if isinstance(kind, str):
-                failure_categories.append(kind)
+    failure_categories = [
+        task.failure_kind for task in summary.failed_tasks if task.failure_kind is not None
+    ]
     failure_sub = failure_categories[0] if failure_categories else "—"
 
     return (
@@ -1179,7 +1143,7 @@ def _build_summary_cards(
             label="Tasks",
             value=format_int(total_tasks),
             sub=tasks_sub,
-            tone="ok" if failed == 0 else "ok",
+            tone="ok",
         ),
         StatCard(
             label="Failures",

--- a/src/ginkgo/reporting/sizing.py
+++ b/src/ginkgo/reporting/sizing.py
@@ -9,7 +9,6 @@ dropped.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -43,92 +42,6 @@ class SizingPolicy:
     log_lines: int = 80
     array_sample_values: int = 8
     embed_full_assets: bool = False
-
-
-# ----- Formatting ---------------------------------------------------------
-
-
-def format_duration(seconds: float | None) -> str:
-    """Return a compact duration label.
-
-    Parameters
-    ----------
-    seconds : float | None
-        Duration in seconds, or ``None`` for unknown.
-
-    Returns
-    -------
-    str
-        ``"4.2s"``, ``"2m 14s"``, ``"8h 03m 12s"``, or ``"—"`` when
-        ``seconds`` is ``None``.
-    """
-    if seconds is None:
-        return "—"
-    value = max(0.0, float(seconds))
-    if value < 60:
-        if value < 10:
-            return f"{value:.1f}s"
-        return f"{int(round(value))}s"
-    if value < 3600:
-        minutes = int(value // 60)
-        remaining = int(round(value - minutes * 60))
-        return f"{minutes}m {remaining:02d}s"
-    hours = int(value // 3600)
-    minutes = int((value - hours * 3600) // 60)
-    remaining = int(round(value - hours * 3600 - minutes * 60))
-    return f"{hours}h {minutes:02d}m {remaining:02d}s"
-
-
-def format_bytes(size_bytes: int | None) -> str:
-    """Return a compact byte-size label.
-
-    Parameters
-    ----------
-    size_bytes : int | None
-        Size in bytes, or ``None`` when unknown.
-
-    Returns
-    -------
-    str
-        Human-readable size (``"14.2 MB"``, ``"62 KB"``, ``"1.2 GB"``) or
-        ``"—"`` when the size is unknown.
-    """
-    if size_bytes is None:
-        return "—"
-    value = float(max(0, int(size_bytes)))
-    for unit in ("B", "KB", "MB", "GB", "TB"):
-        if value < 1024 or unit == "TB":
-            if unit == "B":
-                return f"{int(value)} {unit}"
-            return f"{value:.1f} {unit}"
-        value /= 1024
-    return f"{size_bytes} B"
-
-
-def format_timestamp(value: datetime | None) -> str:
-    """Return an ISO-like timestamp string in UTC.
-
-    Parameters
-    ----------
-    value : datetime | None
-        Timestamp to format, or ``None`` for unknown.
-
-    Returns
-    -------
-    str
-        ``"2026-04-18 14:32:07 UTC"`` or ``"—"``.
-    """
-    if value is None:
-        return "—"
-    aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
-    return aware.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
-
-
-def format_int(value: int | None) -> str:
-    """Return an integer with thousands separators, or ``"—"``."""
-    if value is None:
-        return "—"
-    return f"{int(value):,}"
 
 
 # ----- Table preview ------------------------------------------------------

--- a/src/ginkgo/runtime/run_summary.py
+++ b/src/ginkgo/runtime/run_summary.py
@@ -95,6 +95,47 @@ class TaskSummary:
         """Return True when the task reached a terminal status."""
         return self.status in _TERMINAL_STATUSES
 
+    @property
+    def failure_kind(self) -> str | None:
+        """Return the diagnosed failure category, when the task recorded one."""
+        if isinstance(self.failure, dict):
+            kind = self.failure.get("kind")
+            if isinstance(kind, str):
+                return kind
+        return None
+
+    @property
+    def kind_label(self) -> str:
+        """Return a display label for the task kind (``"task"`` fallback)."""
+        raw = self.raw.get("kind")
+        if isinstance(raw, str) and raw:
+            return raw
+        if self.task_type == "notebook":
+            return "notebook"
+        return "task"
+
+    @property
+    def cache_label(self) -> str:
+        """Return ``"hit"``, ``"miss"``, or ``"—"`` for the cache outcome."""
+        if self.cached or self.status == "cached":
+            return "hit"
+        if self.status in {"succeeded", "failed"}:
+            return "miss"
+        return "—"
+
+    @property
+    def attempts_label(self) -> str:
+        """Return ``"N"`` or ``"N / M"`` for attempts / max_attempts."""
+        attempts = self.raw.get("attempts")
+        max_attempts = self.raw.get("max_attempts")
+        if self.status == "cached":
+            return "—"
+        if isinstance(attempts, int) and isinstance(max_attempts, int) and max_attempts > 1:
+            return f"{attempts + 1} / {max_attempts}"
+        if isinstance(attempts, int):
+            return f"{attempts + 1}"
+        return "1"
+
     def rendered_html_absolute(self, *, run_dir: Path) -> Path | None:
         """Resolve ``rendered_html`` against the run directory.
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -9,13 +9,9 @@ import pytest
 import yaml
 
 from ginkgo.core.asset import AssetKey, make_asset_version
+from ginkgo.formatting import format_bytes, format_duration
 from ginkgo.reporting import SizingPolicy, build_report_data, export_report
-from ginkgo.reporting.sizing import (
-    build_log_tail,
-    build_table_preview,
-    format_bytes,
-    format_duration,
-)
+from ginkgo.reporting.sizing import build_log_tail, build_table_preview
 from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
 from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.runtime.caching.provenance import RunProvenanceRecorder


### PR DESCRIPTION
Closes #79.

## Problem
Two read-only, post-run presenters — the CLI run-finish path and `reporting/model.build_report_data` — independently re-derived formatting and semantic transforms from a run manifest. A schema or formatting change had to be made in multiple places and could silently drift (e.g. two divergent `format_duration` implementations, `1.2s` vs `1.20s`).

The live `CliRunRenderer` streaming state is intentionally left as-is; the task table is built from live `_TaskRow` state, not re-derived from the manifest. Scope here is the read-only presenters only.

## Changes
**Single source of truth**
- New `ginkgo/formatting.py` holds the canonical value formatters (`format_duration`, `format_bytes`, `format_timestamp`, `format_int`). The CLI and HTML report both import from it — the two divergent copies in `cli/renderers/common.py` and `reporting/sizing.py` are gone.
  - The HTML report keeps its exact output (**byte-identical**); the CLI adopts the richer duration formatting (`1m 30s` for long tasks, `0.5s` sub-second) and the shared byte labels.
- Post-run semantic derivations move onto `TaskSummary` as read-only properties: `failure_kind`, `kind_label`, `cache_label`, `attempts_label`. Both presenters consume these instead of re-deriving; the duplicated `task.failure.get("kind")` extraction is removed from both.
- Presentation *vocabulary* stays with each presenter (CLI Rich styles/icons vs HTML tone tokens) — these legitimately differ and are not merged.

**Related `reporting/model` cleanups**
- Remove a dead conditional in the Tasks stat card (`"ok" if failed == 0 else "ok"` — always `"ok"`).
- Resolve the ginkgo version once per report build instead of three times.
- De-duplicate `_array_stats`/`_model_stats` via a shared `_metadata_stats` helper.
- Share image-preview logic between `_fig_preview` and `_file_preview`.
- Add `AssetKey.parse(text, *, strict=...)` as the single asset-key parser; reporting (non-strict) and the CLI (`strict=True`) both delegate to it, removing two divergent copies.

## Verification
- Full suite green: **694 passed, 5 skipped**.
- `ruff` and `ty` clean (no new diagnostics).
- HTML report byte-identical (reporting determinism + formatter assertion tests pass unchanged).