### PR TITLE
feat: local FUSE streaming for remote inputs

### DIFF
--- a/docs/architecture/remote-input-access.md
+++ b/docs/architecture/remote-input-access.md
@@ -16,6 +16,12 @@ inside the worker pod:
 Streaming is **opt-in** per input, per task, or via config default. The
 staged path remains the correctness fallback.
 
+Both the **remote dispatch path** and the **local process-pool path**
+can stream. Local streaming applies to worker (Python) tasks on a host
+with a healthy driver + `/dev/fuse`; driver-kind tasks (`notebook` /
+`script` / `shell`) always stage locally (see
+[Local FUSE](#local-fuse)).
+
 ## Strategy interface
 
 Both strategies satisfy `RemoteInputAccess` in
@@ -81,6 +87,39 @@ The worker:
    unmounts every active mount and records `unmount_seconds`.
 5. Folds `AccessStats.to_dict()` into the result envelope as
    `remote_input_access`.
+
+## Local FUSE
+
+Local (non-dispatched) worker tasks stream through the same
+`MountedAccess` strategy without any pod / privileged-container / CSI
+surface — just the driver binary + `/dev/fuse`.
+
+- **Gating.** `RemoteStager.stage_remote_refs`
+  (`ginkgo/runtime/remote_input_resolver.py`) lifts the remote-only
+  short-circuit for local worker tasks. Fuse selection is resolved
+  per scheme with `driver_available=local_streaming_available(scheme=...)`
+  (`ginkgo/remote/access/doctor.py`) — `/dev/fuse` present **and** the
+  scheme's driver passing its health check. When the host cannot stream,
+  `resolve_access` degrades to `stage`. Driver-kind tasks
+  (`notebook` / `script` / `shell`) run on the scheduler thread with no
+  mount lifecycle and are still forced to `stage`. macOS has no
+  `/dev/fuse`, so it is stage-only there.
+
+- **Hydration + teardown.** `ginkgo/runtime/worker.py::run_task` mirrors
+  `remote/worker.py`: it detects fuse markers in the decoded args, mounts
+  them through a `MountedAccess` rooted **under the task's transport dir**
+  (`<transport>/fuse`, cache `<transport>/fuse-cache`), runs the body,
+  and tears the mount down in a `finally`. The per-task mount root keeps
+  concurrent process-pool workers from colliding on a shared bucket mount
+  point. On success `AccessStats.to_dict()` is folded into the result
+  envelope as `remote_input_access`.
+
+- **Provenance.** `ConcurrentEvaluator._fold_remote_input_access` records
+  the stats from `_handle_completed_worker_phase`, covering both local
+  and remote workers, and surfaces a notice on staged fallback.
+
+This is **one `MountedAccess` per task**, not one shared across the pool;
+a shared, ref-counted mount pool is a possible later optimisation.
 
 ## Pod security
 

--- a/src/ginkgo/remote/access/__init__.py
+++ b/src/ginkgo/remote/access/__init__.py
@@ -17,6 +17,7 @@ heuristic.
 
 from __future__ import annotations
 
+from ginkgo.remote.access.doctor import local_streaming_available
 from ginkgo.remote.access.mounted import MountedAccess
 from ginkgo.remote.access.protocol import (
     FUSE_FILE_TYPE,
@@ -50,5 +51,6 @@ __all__ = [
     "encode_fuse_ref",
     "is_fuse_ref",
     "load_access_config",
+    "local_streaming_available",
     "resolve_access",
 ]

--- a/src/ginkgo/remote/access/doctor.py
+++ b/src/ginkgo/remote/access/doctor.py
@@ -17,6 +17,37 @@ from typing import Any
 from ginkgo.remote.access.resolver import AccessConfig, load_access_config
 
 
+def local_streaming_available(*, scheme: str) -> bool:
+    """Return whether the local host can FUSE-mount objects for ``scheme``.
+
+    Streaming on the local host requires both the kernel FUSE device
+    (``/dev/fuse``) and a healthy driver binary for the URI scheme on
+    ``PATH``. Used to gate local (non-dispatched) tasks into the fuse
+    path; when it returns ``False`` the resolver degrades to ``stage``.
+
+    Parameters
+    ----------
+    scheme : str
+        Remote URI scheme (``"s3"`` / ``"gs"`` / ``"oci"``).
+
+    Returns
+    -------
+    bool
+        ``True`` when ``/dev/fuse`` exists and the scheme's driver passes
+        its health check; ``False`` otherwise (including on macOS, where
+        ``/dev/fuse`` is absent).
+    """
+    if not Path("/dev/fuse").exists():
+        return False
+    from ginkgo.remote.access.drivers.base import resolve_driver
+
+    try:
+        resolve_driver(scheme=scheme).health_check()
+    except Exception:  # noqa: BLE001 - any driver failure means unavailable
+        return False
+    return True
+
+
 @dataclass(frozen=True, kw_only=True)
 class AccessDiagnostic:
     """One diagnostic entry produced by the streaming probes."""

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -793,6 +793,7 @@ class ConcurrentEvaluator:
         remote_job_id: str | None = None,
     ) -> None:
         """Handle the result returned from a Python worker."""
+        self._fold_remote_input_access(node=node, payload=completed_value)
         completed_value = self._decode_worker_result(node=node, payload=completed_value)
         node.remote_job_id = remote_job_id
         self._handle_task_body_result(node=node, completed_value=completed_value)
@@ -1388,8 +1389,15 @@ class ConcurrentEvaluator:
                 scratch_dir=scratch_dir,
             )
 
-        # Fold remote input-access stats (FUSE mount cost, cache hits, fallbacks)
-        # into provenance when the worker reported them.
+        return payload
+
+    def _fold_remote_input_access(self, *, node: _TaskNode, payload: Any) -> None:
+        """Fold worker-reported input-access stats into provenance.
+
+        Records FUSE mount cost, cache hits, and fallbacks for both remote
+        and local (process-pool) workers, and surfaces a notice when a
+        mount fell back to staging.
+        """
         if (
             isinstance(payload, dict)
             and isinstance(payload.get("remote_input_access"), dict)
@@ -1401,8 +1409,6 @@ class ConcurrentEvaluator:
                 remote_input_access=access_stats,
             )
             self._warn_on_access_fallback(node=node, access_stats=access_stats)
-
-        return payload
 
     def _warn_on_access_fallback(
         self,

--- a/src/ginkgo/runtime/remote_input_resolver.py
+++ b/src/ginkgo/runtime/remote_input_resolver.py
@@ -24,6 +24,7 @@ from typing import Any, get_args, get_origin
 from ginkgo.config import load_runtime_config
 from ginkgo.core.remote import RemoteFileRef, RemoteFolderRef, RemoteRef, is_remote_uri
 from ginkgo.core.types import file, folder
+from ginkgo.remote.access.doctor import local_streaming_available
 from ginkgo.remote.access.protocol import encode_fuse_ref
 from ginkgo.remote.access.resolver import (
     AccessConfig,
@@ -31,6 +32,11 @@ from ginkgo.remote.access.resolver import (
     load_access_config,
     resolve_access,
 )
+
+# Task kinds whose bodies run on the scheduler thread / in a driver
+# subprocess rather than through ``run_task`` in the process pool. These
+# have no local mount lifecycle, so they always stage remote inputs.
+_DRIVER_KINDS = frozenset({"notebook", "script", "shell"})
 
 
 def remote_value_requires_staging(*, annotation: Any, value: Any) -> bool:
@@ -234,22 +240,27 @@ class RemoteStager:
         task_policy = TaskAccessPolicy.from_task_def(task_def)
         access_config = self._get_access_config()
 
-        # Fuse mounting is currently only wired for the remote dispatch
-        # path: the worker hydrates fuse markers via `MountedAccess`, but
-        # the local process-pool path has no equivalent mount lifecycle.
-        # For local tasks, force `stage` so downstream code receives a
-        # normal local path. (Local FUSE on a host with a healthy driver
-        # would also be useful for sparse reads of large objects; see the
-        # follow-up tracked on PR #41.)
+        # Fuse mounting is wired for the remote dispatch path (the worker
+        # mounts markers via `MountedAccess`) and for local process-pool
+        # tasks (hydrated in `run_task` against a task-local mount root).
+        # Driver-kind tasks run on the scheduler thread with no mount
+        # lifecycle, so they always stage. Local worker tasks stream only
+        # when the host has a healthy driver + `/dev/fuse`; that per-scheme
+        # check is deferred to `resolve_access` via `require_local_driver`.
         dispatches_remote = bool(
             getattr(task_def, "remote", False) or getattr(task_def, "gpu", 0) > 0
         )
+        is_driver_kind = getattr(task_def, "kind", None) in _DRIVER_KINDS
+        require_local_driver = False
         if not dispatches_remote:
-            task_policy = TaskAccessPolicy(
-                remote_input_access="stage",
-                streaming_compatible=False,
-                fuse_prefetch=task_policy.fuse_prefetch,
-            )
+            if is_driver_kind:
+                task_policy = TaskAccessPolicy(
+                    remote_input_access="stage",
+                    streaming_compatible=False,
+                    fuse_prefetch=task_policy.fuse_prefetch,
+                )
+            else:
+                require_local_driver = True
 
         staged: dict[str, Any] = {}
         for name, value in resolved_args.items():
@@ -264,6 +275,7 @@ class RemoteStager:
                 value=value,
                 task_policy=task_policy,
                 access_config=access_config,
+                require_local_driver=require_local_driver,
             )
         return staged
 
@@ -274,18 +286,33 @@ class RemoteStager:
         value: Any,
         task_policy: TaskAccessPolicy | None = None,
         access_config: AccessConfig | None = None,
+        require_local_driver: bool = False,
     ) -> Any:
-        """Stage a single value, recursing into typed containers."""
+        """Stage a single value, recursing into typed containers.
+
+        When ``require_local_driver`` is ``True`` (local worker tasks),
+        fuse selection is gated per scheme on the local host having a
+        healthy driver + ``/dev/fuse``; otherwise fuse degrades to
+        ``stage``. Remote dispatch leaves this ``False`` and assumes the
+        pod carries the drivers.
+        """
         task_policy = task_policy or TaskAccessPolicy()
         access_config = access_config or self._get_access_config()
 
-        # Explicit remote refs.
-        if isinstance(value, (RemoteFileRef, RemoteFolderRef)):
-            policy = resolve_access(
-                ref=value,
+        def _policy_for(ref: RemoteRef) -> str:
+            driver_available = (
+                local_streaming_available(scheme=ref.scheme) if require_local_driver else True
+            )
+            return resolve_access(
+                ref=ref,
                 task_policy=task_policy,
                 config=access_config,
+                driver_available=driver_available,
             )
+
+        # Explicit remote refs.
+        if isinstance(value, (RemoteFileRef, RemoteFolderRef)):
+            policy = _policy_for(value)
             if policy.startswith("fuse"):
                 return encode_fuse_ref(ref=value, policy=policy)
             if isinstance(value, RemoteFileRef):
@@ -298,7 +325,7 @@ class RemoteStager:
                 from ginkgo.core.remote import remote_file
 
                 ref = remote_file(value)
-                policy = resolve_access(ref=ref, task_policy=task_policy, config=access_config)
+                policy = _policy_for(ref)
                 if policy.startswith("fuse"):
                     return encode_fuse_ref(ref=ref, policy=policy)
                 return file(str(self._stage_remote_ref(ref=ref)))
@@ -306,7 +333,7 @@ class RemoteStager:
                 from ginkgo.core.remote import remote_folder
 
                 ref = remote_folder(value)
-                policy = resolve_access(ref=ref, task_policy=task_policy, config=access_config)
+                policy = _policy_for(ref)
                 if policy.startswith("fuse"):
                     return encode_fuse_ref(ref=ref, policy=policy)
                 return folder(str(self._stage_remote_ref(ref=ref)))
@@ -322,6 +349,7 @@ class RemoteStager:
                     value=item,
                     task_policy=task_policy,
                     access_config=access_config,
+                    require_local_driver=require_local_driver,
                 )
                 for item in value
             ]

