### PR TITLE
Invalidate task caches when local helpers change

### DIFF
--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -21,11 +21,16 @@ Implemented cache hashing includes:
 
 Cache entries are written atomically and reused across reruns when inputs are unchanged.
 
-The runtime hashes the top-level task function source during task registration
-and stores that `source_hash` in both the cache key payload and `meta.json`, so
-task-body changes invalidate prior cache entries without requiring a manual
-`version=` bump. If source extraction fails for a task definition, registration
-fails explicitly instead of silently weakening cache correctness.
+The runtime hashes the top-level task function source and the statically
+imported closure of already-loaded local Python modules during task
+registration. The resulting `source_hash` is stored in both the cache key
+payload and `meta.json`, so task-body and local-helper changes invalidate prior
+cache entries without requiring a manual `version=` bump. This is deliberately
+conservative: an edit anywhere in a reachable local module invalidates tasks
+that import it. Dynamic imports and external runtime dependencies are outside
+this static boundary; use `version=` to invalidate cache entries for them. If
+source extraction fails for a task definition, registration fails explicitly
+instead of silently weakening cache correctness.
 
 File and folder outputs flow through a formal `ArtifactStore` contract,
 implemented locally by `LocalArtifactStore` in

--- a/docs/site/guide/caching-and-provenance.md
+++ b/docs/site/guide/caching-and-provenance.md
@@ -10,13 +10,18 @@ level, Ginkgo hashes:
 
 - task identity
 - task version
-- task source
+- task source and its statically imported local Python modules
 - notebook source for notebook tasks
 - resolved input values
 - environment identity for foreign execution
 
 For path-like inputs, the runtime hashes the contents rather than trusting the
 path string alone.
+
+Local-import tracking is conservative: changing a reachable helper module
+invalidates tasks that import it, even when the changed symbol is not called.
+Dynamic imports and other runtime dependencies cannot be tracked this way; set
+or increment `version=` on the task when those dependencies change.
 
 ## Artifact Storage
 

--- a/docs/site/guide/tasks-and-flows.md
+++ b/docs/site/guide/tasks-and-flows.md
@@ -109,7 +109,8 @@ Key points:
 
 - task functions must live at module scope
 - inputs and outputs should be explicit and typed
-- top-level source changes participate in cache invalidation
+- top-level source and statically imported local-helper changes participate in
+  cache invalidation
 - return ordinary Python values or supported Ginkgo marker types
 
 ## Shell Tasks

--- a/src/ginkgo/core/task.py
+++ b/src/ginkgo/core/task.py
@@ -7,11 +7,17 @@ arguments), enabling lazy expression tree construction.
 
 from __future__ import annotations
 
+import ast
 import inspect
+import sys
+import tokenize
 from dataclasses import dataclass, field
 from importlib import import_module
+from importlib.util import resolve_name
 from itertools import product
+from pathlib import Path
 from typing import Any, Callable, Literal, get_type_hints
+from types import ModuleType
 
 import math
 import re
@@ -189,7 +195,7 @@ class TaskDef:
 
     @property
     def source_hash(self) -> str:
-        """BLAKE3 digest of the task function's source code."""
+        """BLAKE3 digest of task source and local imported modules."""
         return self._source_hash
 
     @property
@@ -769,7 +775,7 @@ def _parse_memory(value: str | None) -> int:
 
 
 def _compute_source_hash(fn: Callable[..., Any]) -> str:
-    """Return the BLAKE3 digest of a function's source code.
+    """Return the BLAKE3 digest of task source and local imports.
 
     Parameters
     ----------
