### PR TITLE
Rename asset checks metadata key to ginkgo_checks and render checks in asset show

### DIFF
--- a/docs/architecture/assets.md
+++ b/docs/architecture/assets.md
@@ -129,7 +129,7 @@ arguments (`format=` for `text`, `framework=` / `metrics=` for
   The registrar runs these checks after serialization and before registering
   the asset version. Every check must return `True`; `False`, an exception, or
   a non-boolean result fails the producing task and leaves no catalog version.
-  Passing results are stored under the reserved `_checks` metadata key as
+  Passing results are stored under the reserved `ginkgo_checks` metadata key as
   ordered `{name, passed}` mappings. Checks are transported through worker and
   remote result encoding, so lambdas, nested functions, and closures are not
   supported.
@@ -243,8 +243,9 @@ metadata:
 re-reading the stored bytes. The UI asset payload surfaces the same
 fields under a `kind_metadata` key for future frontend consumers.
 
-Successful asset checks are stored as `_checks` metadata and rendered by the
-HTML report. The strict registration model intentionally does not preserve a
+Successful asset checks are stored as `ginkgo_checks` metadata and rendered by
+the HTML report and by `ginkgo asset show`, which prints one pass/fail line per
+check outcome. The strict registration model intentionally does not preserve a
 failed check on an asset card: a failed check rejects the asset version and is
 reported as the producing task failure. Cached assets are reused without
 rerunning checks.

--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -105,7 +105,7 @@ name in the card header; they are also surfaced by `ginkgo asset show`.
 Like groups, captions are presentation-only and do not affect identity or
 cache behaviour.
 
-Asset check outcomes are read from the reserved `_checks` version-metadata
+Asset check outcomes are read from the reserved `ginkgo_checks` version-metadata
 field into typed `CheckOutcome` values on `AssetCard`. Each asset card renders
 these outcomes as pass/fail badges beside its kind and name. Current strict
 asset checks register only all-passing versions, but the report model accepts

--- a/src/ginkgo/cli/commands/asset.py
+++ b/src/ginkgo/cli/commands/asset.py
@@ -9,7 +9,10 @@ from rich import box
 from rich.table import Table
 
 from ginkgo.cli.common import ASSETS_ROOT, console
-from ginkgo.runtime.artifacts.asset_registration import ASSET_CAPTION_METADATA_KEY
+from ginkgo.runtime.artifacts.asset_registration import (
+    ASSET_CAPTION_METADATA_KEY,
+    ASSET_CHECKS_METADATA_KEY,
+)
 from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
 from ginkgo.runtime.artifacts.asset_store import AssetStore
 from ginkgo.core.asset import AssetKey
@@ -176,6 +179,9 @@ def render_asset_show(*, console, version) -> int:
     caption = metadata.get(ASSET_CAPTION_METADATA_KEY)
     if isinstance(caption, str) and caption.strip():
         console.print(f"Caption: {caption.strip()}")
+    for name, passed in _check_outcomes_from_metadata(metadata=metadata):
+        outcome = "[green]passed[/]" if passed else "[red]failed[/]"
+        console.print(f"Check: {name} {outcome}")
 
     if namespace == "table":
         _render_table_metadata(console=console, metadata=metadata)
@@ -191,6 +197,23 @@ def render_asset_show(*, console, version) -> int:
         console.print(Panel.fit(repr(metadata), title="metadata"))
 
     return 0
+
+
+def _check_outcomes_from_metadata(*, metadata: dict) -> list[tuple[str, bool]]:
+    """Extract well-formed check outcomes from version metadata."""
+    raw_checks = metadata.get(ASSET_CHECKS_METADATA_KEY)
+    if not isinstance(raw_checks, (list, tuple)):
+        return []
+
+    outcomes: list[tuple[str, bool]] = []
+    for raw_outcome in raw_checks:
+        if not isinstance(raw_outcome, dict):
+            continue
+        name = raw_outcome.get("name")
+        passed = raw_outcome.get("passed")
+        if isinstance(name, str) and name and isinstance(passed, bool):
+            outcomes.append((name, passed))
+    return outcomes
 
 
 def _render_table_metadata(*, console, metadata: dict) -> None:

--- a/src/ginkgo/runtime/artifacts/asset_registration.py
+++ b/src/ginkgo/runtime/artifacts/asset_registration.py
@@ -40,7 +40,7 @@ from ginkgo.runtime.caching.cache import CacheStore
 
 ASSET_GROUP_METADATA_KEY = "ginkgo_group"
 ASSET_CAPTION_METADATA_KEY = "ginkgo_caption"
-ASSET_CHECKS_METADATA_KEY = "_checks"
+ASSET_CHECKS_METADATA_KEY = "ginkgo_checks"
 
 
 class AssetCheckError(RuntimeError):
@@ -345,7 +345,6 @@ def _current_index_for(
 def _metadata_with_group(*, metadata: dict[str, Any], result: AssetResult) -> dict[str, Any]:
     """Return version metadata including report presentation labels."""
     version_metadata = dict(metadata)
-    version_metadata.pop(ASSET_CHECKS_METADATA_KEY, None)
     if result.group is not None:
         version_metadata[ASSET_GROUP_METADATA_KEY] = result.group
     if result.caption is not None:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -509,7 +509,7 @@ class TestEvaluatorIntegration:
         result = ginkgo.evaluate(make_checked_table_task())
 
         assert isinstance(result, AssetRef)
-        assert result.metadata["_checks"] == [{"name": "has_rows", "passed": True}]
+        assert result.metadata["ginkgo_checks"] == [{"name": "has_rows", "passed": True}]
 
     @pytest.mark.parametrize(
         ("expression", "message"),
@@ -660,6 +660,26 @@ class TestAssetShow:
         output = capsys.readouterr().out
         assert "Caption:" in output
         assert "Variant counts after QC filtering" in output
+
+    def test_show_renders_checks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        ginkgo.evaluate(make_checked_table_task())
+
+        from ginkgo.cli.app import main
+
+        rc = main(
+            [
+                "asset",
+                "show",
+                "table:make_checked_table_task.checked",
+            ]
+        )
+
+        assert rc == 0
+        output = capsys.readouterr().out
+        assert "Check: has_rows passed" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -210,7 +210,8 @@ class TestExamples:
         ]
         assert seed_card_assets
         assert all(
-            asset["metadata"]["_checks"] == [{"name": "_seed_card_has_content", "passed": True}]
+            asset["metadata"]["ginkgo_checks"]
+            == [{"name": "_seed_card_has_content", "passed": True}]
             for asset in seed_card_assets
         )
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -127,7 +127,7 @@ def _register_asset(
     if caption is not None:
         metadata["ginkgo_caption"] = caption
     if checks is not None:
-        metadata["_checks"] = checks
+        metadata["ginkgo_checks"] = checks
     version = make_asset_version(
         key=AssetKey(namespace="file", name=name),
         kind="file",


### PR DESCRIPTION
Fixes #104

## 1. Rename `ASSET_CHECKS_METADATA_KEY` from `"_checks"` to `"ginkgo_checks"`

The asset-checks metadata key now matches its prefixed siblings `ginkgo_group` and `ginkgo_caption` (`src/ginkgo/runtime/artifacts/asset_registration.py`). The defensive `.pop(ASSET_CHECKS_METADATA_KEY, None)` in `_metadata_with_group` existed only because the bare `_checks` key could collide with user-supplied metadata; with the prefixed key that risk is handled by convention, the same way the sibling keys handle it, so the pop is removed. Existing tests that hardcoded the old key (`tests/test_assets.py`, `tests/test_reporting.py`, `tests/test_examples.py`) and the docs (`docs/architecture/assets.md`, `docs/architecture/reporting.md`) are updated.

**Compatibility note:** check outcomes persisted by runs made before this change live under the old `"_checks"` key and will no longer render in the HTML report or the CLI. This is a simple rename with no fallback read — a fallback would need to land in two read sites (report model and CLI) and would perpetuate the bare key, which is not worth it for presentation-only metadata; re-running the producing task re-registers the version under the new key.

## 2. `ginkgo asset show` renders check outcomes

`render_asset_show` (`src/ginkgo/cli/commands/asset.py`) now reads `ASSET_CHECKS_METADATA_KEY` and prints one `Check: <name> passed/failed` line per well-formed outcome, directly beneath the caption line and matching the existing key/value output style. Parsing mirrors `_asset_checks` in `reporting/model.py` (only `{name: str, passed: bool}` entries render). A CLI test mirroring the existing caption-rendering test covers it, and `docs/architecture/assets.md` now documents the CLI surface alongside the HTML report.

## Verification

- `pixi run test`: 706 passed, 5 skipped
- `pixi run lint`: all checks passed
- `pixi run format-check`: 194 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)