--- a/src/ginkgo/runtime/worker.py
+++ b/src/ginkgo/runtime/worker.py
@@ -33,6 +33,12 @@ def run_task(payload: dict[str, Any]) -> dict[str, Any]:
         name: decode_value(value, base_dir=base_dir) for name, value in payload["args"].items()
     }
 
+    # Mount any fuse-marked inputs against a task-local mount root so
+    # concurrent workers never collide on a shared bucket mount point. The
+    # access instance is held before hydration so the finally below always
+    # tears mounts down, even if hydration itself fails partway.
+    mounted_access = _local_fuse_access(args=decoded_args, base_dir=base_dir)
+
     stdout_path = payload.get("stdout_path")
     stderr_path = payload.get("stderr_path")
     secret_values = tuple(payload.get("secret_values", ()))
@@ -51,6 +57,12 @@ def run_task(payload: dict[str, Any]) -> dict[str, Any]:
             secret_values=secret_values,
             log_emitter=_queue_log_emitter(event_queue=event_queue, context=log_context),
         ):
+            if mounted_access is not None:
+                from ginkgo.remote.access.worker_hydration import hydrate_fuse_refs
+
+                decoded_args, _ = hydrate_fuse_refs(
+                    args=decoded_args, mounted_access=mounted_access
+                )
             task_binding = _load_task_binding(payload=payload)
             fn = getattr(task_binding, "fn", task_binding)
             result = fn(**decoded_args)
