### PR TITLE
Add asset checks

### DIFF
--- a/docs/architecture/assets.md
+++ b/docs/architecture/assets.md
@@ -24,7 +24,7 @@ The current asset model supports:
 - a single `AssetResult` sentinel with a `kind` discriminator (one of
   `file`, `table`, `array`, `fig`, `text`, `model`)
 - `asset(payload, kind=..., name=..., group=..., caption=...,
-  metadata=..., **kind_fields)` as the canonical constructor, with
+  metadata=..., checks=..., **kind_fields)` as the canonical constructor, with
   `table`, `array`, `fig`, `text`, and `model` as kind-preset shorthand
   factories
 - immutable `AssetVersion` records keyed by logical `AssetKey`
@@ -125,6 +125,14 @@ arguments (`format=` for `text`, `framework=` / `metrics=` for
   `ginkgo_caption`, affects presentation only, and is not part of
   `AssetKey`.
 - `metadata` — free-form user metadata persisted on the version.
+- `checks` — an ordered tuple of importable `(payload) -> bool` callables.
+  The registrar runs these checks after serialization and before registering
+  the asset version. Every check must return `True`; `False`, an exception, or
+  a non-boolean result fails the producing task and leaves no catalog version.
+  Passing results are stored under the reserved `_checks` metadata key as
+  ordered `{name, passed}` mappings. Checks are transported through worker and
+  remote result encoding, so lambdas, nested functions, and closures are not
+  supported.
 - `kind_fields` — a `dict[str, Any]` bag carrying kind-specific
   construction-time fields (`format` for `text`, `framework` and
   `metrics` for `model`). The keys are scoped to the kind's
@@ -196,12 +204,16 @@ every nested `AssetResult`, and replaces it with a resolved `AssetRef`:
    - For semantic kinds it invokes the registered serializer, stores
      the bytes via `ArtifactStore.store_bytes`, and extracts the
      per-kind metadata returned by the serializer.
-3. An immutable `AssetVersion` is registered under the kind-scoped
+3. The registrar runs every attached check against the original payload. If a
+   check fails, no `AssetVersion`, lineage record, or live payload is created;
+   the content-addressed bytes written during serialization are eligible for
+   ordinary orphan-artifact cleanup.
+4. An immutable `AssetVersion` is registered under the kind-scoped
    namespace (`file` / `table` / `array` / `fig` / `text` / `model`),
    and the sentinel is replaced with an `AssetRef` pointing at the
    stored artifact.
-4. Upstream lineage is recorded for any consumed `AssetRef` inputs.
-5. For kinds flagged as `rehydrate_on_receive` (all except `file` and
+5. Upstream lineage is recorded for any consumed `AssetRef` inputs.
+6. For kinds flagged as `rehydrate_on_receive` (all except `file` and
    `fig`), the producer's live Python object is stashed in the
    per-evaluator `LivePayloadRegistry` keyed by `artifact_id`, so a
    downstream task in the same process can consume it without a disk
@@ -230,6 +242,12 @@ metadata:
 `ginkgo asset show <key>` renders this metadata through the CLI without
 re-reading the stored bytes. The UI asset payload surfaces the same
 fields under a `kind_metadata` key for future frontend consumers.
+
+Successful asset checks are stored as `_checks` metadata and rendered by the
+HTML report. The strict registration model intentionally does not preserve a
+failed check on an asset card: a failed check rejects the asset version and is
+reported as the producing task failure. Cached assets are reused without
+rerunning checks.
 
 ## Rehydration on receive
 

--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -105,6 +105,13 @@ name in the card header; they are also surfaced by `ginkgo asset show`.
 Like groups, captions are presentation-only and do not affect identity or
 cache behaviour.
 
+Asset check outcomes are read from the reserved `_checks` version-metadata
+field into typed `CheckOutcome` values on `AssetCard`. Each asset card renders
+these outcomes as pass/fail badges beside its kind and name. Current strict
+asset checks register only all-passing versions, but the report model accepts
+either persisted outcome so it remains forward-compatible with future soft
+checks. Assets created before checks have an empty check collection.
+
 ## Bundle layout
 
 ```