@@ -786,7 +792,7 @@ def _compute_source_hash(fn: Callable[..., Any]) -> str:
     ValueError
         If the source cannot be extracted (lambdas, dynamic functions).
     """
-    from ginkgo.runtime.caching.hashing import hash_str
+    from ginkgo.runtime.caching.hashing import hash_file, hash_str
 
     try:
         source = inspect.getsource(fn)
@@ -795,7 +801,97 @@ def _compute_source_hash(fn: Callable[..., Any]) -> str:
             f"Cannot extract source for task '{fn.__qualname__}'. "
             "Tasks must be defined as named, top-level functions."
         ) from exc
-    return hash_str(source)
+    module = sys.modules.get(fn.__module__)
+    if not isinstance(module, ModuleType):
+        return hash_str(source)
+
+    modules = _local_import_closure(module)
+    module_hashes = [f"{name}:{hash_file(path)}" for name, path in sorted(modules.items())]
+    return hash_str("\n".join((source, *module_hashes)))
+
+
+def _local_import_closure(module: ModuleType) -> dict[str, Path]:
+    """Return loaded local Python modules statically imported by ``module``."""
+    source_path = _module_source_path(module)
+    if source_path is None:
+        return {}
+
+    source_root = _module_source_root(module=module, source_path=source_path)
+    pending = [module]
+    sources: dict[str, Path] = {}
+
+    while pending:
+        current = pending.pop()
+        if current.__name__ in sources:
+            continue
+
+        current_path = _module_source_path(current)
+        if current_path is None or not current_path.is_relative_to(source_root):
+            continue
+
+        sources[current.__name__] = current_path
+        pending.extend(_imported_modules(module=current, source_path=current_path))
+
+    return sources
+
+
+def _module_source_path(module: ModuleType) -> Path | None:
+    """Return the resolved Python source path for ``module``, when available."""
+    filename = getattr(module, "__file__", None)
+    if filename is None:
+        return None
+
+    path = Path(filename).resolve()
+    return path if path.suffix == ".py" and path.is_file() else None
+
+
+def _module_source_root(*, module: ModuleType, source_path: Path) -> Path:
+    """Return the import root containing the task module's package."""
+    package_depth = len(module.__name__.split("."))
+    if source_path.name != "__init__.py":
+        package_depth -= 1
+
+    source_root = source_path.parent
+    for _ in range(package_depth):
+        source_root = source_root.parent
+    return source_root
+
+
+def _imported_modules(*, module: ModuleType, source_path: Path) -> list[ModuleType]:
+    """Return already-loaded modules named by static imports in ``module``."""
+    try:
+        with tokenize.open(source_path) as source_file:
+            tree = ast.parse(source_file.read(), filename=str(source_path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            base = _import_base_name(node=node, package=module.__package__)
+            if base is None:
+                continue
+            names.add(base)
+            names.update(f"{base}.{alias.name}" for alias in node.names)
+
+    return [
+        imported
+        for name in sorted(names)
+        if isinstance(imported := sys.modules.get(name), ModuleType)
+    ]
+
+
+def _import_base_name(*, node: ast.ImportFrom, package: str | None) -> str | None:
+    """Resolve the module portion of an import statement without importing it."""
+    if node.level == 0:
+        return node.module
+    if not package:
+        return None
+
+    relative_name = "." * node.level + (node.module or "")
+    return resolve_name(relative_name, package)
 
 
 def _load_taskdef(module_name: str, task_name: str) -> TaskDef:

--- a/tests/test_cache_integrity.py
+++ b/tests/test_cache_integrity.py
@@ -96,6 +96,66 @@ class TestSourceHashCacheInvalidation:
             sys.modules.pop("pkg.tasks", None)
             sys.modules.pop("pkg", None)
 
+    def test_modified_imported_helper_causes_cache_miss(self, tmp_path):
+        """Changing a transitive local helper invalidates an unchanged task."""
+        module_dir = tmp_path / "pkg"
+        module_dir.mkdir()
+        (module_dir / "__init__.py").write_text("")
+        (module_dir / "tasks.py").write_text(
+            textwrap.dedent("""\
+                from ginkgo import task
+                from . import helpers
+
+                @task()
+                def compute(x: int) -> int:
+                    return helpers.compute(x)
+            """),
+            encoding="utf-8",
+        )
+        (module_dir / "helpers.py").write_text(
+            textwrap.dedent("""\
+                from .transform import adjust
+
+                def compute(x: int) -> int:
+                    return adjust(x)
+            """),
+            encoding="utf-8",
+        )
+        transform_path = module_dir / "transform.py"
+        transform_path.write_text(
+            "def adjust(x: int) -> int:\n    return x + 1\n", encoding="utf-8"
+        )
+
+        import importlib
+        import sys
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            tasks = importlib.import_module("pkg.tasks")
+            assert evaluate(tasks.compute(x=5)) == 6
+
+            cached = EventCollector()
+            assert evaluate(tasks.compute(x=5), event_bus=cached.bus) == 6
+            assert cached.cached()
+
+            transform_path.write_text(
+                "def adjust(x: int) -> int:\n    return x + 10\n", encoding="utf-8"
+            )
+            importlib.reload(sys.modules["pkg.transform"])
+            importlib.reload(sys.modules["pkg.helpers"])
+            tasks = importlib.reload(tasks)
+
+            collector = EventCollector()
+            assert evaluate(tasks.compute(x=5), event_bus=collector.bus) == 15
+            assert collector.started()
+            assert not collector.cached()
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("pkg.transform", None)
+            sys.modules.pop("pkg.helpers", None)
+            sys.modules.pop("pkg.tasks", None)
+            sys.modules.pop("pkg", None)
+
 
 # ---------------------------------------------------------------------------
 # File output symlinks


### PR DESCRIPTION
## Summary

Fixes #92 by extending Python task source hashing beyond the decorated wrapper.

- Hash the task wrapper together with the statically imported closure of already-loaded local Python modules.
- Traverse transitive local imports deterministically and safely handle import cycles.
- Avoid importing new modules while calculating cache identity.
- Document the static dependency boundary and the `version=` escape hatch for dynamic dependencies.

## Behaviour

An edit to a reachable local helper module now changes the cache key for tasks that import it, even when the task wrapper is unchanged. This intentionally over-invalidates when an unrelated symbol in a reachable helper changes; recomputation is preferable to serving stale results. Dynamic imports, plugins, generated code, and external runtime dependencies remain outside this static analysis and require an explicit task `version=` change.

## Tests

- Added a temporary-package regression test covering a task that delegates through a helper and a transitive helper module.
- Verifies an unchanged rerun is cached, then changing only the transitive helper causes a cache miss and returns the new result.
- `pixi run pytest tests/test_cache_integrity.py -q`
- `pixi run pytest tests/test_task.py tests/test_cache_integrity.py -q`
- `pixi run ruff check src/ginkgo/ tests/`
- Commit hooks passed, including Ruff, Ty, and uncoded sync.