@@ -62,12 +74,51 @@ def run_task(payload: dict[str, Any]) -> dict[str, Any]:
                 )
         exc.args = (redact_text(text=str(exc), secret_values=secret_values),)
         return error_response(exc)
+    finally:
+        if mounted_access is not None:
+            mounted_access.close()
 
     if payload.get("dynamic_result", True) and _is_dynamic_result(result):
-        return {"ok": True, "result": result, "result_encoding": "direct"}
+        response = {"ok": True, "result": result, "result_encoding": "direct"}
+    else:
+        encoded_result = encode_value(result, base_dir=base_dir)
+        response = {"ok": True, "result": encoded_result, "result_encoding": "encoded"}
 
-    encoded_result = encode_value(result, base_dir=base_dir)
-    return {"ok": True, "result": encoded_result, "result_encoding": "encoded"}
+    if mounted_access is not None:
+        response["remote_input_access"] = mounted_access.stats().to_dict()
+    return response
+
+
+def _local_fuse_access(*, args: dict[str, Any], base_dir: Path) -> Any:
+    """Build a task-local :class:`MountedAccess` when args carry fuse markers.
+
+    Mount points live under ``base_dir`` (the task's transport dir) so
+    parallel process-pool workers do not share a bucket mount point.
+    Returns ``None`` when no fuse markers are present so non-streaming
+    tasks pay no import or setup cost.
+    """
+    if not _args_have_fuse_markers(args):
+        return None
+
+    from ginkgo.remote.access.mounted import MountedAccess
+
+    return MountedAccess(
+        mount_root=base_dir / "fuse",
+        cache_root=base_dir / "fuse-cache",
+    )
+
+
+def _args_have_fuse_markers(value: Any) -> bool:
+    """Return whether ``value`` contains any fuse marker dict."""
+    from ginkgo.remote.access.protocol import is_fuse_ref
+
+    if is_fuse_ref(value):
+        return True
+    if isinstance(value, dict):
+        return any(_args_have_fuse_markers(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_args_have_fuse_markers(item) for item in value)
+    return False
 
 
 def _is_dynamic_result(value: Any) -> bool:

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -430,6 +430,92 @@ class TestWorkerHydration:
 
 
 # ---------------------------------------------------------------------------
+# Local streaming probe
+# ---------------------------------------------------------------------------
+
+
+class TestLocalStreamingAvailable:
+    def test_false_when_dev_fuse_missing(self, monkeypatch) -> None:
+        from ginkgo.remote.access import doctor
+
+        monkeypatch.setattr(doctor.Path, "exists", lambda self: False)
+        assert doctor.local_streaming_available(scheme="s3") is False
+
+    def test_false_when_driver_unhealthy(self, monkeypatch) -> None:
+        from ginkgo.remote.access import doctor
+        from ginkgo.remote.access.drivers import base as driver_base
+
+        monkeypatch.setattr(doctor.Path, "exists", lambda self: True)
+
+        class _DeadDriver:
+            def health_check(self) -> None:
+                raise DriverUnavailableError("missing")
+
+        monkeypatch.setattr(driver_base, "resolve_driver", lambda *, scheme: _DeadDriver())
+        assert doctor.local_streaming_available(scheme="s3") is False
+
+    def test_true_when_device_and_driver_present(self, monkeypatch) -> None:
+        from ginkgo.remote.access import doctor
+        from ginkgo.remote.access.drivers import base as driver_base
+
+        monkeypatch.setattr(doctor.Path, "exists", lambda self: True)
+
+        class _HealthyDriver:
+            def health_check(self) -> None:
+                return
+
+        monkeypatch.setattr(driver_base, "resolve_driver", lambda *, scheme: _HealthyDriver())
+        assert doctor.local_streaming_available(scheme="s3") is True
+
+
+# ---------------------------------------------------------------------------
+# Local process-pool worker hydration
+# ---------------------------------------------------------------------------
+
+
+class TestLocalWorkerFuseHydration:
+    def test_args_have_fuse_markers_detects_nested(self) -> None:
+        from ginkgo.runtime.worker import _args_have_fuse_markers
+
+        ref = remote_file("s3://bucket/one.txt", access="fuse")
+        marker = encode_fuse_ref(ref=ref, policy="fuse")
+        assert _args_have_fuse_markers({"a": marker}) is True
+        assert _args_have_fuse_markers({"a": [1, {"b": marker}]}) is True
+        assert _args_have_fuse_markers({"a": 1, "b": "s3://x/y"}) is False
+
+    def test_local_fuse_access_mounts_under_transport_dir(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from ginkgo.core.types import file as file_type
+        from ginkgo.remote.access import mounted as mounted_mod
+        from ginkgo.remote.access.worker_hydration import hydrate_fuse_refs
+        from ginkgo.runtime.worker import _local_fuse_access
+
+        driver = _StubDriver()
+        monkeypatch.setattr(mounted_mod, "resolve_driver", lambda *, scheme: driver)
+
+        ref = remote_file("s3://bucket/one.txt", access="fuse")
+        marker = encode_fuse_ref(ref=ref, policy="fuse")
+        access = _local_fuse_access(args={"data": marker}, base_dir=tmp_path)
+
+        assert access is not None
+        rewritten, _ = hydrate_fuse_refs(args={"data": marker}, mounted_access=access)
+        assert isinstance(rewritten["data"], file_type)
+        # Mount lives under the task-local transport dir, not a shared root.
+        assert str(rewritten["data"]).startswith(str(tmp_path / "fuse"))
+        assert access.stats().policy == "fuse"
+
+        access.close()
+        assert len(driver.unmounted) == 1
+
+    def test_local_fuse_access_none_without_markers(self, tmp_path: Path) -> None:
+        from ginkgo.runtime.worker import _local_fuse_access
+
+        args = {"data": 5, "uri": "s3://bucket/plain.txt"}
+        assert _local_fuse_access(args=args, base_dir=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
 # Executor fuse detection
 # ---------------------------------------------------------------------------
 
@@ -465,6 +551,7 @@ class _MockTaskDef:
 
     remote: bool = True
     gpu: int = 0
+    kind: str = "python"
     remote_input_access: str | None = None
     streaming_compatible: bool = True
     fuse_prefetch: tuple = ()
@@ -542,9 +629,15 @@ class TestRemoteStagerFuseRouting:
         assert is_fuse_ref(staged["data"])
         assert staged["data"]["uri"] == "s3://bucket/k.txt"
 
-    def test_non_remote_task_forces_stage(self, tmp_path: Path, monkeypatch) -> None:
+    def test_local_task_without_driver_forces_stage(self, tmp_path: Path, monkeypatch) -> None:
         from ginkgo.remote.access.resolver import AccessConfig
+        from ginkgo.runtime import remote_input_resolver
         from ginkgo.runtime.remote_input_resolver import RemoteStager
+
+        # No healthy local driver: fuse must degrade to a staged download.
+        monkeypatch.setattr(
+            remote_input_resolver, "local_streaming_available", lambda *, scheme: False
+        )
 
         # The stager must route through StagingCache.stage_file; patch it to
         # avoid a real download.
@@ -576,7 +669,74 @@ class TestRemoteStagerFuseRouting:
             task_def=task_def,
             resolved_args={"data": ref},
         )
-        # Local task ignores fuse; output is a staged local path (file instance).
+        # Without a local driver, output is a staged local path (file instance).
+        from ginkgo.core.types import file as file_type
+
+        assert isinstance(staged["data"], file_type)
+        assert not is_fuse_ref(staged["data"])
+
+    def test_local_task_streams_when_driver_available(self, monkeypatch) -> None:
+        from ginkgo.remote.access.resolver import AccessConfig
+        from ginkgo.runtime import remote_input_resolver
+        from ginkgo.runtime.remote_input_resolver import RemoteStager
+
+        # Healthy local driver: a fuse-marked ref streams instead of staging.
+        monkeypatch.setattr(
+            remote_input_resolver, "local_streaming_available", lambda *, scheme: True
+        )
+
+        stager = RemoteStager(access_config=AccessConfig(default="stage"))
+        from inspect import Parameter, Signature
+
+        task_def = _MockTaskDef(
+            remote=False,
+            type_hints={"data": RemoteFileRef},
+            signature=Signature(parameters=[Parameter("data", Parameter.POSITIONAL_OR_KEYWORD)]),
+        )
+        ref = remote_file("s3://bucket/k.txt", access="fuse")
+        staged = stager.stage_remote_refs(
+            task_def=task_def,
+            resolved_args={"data": ref},
+        )
+        assert is_fuse_ref(staged["data"])
+        assert staged["data"]["uri"] == "s3://bucket/k.txt"
+
+    def test_local_driver_kind_task_forces_stage(self, tmp_path: Path, monkeypatch) -> None:
+        from ginkgo.remote.access.resolver import AccessConfig
+        from ginkgo.runtime import remote_input_resolver
+        from ginkgo.runtime.remote_input_resolver import RemoteStager
+
+        # Even with a healthy driver, driver-kind tasks (shell/notebook/script)
+        # have no local mount lifecycle and must stage.
+        monkeypatch.setattr(
+            remote_input_resolver, "local_streaming_available", lambda *, scheme: True
+        )
+        from ginkgo.remote import staging
+
+        class _FakeCache:
+            def stage_file(self, *, ref: RemoteFileRef) -> Path:  # noqa: ARG002
+                return tmp_path / "staged.bin"
+
+            def stage_folder(self, *, ref: RemoteFolderRef) -> Path:  # noqa: ARG002
+                raise NotImplementedError
+
+        (tmp_path / "staged.bin").write_bytes(b"")
+        monkeypatch.setattr(staging, "StagingCache", lambda: _FakeCache())
+
+        stager = RemoteStager(access_config=AccessConfig(default="stage"))
+        from inspect import Parameter, Signature
+
+        task_def = _MockTaskDef(
+            remote=False,
+            kind="shell",
+            type_hints={"data": RemoteFileRef},
+            signature=Signature(parameters=[Parameter("data", Parameter.POSITIONAL_OR_KEYWORD)]),
+        )
+        ref = remote_file("s3://bucket/k.txt", access="fuse")
+        staged = stager.stage_remote_refs(
+            task_def=task_def,
+            resolved_args={"data": ref},
+        )
         from ginkgo.core.types import file as file_type
 
         assert isinstance(staged["data"], file_type)


### PR DESCRIPTION
Closes #75.

Lifts the remote-only gate on FUSE streaming so tasks running **locally** can mount remote objects on demand instead of always downloading them — the same sparse-access win the remote dispatch path already realises.

## What changed

**Local streaming probe** (`remote/access/doctor.py`)
`local_streaming_available(scheme)` returns `True` only when `/dev/fuse` exists **and** the scheme's driver passes its health check. macOS (no `/dev/fuse`) stays stage-only automatically.

**Lifted the gate** (`runtime/remote_input_resolver.py`)
`stage_remote_refs` no longer blanket-forces `stage` for local tasks:
- Local **worker (Python)** tasks may stream; fuse selection is resolved per scheme via `resolve_access(driver_available=local_streaming_available(...))`, degrading to `stage` when the host can't stream and honouring `ref.access` / task / pattern / config when it can.
- Local **driver-kind** tasks (`notebook`/`script`/`shell`) still stage — they run on the scheduler thread with no mount lifecycle.

**Local hydration + teardown** (`runtime/worker.py`)
`run_task` mirrors the remote worker: it mounts fuse markers through a `MountedAccess` rooted **under the task's transport dir** (`<transport>/fuse`), runs the body, tears the mount down in a `finally`, and folds `AccessStats` into the result envelope. One `MountedAccess` per task avoids concurrent workers colliding on a shared bucket mount point — this settles the open "per-worker vs. shared" design question in favour of per-task.

**Provenance** (`runtime/evaluator.py`)
Extracted `_fold_remote_input_access`, now called from `_handle_completed_worker_phase`, so local fuse stats and staged-fallback notices surface in provenance exactly as remote ones do. Remote behaviour is unchanged (still folded exactly once).

## Success criteria
- ✅ A local `fuse`-policy Python task on a Linux host with a healthy driver mounts and reads on demand rather than staging.
- ✅ Mount failure / unhealthy driver / macOS degrades cleanly to `stage (fallback)` / `stage`.
- ✅ No behaviour change for tasks that dispatch remote.

## Testing
Added tests in `tests/test_remote_access.py` covering the probe, the gate (local-with-driver streams, local-without-driver stages, driver-kind always stages), marker detection, and the task-local mount lifecycle with a stub driver. Ran the evaluator, remote-evaluator, remote-provenance, staging, warm-run, fuse-tuning, task, remote, and doctor-CLI suites — all pass. Ruff clean; no new `ty` diagnostics.

Real end-to-end FUSE can't be exercised on macOS (no `/dev/fuse`), so stub-driver tests stand in for the mount path.

Follow-up from PR #41. Local FUSE for driver-kind tasks (a scheduler-thread mount lifecycle) and a shared ref-counted mount pool remain as possible later work.