--- a/docs/site/guide/assets.md
+++ b/docs/site/guide/assets.md
@@ -37,7 +37,35 @@ The typed helpers each map to an asset **kind**:
 
 Each helper accepts a `name` (the asset key, written `namespace/name`), a
 `group` label for report sections, a `caption` shown beneath the asset name,
-and a `metadata` dict. `model()` also takes `framework` and `metrics`:
+and a `metadata` dict. Each also accepts `checks`: small data-quality
+assertions that run before Ginkgo registers the asset version. `model()` also
+takes `framework` and `metrics`.
+
+```python
+import pandas as pd
+
+from ginkgo import table, task
+
+
+def has_rows(frame: pd.DataFrame) -> bool:
+    return not frame.empty
+
+
+@task()
+def prepare_observations() -> object:
+    frame = load_observations()
+    return table(frame, name="observations", checks=[has_rows])
+```
+
+A check receives the wrapped payload and must return `True` or `False`.
+`False`, a raised exception, or any other return value fails the producing
+task and prevents the asset version from being registered. Define checks as
+top-level functions in an importable workflow module: lambdas, nested
+functions, and closures cannot be transported to worker or remote execution.
+Passing outcomes are stored with the asset version and displayed on HTML report
+cards. Checks are not rerun for cached assets.
+
+`model()` also takes `framework` and `metrics`:
 
 ```python
 from ginkgo import model, task

--- a/examples/bioinfo/bioinfo/workflow.py
+++ b/examples/bioinfo/bioinfo/workflow.py
@@ -19,6 +19,11 @@ cfg = ginkgo.config("ginkgo.toml")
 samples = pd.read_csv(cfg["paths"]["samples_csv"])
 
 
+def _summary_has_records(payload: object) -> bool:
+    """Return whether a QC summary contains at least one sample record."""
+    return isinstance(payload, pd.DataFrame) and not payload.empty
+
+
 @task(env="bioinfo_tools", kind="shell")
 def filter_fastq(sample_id: str, fastq_1: file, fastq_2: file, min_length: int) -> list[file]:
     """Filter paired-end reads shorter than ``min_length`` with seqkit."""
@@ -142,7 +147,7 @@ def build_summary(
     output.parent.mkdir(parents=True, exist_ok=True)
     summary.to_csv(output, index=False)
 
-    return table(summary, name="qc_summary")
+    return table(summary, name="qc_summary", checks=[_summary_has_records])
 
 
 @flow

--- a/examples/init/ginkgo_init_template/modules/prep.py
+++ b/examples/init/ginkgo_init_template/modules/prep.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from ginkgo import AssetRef, asset, file, shell, task
 
 
+def _seed_card_has_content(payload: object) -> bool:
+    """Return whether a seed-card file exists and has content."""
+    return isinstance(payload, Path) and payload.is_file() and payload.stat().st_size > 0
+
+
 @task()
 def write_seed_card(item: str, output_path: str) -> file:
     """Write a tiny text artifact for one item.
@@ -34,6 +39,7 @@ def write_seed_card(item: str, output_path: str) -> file:
         output,
         name=f"starter/seed_cards/{item}",
         metadata={"item": item, "stage": "seed"},
+        checks=[_seed_card_has_content],
     )
 
 

--- a/src/ginkgo/core/asset.py
+++ b/src/ginkgo/core/asset.py
@@ -9,6 +9,7 @@ the shorthand factories :func:`table`, :func:`array`, :func:`fig`,
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -200,6 +201,10 @@ class AssetResult:
         participate in asset identity.
     metadata : dict[str, Any]
         Optional user-supplied metadata stored on the asset version.
+    checks : tuple[Callable[[Any], bool], ...]
+        Ordered asset checks run during registration. Each check receives the
+        wrapped payload and must return ``True`` or ``False``. Checks must be
+        importable module-level functions when the task runs in a worker.
     kind_fields : dict[str, Any]
         Internal bag carrying kind-specific construction-time fields
         (e.g. ``"format"`` for ``text`` / ``"framework"`` and
@@ -215,6 +220,7 @@ class AssetResult:
     group: str | None = None
     caption: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    checks: tuple[Callable[[Any], bool], ...] = ()
     kind_fields: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -332,6 +338,7 @@ def asset(
     group: str | None = None,
     caption: str | None = None,
     metadata: dict[str, Any] | None = None,
+    checks: Iterable[Callable[[Any], bool]] | None = None,
     **kind_fields: Any,
 ) -> AssetResult:
     """Wrap a task output for registration as an asset.
@@ -362,6 +369,9 @@ def asset(
         do not affect the stable asset key.
     metadata : dict[str, Any] | None
         Optional user-supplied metadata persisted on the asset version.
+    checks : Iterable[Callable[[Any], bool]] | None
+        Optional ordered checks run against the payload during asset
+        registration. Every check must return ``True`` or ``False``.
     **kind_fields : Any
         Kind-specific construction-time fields. For ``text`` this
         accepts ``format``; for ``model`` this accepts ``framework`` and
@@ -390,6 +400,7 @@ def asset(
         group=group.strip() if isinstance(group, str) and group.strip() else None,
         caption=caption.strip() if isinstance(caption, str) and caption.strip() else None,
         metadata=dict(metadata or {}),
+        checks=tuple(checks) if checks is not None else (),
         kind_fields=extra_kind_fields,
     )
 
@@ -401,6 +412,7 @@ def table(
     group: str | None = None,
     caption: str | None = None,
     metadata: dict[str, Any] | None = None,
+    checks: Iterable[Callable[[Any], bool]] | None = None,
 ) -> AssetResult:
     """Wrap a tabular value as an asset return.
 
@@ -419,12 +431,22 @@ def table(
         inspection output.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
+    checks : Iterable[Callable[[Any], bool]] | None
+        Optional checks run against the payload during asset registration.
 
     Returns
     -------
     AssetResult
     """
-    return asset(payload, kind="table", name=name, group=group, caption=caption, metadata=metadata)
+    return asset(
+        payload,
+        kind="table",
+        name=name,
+        group=group,
+        caption=caption,
+        metadata=metadata,
+        checks=checks,
+    )
 
 
 def array(
@@ -434,6 +456,7 @@ def array(
     group: str | None = None,
     caption: str | None = None,
     metadata: dict[str, Any] | None = None,
+    checks: Iterable[Callable[[Any], bool]] | None = None,
 ) -> AssetResult:
     """Wrap an n-dimensional array value as an asset return.
 
@@ -451,12 +474,22 @@ def array(
         inspection output.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
+    checks : Iterable[Callable[[Any], bool]] | None
+        Optional checks run against the payload during asset registration.
 
     Returns
     -------
     AssetResult
     """
-    return asset(payload, kind="array", name=name, group=group, caption=caption, metadata=metadata)
+    return asset(
+        payload,
+        kind="array",
+        name=name,
+        group=group,
+        caption=caption,
+        metadata=metadata,
+        checks=checks,
+    )
 
 
 def fig(
@@ -466,6 +499,7 @@ def fig(
     group: str | None = None,
     caption: str | None = None,
     metadata: dict[str, Any] | None = None,
+    checks: Iterable[Callable[[Any], bool]] | None = None,
 ) -> AssetResult:
     """Wrap a figure or plot value as an asset return.
 
@@ -483,12 +517,22 @@ def fig(
         inspection output.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
+    checks : Iterable[Callable[[Any], bool]] | None
+        Optional checks run against the payload during asset registration.
 
     Returns
     -------
     AssetResult
     """
-    return asset(payload, kind="fig", name=name, group=group, caption=caption, metadata=metadata)
+    return asset(
+        payload,
+        kind="fig",
+        name=name,
+        group=group,
+        caption=caption,
+        metadata=metadata,
+        checks=checks,
+    )
 
 
 def text(
@@ -499,6 +543,7 @@ def text(
     caption: str | None = None,
     format: Literal["plain", "markdown", "json"] | None = None,
     metadata: dict[str, Any] | None = None,
+    checks: Iterable[Callable[[Any], bool]] | None = None,
 ) -> AssetResult:
     """Wrap a text or structured document value as an asset return.
 
@@ -518,6 +563,8 @@ def text(
         Document format. Auto-detected from the payload when omitted.
     metadata : dict[str, Any] | None
         Optional user-defined metadata stored with the asset version.
+    checks : Iterable[Callable[[Any], bool]] | None
+        Optional checks run against the payload during asset registration.
 
     Returns
     -------
@@ -530,6 +577,7 @@ def text(
         group=group,
         caption=caption,
         metadata=metadata,
+        checks=checks,
         format=format,
     )
 
@@ -543,6 +591,7 @@ def model(
     framework: str | None = None,
     metrics: dict[str, float] | None = None,
     metadata: dict[str, Any] | None = None,
+    checks: Iterable[Callable[[Any], bool]] | None = None,
 ) -> AssetResult:
     """Wrap a trained model as an asset return.
 
@@ -569,6 +618,8 @@ def model(
         UI rendering.
     metadata : dict[str, Any] | None
         Optional free-form metadata stored on the asset version.
+    checks : Iterable[Callable[[Any], bool]] | None
+        Optional checks run against the payload during asset registration.
 
     Returns
     -------
@@ -581,6 +632,7 @@ def model(
         group=group,
         caption=caption,
         metadata=metadata,
+        checks=checks,
         framework=framework,
         metrics=metrics,
     )

--- a/src/ginkgo/reporting/model.py
+++ b/src/ginkgo/reporting/model.py
@@ -19,6 +19,7 @@ from ginkgo.runtime.artifacts.artifact_model import ArtifactRecord
 from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
 from ginkgo.runtime.artifacts.asset_registration import (
     ASSET_CAPTION_METADATA_KEY,
+    ASSET_CHECKS_METADATA_KEY,
     ASSET_GROUP_METADATA_KEY,
 )
 from ginkgo.runtime.artifacts.asset_store import AssetStore
@@ -182,6 +183,22 @@ class AssetPreview:
 
 
 @dataclass(frozen=True, kw_only=True)
+class CheckOutcome:
+    """One persisted result from an asset check.
+
+    Parameters
+    ----------
+    name : str
+        Human-readable check function name.
+    passed : bool
+        Whether the check passed.
+    """
+
+    name: str
+    passed: bool
+
+
+@dataclass(frozen=True, kw_only=True)
 class AssetCard:
     """One asset version produced by the run."""
 
@@ -194,6 +211,7 @@ class AssetCard:
     artifact_id: str
     meta_line: str
     version_id: str
+    checks: tuple[CheckOutcome, ...]
     preview: AssetPreview
 
 
@@ -770,6 +788,7 @@ def _build_asset_card(
         artifact_id=version.artifact_id,
         meta_line=meta_line,
         version_id=version.version_id,
+        checks=_asset_checks(metadata=version.metadata),
         preview=preview,
     )
 
@@ -1034,6 +1053,23 @@ def _asset_caption(*, metadata: Mapping[str, Any]) -> str | None:
     if isinstance(caption, str) and caption.strip():
         return caption.strip()
     return None
+
+
+def _asset_checks(*, metadata: Mapping[str, Any]) -> tuple[CheckOutcome, ...]:
+    """Extract well-formed asset check outcomes from version metadata."""
+    raw_checks = metadata.get(ASSET_CHECKS_METADATA_KEY)
+    if not isinstance(raw_checks, (list, tuple)):
+        return ()
+
+    outcomes: list[CheckOutcome] = []
+    for raw_outcome in raw_checks:
+        if not isinstance(raw_outcome, Mapping):
+            continue
+        name = raw_outcome.get("name")
+        passed = raw_outcome.get("passed")
+        if isinstance(name, str) and name and isinstance(passed, bool):
+            outcomes.append(CheckOutcome(name=name, passed=passed))
+    return tuple(outcomes)
 
 
 def _artifact_record(

--- a/src/ginkgo/reporting/static/report.css
+++ b/src/ginkgo/reporting/static/report.css
@@ -789,6 +789,18 @@ pre.log {
 .kind-badge.kind-model { color: var(--teal-deep);  background: var(--teal-soft);  border: 1px solid var(--teal); }
 .kind-badge.kind-file  { color: var(--ink-muted);  background: var(--paper-deep); border: 1px solid var(--rule); }
 
+.check-badge {
+  display: inline-block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  padding: 3px 7px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.check-badge.check-pass { color: var(--moss); background: var(--moss-soft); border: 1px solid var(--moss); }
+.check-badge.check-fail { color: var(--rose-deep); background: var(--rose-soft); border: 1px solid var(--rose); }
+
 /* Data table in asset previews */
 
 .table-scroll {

--- a/src/ginkgo/reporting/templates/_assets.html.j2
+++ b/src/ginkgo/reporting/templates/_assets.html.j2
@@ -9,6 +9,9 @@
     <div>
       <span class="kind-badge kind-{{ card.kind_tone }}">{{ card.kind_label }}</span>
       <span class="name">{{ card.name }}</span>
+      {% for check in card.checks %}
+      <span class="check-badge check-{{ "pass" if check.passed else "fail" }}">{{ "✓" if check.passed else "✗" }} {{ check.name }}</span>
+      {% endfor %}
       {% if card.caption %}
       <div class="caption">{{ card.caption }}</div>
       {% endif %}

--- a/src/ginkgo/runtime/artifacts/asset_registration.py
+++ b/src/ginkgo/runtime/artifacts/asset_registration.py
@@ -40,6 +40,11 @@ from ginkgo.runtime.caching.cache import CacheStore
 
 ASSET_GROUP_METADATA_KEY = "ginkgo_group"
 ASSET_CAPTION_METADATA_KEY = "ginkgo_caption"
+ASSET_CHECKS_METADATA_KEY = "_checks"
+
+
+class AssetCheckError(RuntimeError):
+    """Raised when an asset check cannot verify a wrapped payload."""
 
 
 def asset_key_for_result(*, name: str, kind: str) -> AssetKey:
@@ -264,7 +269,12 @@ class AssetRegistrar:
             )
             version_metadata = _metadata_with_group(metadata=serialized.metadata, result=result)
 
-        # 2. Build and register the immutable version record.
+        # 2. Verify the stored payload before publishing a catalog version.
+        check_outcomes = _check_outcomes(result=result)
+        if check_outcomes:
+            version_metadata[ASSET_CHECKS_METADATA_KEY] = check_outcomes
+
+        # 3. Build and register the immutable version record.
         version = make_asset_version(
             key=asset_key_for_result(name=asset_name, kind=result.kind),
             kind=result.kind,
@@ -284,7 +294,7 @@ class AssetRegistrar:
         if parent_refs:
             self.asset_store.record_lineage(child=asset_ref, parents=parent_refs)
 
-        # 3. Cache live payloads for in-process downstream consumers.
+        # 4. Cache live payloads for in-process downstream consumers.
         # File assets don't benefit (consumers get a path either way); fig
         # payloads are binary blobs that are rarely consumed as live Python
         # objects — skipping them aligns the registry with the evaluator's
@@ -335,6 +345,7 @@ def _current_index_for(
 def _metadata_with_group(*, metadata: dict[str, Any], result: AssetResult) -> dict[str, Any]:
     """Return version metadata including report presentation labels."""
     version_metadata = dict(metadata)
+    version_metadata.pop(ASSET_CHECKS_METADATA_KEY, None)
     if result.group is not None:
         version_metadata[ASSET_GROUP_METADATA_KEY] = result.group
     if result.caption is not None:
@@ -342,11 +353,41 @@ def _metadata_with_group(*, metadata: dict[str, Any], result: AssetResult) -> di
     return version_metadata
 
 
+def _check_outcomes(*, result: AssetResult) -> list[dict[str, bool | str]]:
+    """Run asset checks and return their serialisable passing outcomes."""
+    outcomes: list[dict[str, bool | str]] = []
+    for check in result.checks:
+        check_name = getattr(check, "__name__", type(check).__name__)
+        if not callable(check):
+            raise AssetCheckError(
+                f"Asset check {check_name!r} for {result.kind!r} asset is not callable."
+            )
+
+        try:
+            passed = check(result.payload)
+        except Exception as exc:
+            raise AssetCheckError(
+                f"Asset check {check_name!r} raised an exception for {result.kind!r} asset."
+            ) from exc
+
+        if not isinstance(passed, bool):
+            raise AssetCheckError(
+                f"Asset check {check_name!r} for {result.kind!r} asset must return bool, "
+                f"got {type(passed).__name__}."
+            )
+        if not passed:
+            raise AssetCheckError(f"Asset check {check_name!r} failed for {result.kind!r} asset.")
+        outcomes.append({"name": check_name, "passed": passed})
+    return outcomes
+
+
 # Re-export for callers that used to import from asset_registration.
 __all__ = [
     "AssetRegistrar",
     "ASSET_CAPTION_METADATA_KEY",
+    "ASSET_CHECKS_METADATA_KEY",
     "ASSET_GROUP_METADATA_KEY",
+    "AssetCheckError",
     "AssetSerializationError",
     "asset_index_for",
     "asset_key_for_result",

--- a/src/ginkgo/runtime/artifacts/value_codec.py
+++ b/src/ginkgo/runtime/artifacts/value_codec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import io
 import logging
 import pickle
@@ -95,6 +96,7 @@ def encode_value(
             "kind": value.kind,
             "sub_kind": value.sub_kind,
             "metadata": dict(value.metadata),
+            "checks": _encode_asset_checks(checks=value.checks),
             "kind_fields": dict(value.kind_fields),
             "payload": payload_encoded,
         }
@@ -216,6 +218,7 @@ def decode_value(
             kind=cast(AssetKind, payload.get("kind", "file")),
             sub_kind=payload.get("sub_kind"),
             metadata=dict(payload.get("metadata", {})),
+            checks=_decode_asset_checks(payload=payload.get("checks")),
             kind_fields=dict(payload.get("kind_fields", {})),
         )
     if kind == "tmp_dir":
@@ -246,6 +249,42 @@ def decode_value(
             payload=payload, base_dir=base_dir, artifact_store=artifact_store
         )
     return payload
+
+
+def _encode_asset_checks(*, checks: tuple[Any, ...]) -> str:
+    """Encode asset checks for process and remote-result transport."""
+    try:
+        data = pickle.dumps(checks, protocol=5)
+    except Exception as exc:
+        raise CodecError(
+            "Asset checks must be importable module-level functions when a task runs "
+            "in a worker or remote executor."
+        ) from exc
+    return base64.b64encode(data).decode("ascii")
+
+
+def _decode_asset_checks(*, payload: Any) -> tuple[Any, ...]:
+    """Decode asset checks from process and remote-result transport."""
+    if payload is None:
+        return ()
+    if not isinstance(payload, str):
+        raise CodecError("Encoded asset checks must be a base64 string.")
+
+    try:
+        checks = pickle.loads(base64.b64decode(payload))
+    except (
+        binascii.Error,
+        EOFError,
+        ImportError,
+        ValueError,
+        pickle.UnpicklingError,
+        TypeError,
+    ) as exc:
+        raise CodecError("Could not decode asset checks from a worker result.") from exc
+
+    if not isinstance(checks, tuple):
+        raise CodecError("Decoded asset checks must be a tuple.")
+    return checks
 
 
 def summarise_value(value: Any) -> Any:

--- a/src/ginkgo/templates/init/base/ginkgo_init_template/modules/prep.py
+++ b/src/ginkgo/templates/init/base/ginkgo_init_template/modules/prep.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from ginkgo import AssetRef, asset, file, shell, task
 
 
+def _seed_card_has_content(payload: object) -> bool:
+    """Return whether a seed-card file exists and has content."""
+    return isinstance(payload, Path) and payload.is_file() and payload.stat().st_size > 0
+
+
 @task()
 def write_seed_card(item: str, output_path: str) -> file:
     """Write a tiny text artifact for one item.
@@ -34,6 +39,7 @@ def write_seed_card(item: str, output_path: str) -> file:
         output,
         name=f"starter/seed_cards/{item}",
         metadata={"item": item, "stage": "seed"},
+        checks=[_seed_card_has_content],
     )
 
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -18,6 +18,35 @@ from ginkgo.runtime.artifacts.asset_serialization import (
     serialize_asset,
 )
 from ginkgo.runtime.artifacts.asset_store import AssetStore
+from ginkgo.runtime.artifacts.asset_registration import AssetCheckError
+from ginkgo.runtime.artifacts.remote_arg_transfer import (
+    hydrate_result_from_remote,
+    stage_result_for_remote,
+)
+from ginkgo.runtime.artifacts.value_codec import CodecError, decode_value, encode_value
+
+
+def has_rows(payload: Any) -> bool:
+    """Return whether a tabular payload has at least one row."""
+    return len(payload) > 0
+
+
+def always_fails(payload: Any) -> bool:
+    """Return a deterministic failed asset check outcome."""
+    del payload
+    return False
+
+
+def returns_non_boolean(payload: Any) -> str:
+    """Return an invalid asset check outcome for testing."""
+    del payload
+    return "yes"
+
+
+def raises_from_check(payload: Any) -> bool:
+    """Raise a deterministic exception from an asset check."""
+    del payload
+    raise ValueError("check exploded")
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +90,15 @@ class TestFactories:
         assert via_asset.name == via_shorthand.name == "features"
         assert via_asset.group == via_shorthand.group == "QC metrics"
         assert via_asset.caption == via_shorthand.caption == "Variant counts after QC filtering"
+
+    def test_checks_are_preserved_by_asset_factories(self) -> None:
+        frame = pd.DataFrame({"a": [1]})
+        via_asset = ginkgo.asset(frame, kind="table", checks=[has_rows])
+        via_shorthand = table(frame, checks=[has_rows])
+
+        assert via_asset.checks == (has_rows,)
+        assert via_shorthand.checks == (has_rows,)
+        assert table(frame).checks == ()
 
     def test_presentation_labels_are_normalized(self) -> None:
         grouped = table(
@@ -356,6 +394,26 @@ def make_exploding_table_task() -> object:
 
 
 @task()
+def make_checked_table_task() -> object:
+    return table(pd.DataFrame({"a": [1]}), name="checked", checks=[has_rows])
+
+
+@task()
+def make_failed_check_task() -> object:
+    return table(pd.DataFrame({"a": [1]}), name="rejected", checks=[always_fails])
+
+
+@task()
+def make_invalid_check_task() -> object:
+    return table(pd.DataFrame({"a": [1]}), name="invalid", checks=[returns_non_boolean])
+
+
+@task()
+def make_raising_check_task() -> object:
+    return table(pd.DataFrame({"a": [1]}), name="raising", checks=[raises_from_check])
+
+
+@task()
 def consumer_task(upstream: object) -> int:
     # Wrapped ``AssetRef`` inputs are rehydrated to the live payload at
     # arg-binding time, so downstream tasks observe the canonical
@@ -443,6 +501,40 @@ class TestEvaluatorIntegration:
         keys = AssetStore(root=asset_dir).list_asset_keys() if asset_dir.is_dir() else []
         assert not any(key.namespace == "table" and key.name == "dup" for key in keys)
 
+    def test_passing_check_is_persisted_with_asset_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        result = ginkgo.evaluate(make_checked_table_task())
+
+        assert isinstance(result, AssetRef)
+        assert result.metadata["_checks"] == [{"name": "has_rows", "passed": True}]
+
+    @pytest.mark.parametrize(
+        ("expression", "message"),
+        [
+            (make_failed_check_task(), "Asset check 'always_fails' failed"),
+            (make_invalid_check_task(), "must return bool, got str"),
+            (make_raising_check_task(), "Asset check 'raises_from_check' raised an exception"),
+        ],
+    )
+    def test_rejected_checks_do_not_register_versions(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        expression: object,
+        message: str,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(AssetCheckError, match=message):
+            ginkgo.evaluate(expression)
+
+        asset_dir = tmp_path / ".ginkgo" / "assets"
+        keys = AssetStore(root=asset_dir).list_asset_keys() if asset_dir.is_dir() else []
+        assert not keys
+
     def test_cache_hit_reuses_artifact_id(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -465,6 +557,46 @@ class TestEvaluatorIntegration:
         assert ginkgo.evaluate(expr) == 1
         # Second call must also succeed, keyed on artifact id rather than payload.
         assert ginkgo.evaluate(expr) == 1
+
+
+class TestAssetCheckTransport:
+    def test_asset_checks_round_trip_through_value_codec(self, tmp_path: Path) -> None:
+        encoded = encode_value(
+            table(pd.DataFrame({"a": [1]}), checks=[has_rows]),
+            base_dir=tmp_path,
+        )
+
+        decoded = decode_value(encoded, base_dir=tmp_path)
+
+        assert isinstance(decoded, AssetResult)
+        assert decoded.checks == (has_rows,)
+
+    def test_unserializable_asset_check_raises_clear_error(self, tmp_path: Path) -> None:
+        def nested_check(payload: Any) -> bool:
+            return payload is not None
+
+        with pytest.raises(CodecError, match="importable module-level functions"):
+            encode_value(
+                table(pd.DataFrame({"a": [1]}), checks=[nested_check]),
+                base_dir=tmp_path,
+            )
+
+    def test_asset_checks_survive_remote_result_transport(self, tmp_path: Path) -> None:
+        encoded = encode_value(
+            table(pd.DataFrame({"a": [1]}), checks=[has_rows]),
+            base_dir=tmp_path,
+        )
+        staged = stage_result_for_remote(result=encoded, remote_store=object())
+        hydrated = hydrate_result_from_remote(
+            result=staged,
+            remote_store=object(),
+            scratch_dir=tmp_path / "hydrated",
+        )
+
+        decoded = decode_value(hydrated, base_dir=tmp_path)
+
+        assert isinstance(decoded, AssetResult)
+        assert decoded.checks == (has_rows,)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -202,10 +202,16 @@ class TestExamples:
         assert notebook_html.is_file()
         assert (example_dir / "results" / "summary.json").is_file()
         assert (example_dir / "results" / "delivery_manifest.md").is_file()
-        assert any(
-            task.get("assets")
+        seed_card_assets = [
+            asset
             for task in first_manifest["tasks"].values()
             if str(task["task"]).endswith(".write_seed_card")
+            for asset in task.get("assets", [])
+        ]
+        assert seed_card_assets
+        assert all(
+            asset["metadata"]["_checks"] == [{"name": "_seed_card_has_content", "passed": True}]
+            for asset in seed_card_assets
         )
 
         with _mock_docker(), _mock_notebook_tools():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -112,6 +112,7 @@ def _register_asset(
     text: str = "alpha\nbeta\ngamma\n",
     group: str | None = None,
     caption: str | None = None,
+    checks: list[dict[str, bool | str]] | None = None,
     append: bool = False,
 ) -> None:
     """Register a file asset and patch the manifest to reference it."""
@@ -125,6 +126,8 @@ def _register_asset(
         metadata["ginkgo_group"] = group
     if caption is not None:
         metadata["ginkgo_caption"] = caption
+    if checks is not None:
+        metadata["_checks"] = checks
     version = make_asset_version(
         key=AssetKey(namespace="file", name=name),
         kind="file",
@@ -254,6 +257,28 @@ class TestReportData:
         status_entries = [kv for kv in report.masthead_kv if kv.key == "status"]
         assert len(status_entries) == 1
 
+    def test_asset_checks_are_exposed_on_cards(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path=tmp_path, run_id="run-checks", fail=False)
+        _register_asset(
+            tmp_path=tmp_path,
+            run_id="run-checks",
+            run_dir=run_dir,
+            name="demo/checked",
+            checks=[{"name": "has_rows", "passed": True}],
+            append=True,
+        )
+
+        report = build_report_data(run_dir=run_dir)
+        checked_card = next(
+            card
+            for section in report.assets
+            for card in section.cards
+            if card.name == "demo/checked"
+        )
+
+        assert checked_card.checks[0].name == "has_rows"
+        assert checked_card.checks[0].passed is True
+
     def test_grouped_assets_render_in_named_sections(self, tmp_path: Path) -> None:
         run_dir = _make_run(tmp_path=tmp_path, run_id="run-assets", fail=False)
         _register_asset(
@@ -318,6 +343,23 @@ class TestReportData:
 
 
 class TestExport:
+    def test_bundle_mode_renders_asset_check_badges(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path=tmp_path, run_id="run-checks", fail=False)
+        _register_asset(
+            tmp_path=tmp_path,
+            run_id="run-checks",
+            run_dir=run_dir,
+            name="demo/checked",
+            checks=[{"name": "has_rows", "passed": True}],
+            append=True,
+        )
+
+        result = export_report(run_dir=run_dir, out_dir=tmp_path / "out")
+        html = result.index_path.read_text(encoding="utf-8")
+
+        assert "has_rows" in html
+        assert "check-pass" in html
+
     def test_bundle_mode_writes_index_and_assets(self, tmp_path: Path) -> None:
         run_dir = _make_run(tmp_path=tmp_path, run_id="run-ok", fail=False)
         out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- add strict, callable checks to all asset constructors
- preserve checks across worker and remote result transport, then store passing outcomes with asset versions
- render check badges in HTML reports and document the contract

## Validation
- ....................s..sss.............................................. [ 85%]
............                                                             [100%]
80 passed, 4 skipped in 16.95s
- All checks passed!
- commit hooks: Ruff format, Ty, uncoded sync

Closes #49