### PR TITLE
Fail loudly on unparseable modules in the import closure

### DIFF
--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -29,8 +29,9 @@ cache entries without requiring a manual `version=` bump. This is deliberately
 conservative: an edit anywhere in a reachable local module invalidates tasks
 that import it. Dynamic imports and external runtime dependencies are outside
 this static boundary; use `version=` to invalidate cache entries for them. If
-source extraction fails for a task definition, registration fails explicitly
-instead of silently weakening cache correctness.
+source extraction fails for a task definition, or a module in the local import
+closure cannot be read or parsed, registration fails explicitly instead of
+silently weakening cache correctness.
 
 File and folder outputs flow through a formal `ArtifactStore` contract,
 implemented locally by `LocalArtifactStore` in

--- a/src/ginkgo/core/task.py
+++ b/src/ginkgo/core/task.py
@@ -790,7 +790,8 @@ def _compute_source_hash(fn: Callable[..., Any]) -> str:
     Raises
     ------
     ValueError
-        If the source cannot be extracted (lambdas, dynamic functions).
+        If the source cannot be extracted (lambdas, dynamic functions), or
+        if a module in the local import closure cannot be read or parsed.
     """
     from ginkgo.runtime.caching.hashing import hash_file, hash_str
 
@@ -858,12 +859,24 @@ def _module_source_root(*, module: ModuleType, source_path: Path) -> Path:
 
 
 def _imported_modules(*, module: ModuleType, source_path: Path) -> list[ModuleType]:
-    """Return already-loaded modules named by static imports in ``module``."""
+    """Return already-loaded modules named by static imports in ``module``.
+
+    Raises
+    ------
+    ValueError
+        If the module source cannot be read or parsed. Swallowing the error
+        would silently truncate the import closure and stop deeper helper
+        changes from invalidating the cache.
+    """
     try:
         with tokenize.open(source_path) as source_file:
             tree = ast.parse(source_file.read(), filename=str(source_path))
-    except (OSError, SyntaxError, UnicodeDecodeError):
-        return []
+    except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+        raise ValueError(
+            f"Cannot parse imports of module '{module.__name__}' ({source_path}) "
+            "while hashing the task's local import closure. Fix the module source "
+            "so cache invalidation can track the full import closure."
+        ) from exc
 
     names: set[str] = set()
     for node in ast.walk(tree):

--- a/tests/test_cache_integrity.py
+++ b/tests/test_cache_integrity.py
@@ -43,6 +43,43 @@ class TestSourceHash:
         with pytest.raises(ValueError, match="Cannot extract source"):
             TaskDef(fn=ns["dynamic_fn"])
 
+    def test_unparseable_helper_in_import_closure_raises_at_registration(self, tmp_path):
+        """A helper that fails to parse must fail loudly, not truncate the closure."""
+        module_dir = tmp_path / "pkg"
+        module_dir.mkdir()
+        (module_dir / "__init__.py").write_text("")
+        (module_dir / "tasks.py").write_text(
+            textwrap.dedent("""\
+                from . import helpers
+
+                def compute(x: int) -> int:
+                    return helpers.compute(x)
+            """),
+            encoding="utf-8",
+        )
+        helpers_path = module_dir / "helpers.py"
+        helpers_path.write_text(
+            "def compute(x: int) -> int:\n    return x + 1\n", encoding="utf-8"
+        )
+
+        import importlib
+        import sys
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            tasks = importlib.import_module("pkg.tasks")
+
+            # Break the already-imported helper on disk, as during a mid-edit.
+            helpers_path.write_text("def compute(x: int) ->\n", encoding="utf-8")
+
+            with pytest.raises(ValueError, match="Cannot parse imports of module 'pkg.helpers'"):
+                TaskDef(fn=tasks.compute)
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("pkg.helpers", None)
+            sys.modules.pop("pkg.tasks", None)
+            sys.modules.pop("pkg", None)
+
 
 class TestSourceHashCacheInvalidation:
     """Verify that modifying a task function body causes a cache miss."""


### PR DESCRIPTION
## Summary

`_imported_modules` in `src/ginkgo/core/task.py` swallowed `(OSError, SyntaxError, UnicodeDecodeError)` and returned `[]`, silently truncating the transitive import closure used for cache invalidation. A helper module that failed to read or parse would still be hashed itself, but everything *it* imports dropped out of the closure — so a deeper transitive change could silently fail to invalidate the cache.

Following the precedent a few lines above (task construction already fails loudly with a `ValueError` on `inspect.getsource` failures), the swallow is replaced with a `ValueError` naming the module and source path, chained from the original error. The `_compute_source_hash` docstring and `docs/architecture/caching.md` are updated to match — the architecture doc already claimed registration "fails explicitly instead of silently weakening cache correctness", which this makes fully true for the closure walk.

## Test coverage

New test `TestSourceHash::test_unparseable_helper_in_import_closure_raises_at_registration` in `tests/test_cache_integrity.py`: builds a package whose task module imports a helper, imports it, then rewrites the helper on disk with a syntax error (the mid-edit scenario) and asserts `TaskDef` construction raises the contextual `ValueError`.

Verified with `pixi run test` (705 passed, 5 skipped; one unrelated event-ordering flake in `tests/test_vw6_failure.py` passes on rerun), `pixi run lint`, and `pixi run format-check`.

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)