### PR TITLE
Give terminal task statuses a single home

### DIFF
--- a/src/ginkgo/cli/renderers/models.py
+++ b/src/ginkgo/cli/renderers/models.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Callable
 
 from ginkgo.cli.common import RunMode
+from ginkgo.runtime.run_summary import TERMINAL_STATUSES
 
 
 @dataclass(kw_only=True)
@@ -75,11 +76,11 @@ class _TaskGroup:
 
     def is_terminal(self) -> bool:
         """Return True if every invocation has reached a terminal state."""
-        return all(row.status in {"cached", "succeeded", "failed"} for row in self.rows)
+        return all(row.status in TERMINAL_STATUSES for row in self.rows)
 
     def terminal_count(self) -> int:
         """Return the number of invocations in a terminal state."""
-        return sum(1 for row in self.rows if row.status in {"cached", "succeeded", "failed"})
+        return sum(1 for row in self.rows if row.status in TERMINAL_STATUSES)
 
     def elapsed(self, *, now: float) -> float | None:
         """Return wall-clock seconds from earliest start to latest finish or *now*."""

--- a/src/ginkgo/cli/renderers/run.py
+++ b/src/ginkgo/cli/renderers/run.py
@@ -31,6 +31,7 @@ from ginkgo.cli.renderers.common import (
     _truncate_task_label,
 )
 from ginkgo.formatting import format_bytes, format_duration
+from ginkgo.runtime.run_summary import TERMINAL_STATUSES
 from ginkgo.cli.renderers.models import (
     CliAssetSummary,
     FailureDetails,
@@ -194,7 +195,7 @@ class CliRunRenderer:
         if status in {"staging", "submitted", "running"}:
             row.started_at = row.started_at or event_time
             row.finished_at = None
-        elif status in {"cached", "succeeded", "failed"}:
+        elif status in TERMINAL_STATUSES:
             row.started_at = row.started_at or event_time
             row.finished_at = event_time
         # Only refresh on state transitions that the user needs to see
@@ -560,7 +561,7 @@ class CliRunRenderer:
 
     def _terminal_count(self) -> int:
         counts = self._status_counts()
-        return counts["cached"] + counts["succeeded"] + counts["failed"]
+        return sum(counts[status] for status in TERMINAL_STATUSES)
 
     def _elapsed_clock(self) -> float:
         if self._final_elapsed is not None and self._run_started_at is not None:

--- a/src/ginkgo/runtime/run_summary.py
+++ b/src/ginkgo/runtime/run_summary.py
@@ -20,7 +20,10 @@ import yaml
 
 from ginkgo.runtime.caching.provenance import load_manifest
 
-_TERMINAL_STATUSES = frozenset({"cached", "succeeded", "failed"})
+# Statuses that mark a task as finished; shared by every consumer that
+# needs to decide terminality (see TaskSummary.is_terminal and the CLI
+# renderers).
+TERMINAL_STATUSES = frozenset({"cached", "succeeded", "failed"})
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -93,7 +96,7 @@ class TaskSummary:
 
     def is_terminal(self) -> bool:
         """Return True when the task reached a terminal status."""
-        return self.status in _TERMINAL_STATUSES
+        return self.status in TERMINAL_STATUSES
 
     @property
     def failure_kind(self) -> str | None:


### PR DESCRIPTION
## Summary

The set of terminal task statuses (`{"cached", "succeeded", "failed"}`) was encoded independently in five places, with nothing keeping them in sync. This promotes `run_summary.py`'s private `_TERMINAL_STATUSES` to a public `TERMINAL_STATUSES` and makes it the single definition:

- `src/ginkgo/runtime/run_summary.py` — renamed `_TERMINAL_STATUSES` to `TERMINAL_STATUSES`; `TaskSummary.is_terminal` uses it as before.
- `src/ginkgo/cli/renderers/models.py` — `_TaskGroup.is_terminal` and `_TaskGroup.terminal_count` now import and use `TERMINAL_STATUSES` instead of restating the literal set.
- `src/ginkgo/cli/renderers/run.py` — the status-transition branch in `_handle_event_line` checks membership in `TERMINAL_STATUSES`, and `_terminal_count` sums `counts[status] for status in TERMINAL_STATUSES` instead of re-deriving the set arithmetically.

Left alone, per the issue: `reporting/model.py`'s `{"succeeded", "cached"}` is a distinct "ok display tone" grouping, not terminality. No Literal/Enum typing introduced — that is tracked separately.

Fixes #102

## Verification

- `pixi run test`: 705 passed, 5 skipped
- `pixi run lint`: all checks passed
- `pixi run format-check`: 194 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)