### PR TITLE
Expose public store APIs instead of reaching into private internals

### DIFF
--- a/src/ginkgo/cli/commands/asset.py
+++ b/src/ginkgo/cli/commands/asset.py
@@ -50,10 +50,7 @@ def command_asset(args) -> int:
             rich_console.print(f"[dim]No versions found for {key}.[/]")
             return 0
 
-        index = store._load_index(key)
-        aliases = {
-            str(version_id): alias for alias, version_id in dict(index.get("aliases", {})).items()
-        }
+        aliases = {version_id: alias for alias, version_id in store.list_aliases(key=key).items()}
         rich_console.print(f"Asset Key: [bold]{key}[/]")
         for version in versions:
             rich_console.print(

--- a/src/ginkgo/cli/commands/cache.py
+++ b/src/ginkgo/cli/commands/cache.py
@@ -353,78 +353,30 @@ def _safe_rmtree(path: Path) -> None:
         shutil.rmtree(path)
 
 
-def _cache_artifact_ids(cache_root: Path) -> set[str]:
-    """Return artifact IDs referenced by surviving cache entries."""
-    referenced: set[str] = set()
-    if not cache_root.exists():
-        return referenced
-    for entry_dir in cache_root.iterdir():
-        if not entry_dir.is_dir():
-            continue
-        meta_path = entry_dir / "meta.json"
-        if not meta_path.exists():
-            continue
-        try:
-            meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        for artifact_id in meta.get("artifact_ids", {}).values():
-            referenced.add(artifact_id)
-    return referenced
-
-
-def _asset_artifact_ids(assets_root: Path) -> set[str]:
-    """Return artifact IDs referenced by every catalogued asset version.
-
-    The asset catalog and the cache share a single content-addressed
-    artifact store. Asset versions are intended to outlive the ephemeral
-    cache, so their artifacts must be kept alive even when no cache entry
-    still references them. Each version is persisted at
-    ``<assets_root>/<namespace>/<name>/versions/v-<id>/meta.yaml``.
-    """
-    referenced: set[str] = set()
-    if not assets_root.exists():
-        return referenced
-    for meta_path in assets_root.glob("*/*/versions/v-*/meta.yaml"):
-        try:
-            meta = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
-        except (yaml.YAMLError, OSError):
-            continue
-        artifact_id = meta.get("artifact_id")
-        if isinstance(artifact_id, str) and artifact_id:
-            referenced.add(artifact_id)
-    return referenced
-
-
 def _gc_orphan_artifacts(cache_root: Path) -> None:
     """Remove artifacts not referenced by any cache entry or catalogued asset.
 
-    Collects referenced artifact IDs from every surviving cache entry's
-    ``meta.json`` *and* from every asset version in the sibling ``assets/``
-    catalog, then deletes any artifact in the sibling ``artifacts/``
-    directory that neither references.
-
     The cache and the asset catalog share one artifact store. Scanning only
     the cache would treat asset-only artifacts as orphans and delete data
-    the asset catalog still points to, so the asset catalog must be scanned
-    here as well.
+    the asset catalog still points to, so each store reports its own live
+    artifact IDs and anything the artifact store holds beyond their union
+    is deleted.
     """
     artifacts_root = cache_root.parent / "artifacts"
     if not artifacts_root.exists():
         return
 
-    referenced = _cache_artifact_ids(cache_root)
-    referenced |= _asset_artifact_ids(cache_root.parent / "assets")
-
-    # Remove orphaned artifacts via the store's delete method.
+    # Each store owns its on-disk format and reports the artifact IDs it
+    # still references.
     from ginkgo.runtime.artifacts.artifact_store import LocalArtifactStore
+    from ginkgo.runtime.artifacts.asset_store import AssetStore
+    from ginkgo.runtime.caching.cache import CacheStore
+
+    referenced = CacheStore(root=cache_root).referenced_artifact_ids()
+    referenced |= AssetStore(root=cache_root.parent / "assets").referenced_artifact_ids()
 
     store = LocalArtifactStore(root=artifacts_root)
-    refs_dir = artifacts_root / "refs"
-    if not refs_dir.exists():
-        return
-    for ref_file in list(refs_dir.iterdir()):
-        artifact_id = ref_file.stem
+    for artifact_id in store.list_artifact_ids():
         if artifact_id not in referenced:
             store.delete(artifact_id=artifact_id)
 

--- a/src/ginkgo/reporting/model.py
+++ b/src/ginkgo/reporting/model.py
@@ -757,7 +757,7 @@ def _build_asset_card(
     artifact_copies: list[ArtifactCopy],
 ) -> AssetCard | None:
     """Build one :class:`AssetCard` for a stored asset version."""
-    record = _artifact_record(artifact_store=artifact_store, artifact_id=version.artifact_id)
+    record = artifact_store.load_record(artifact_id=version.artifact_id)
     path = _artifact_path(artifact_store=artifact_store, artifact_id=version.artifact_id)
 
     namespace = version.key.namespace
@@ -1070,16 +1070,6 @@ def _asset_checks(*, metadata: Mapping[str, Any]) -> tuple[CheckOutcome, ...]:
         if isinstance(name, str) and name and isinstance(passed, bool):
             outcomes.append(CheckOutcome(name=name, passed=passed))
     return tuple(outcomes)
-
-
-def _artifact_record(
-    *, artifact_store: LocalArtifactStore, artifact_id: str
-) -> ArtifactRecord | None:
-    """Return stored artifact metadata when it exists."""
-    ref_path = artifact_store._refs_dir / f"{artifact_id}.json"
-    if not ref_path.is_file():
-        return None
-    return ArtifactRecord.from_path(ref_path)
 
 
 def _artifact_path(*, artifact_store: LocalArtifactStore, artifact_id: str) -> Path | None:

--- a/src/ginkgo/runtime/artifacts/artifact_store.py
+++ b/src/ginkgo/runtime/artifacts/artifact_store.py
@@ -314,6 +314,36 @@ class LocalArtifactStore:
         """
         return (self._refs_dir / f"{artifact_id}.json").exists()
 
+    def load_record(self, *, artifact_id: str) -> ArtifactRecord | None:
+        """Return the stored metadata record for one artifact.
+
+        Parameters
+        ----------
+        artifact_id : str
+            The artifact ID to look up.
+
+        Returns
+        -------
+        ArtifactRecord | None
+            The record, or ``None`` when the artifact is not in the store.
+        """
+        ref_path = self._refs_dir / f"{artifact_id}.json"
+        if not ref_path.is_file():
+            return None
+        return ArtifactRecord.from_path(ref_path)
+
+    def list_artifact_ids(self) -> list[str]:
+        """Return the IDs of every artifact currently in the store.
+
+        Returns
+        -------
+        list[str]
+            Sorted artifact IDs.
+        """
+        return sorted(
+            ref_path.stem for ref_path in self._refs_dir.iterdir() if ref_path.suffix == ".json"
+        )
+
     def delete(self, *, artifact_id: str) -> None:
         """Remove an artifact from the store.
 
@@ -593,10 +623,10 @@ class LocalArtifactStore:
 
     def _load_record(self, *, artifact_id: str) -> ArtifactRecord:
         """Load one artifact record or raise if it does not exist."""
-        ref_path = self._refs_dir / f"{artifact_id}.json"
-        if not ref_path.exists():
+        record = self.load_record(artifact_id=artifact_id)
+        if record is None:
             raise FileNotFoundError(f"Artifact not found in store: {artifact_id}")
-        return ArtifactRecord.from_path(ref_path)
+        return record
 
     def _load_tree_ref(self, *, record: ArtifactRecord) -> TreeRef:
         """Load the tree manifest for one directory artifact."""

--- a/src/ginkgo/runtime/artifacts/asset_store.py
+++ b/src/ginkgo/runtime/artifacts/asset_store.py
@@ -107,6 +107,51 @@ class AssetStore:
         versions = [str(item) for item in index.get("versions", [])]
         return [self.get_version(key=key, version_id=version_id) for version_id in versions]
 
+    def list_aliases(self, *, key: AssetKey) -> dict[str, str]:
+        """Return the alias mapping for one asset key.
+
+        Parameters
+        ----------
+        key : AssetKey
+            Asset identity.
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping of alias label to the version id it points at. Empty
+            when the asset has no aliases or is unknown.
+        """
+        index = self._load_index(key)
+        return {
+            str(alias): str(version_id)
+            for alias, version_id in dict(index.get("aliases", {})).items()
+        }
+
+    def referenced_artifact_ids(self) -> set[str]:
+        """Return artifact IDs referenced by every catalogued asset version.
+
+        The asset catalog and the cache share a single content-addressed
+        artifact store. Asset versions are intended to outlive the ephemeral
+        cache, so garbage collectors must treat these IDs as live even when
+        no cache entry still references them. The scan is tolerant: malformed
+        or unreadable version metadata is skipped.
+
+        Returns
+        -------
+        set[str]
+            Artifact IDs referenced by all persisted asset versions.
+        """
+        referenced: set[str] = set()
+        for meta_path in self._root.glob("*/*/versions/v-*/meta.yaml"):
+            try:
+                meta = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+            except (yaml.YAMLError, OSError):
+                continue
+            artifact_id = meta.get("artifact_id")
+            if isinstance(artifact_id, str) and artifact_id:
+                referenced.add(artifact_id)
+        return referenced
+
     def list_asset_keys(self) -> list[AssetKey]:
         """Return all asset keys currently present in the catalog."""
         keys: list[AssetKey] = []

--- a/src/ginkgo/runtime/caching/cache.py
+++ b/src/ginkgo/runtime/caching/cache.py
@@ -267,7 +267,7 @@ class CacheStore:
             a restore fails.
         """
         return_annotation = task_def.type_hints.get("return", task_def.signature.return_annotation)
-        artifact_ids = self._load_artifact_ids(cache_key=cache_key)
+        artifact_ids = self.load_artifact_ids(cache_key=cache_key)
         if artifact_ids is None:
             return False
         return self._validate_output_value(
@@ -359,8 +359,20 @@ class CacheStore:
         extra = meta.get("extra")
         return extra if isinstance(extra, dict) else None
 
-    def _load_artifact_ids(self, *, cache_key: str) -> dict[str, str] | None:
-        """Load output artifact mappings for one cache entry."""
+    def load_artifact_ids(self, *, cache_key: str) -> dict[str, str] | None:
+        """Return output-path to artifact-ID mappings for one cache entry.
+
+        Parameters
+        ----------
+        cache_key : str
+            The content-addressed cache key.
+
+        Returns
+        -------
+        dict[str, str] | None
+            Mapping of output path to artifact ID, or ``None`` when the
+            entry is missing or recorded no artifact mappings.
+        """
         meta = self._load_meta(cache_key=cache_key)
         if meta is None:
             return None
@@ -372,6 +384,26 @@ class CacheStore:
             for path, artifact_id in artifact_ids.items()
             if isinstance(path, str) and isinstance(artifact_id, str)
         }
+
+    def referenced_artifact_ids(self) -> set[str]:
+        """Return artifact IDs referenced by any surviving cache entry.
+
+        Entries with missing or unreadable metadata contribute nothing;
+        garbage collectors treat every returned ID as live.
+
+        Returns
+        -------
+        set[str]
+            Artifact IDs referenced by all cache entries under the root.
+        """
+        referenced: set[str] = set()
+        for entry_dir in self._root.iterdir():
+            if not entry_dir.is_dir():
+                continue
+            artifact_ids = self.load_artifact_ids(cache_key=entry_dir.name)
+            if artifact_ids:
+                referenced.update(artifact_ids.values())
+        return referenced
 
     def _load_meta(self, *, cache_key: str) -> dict[str, Any] | None:
         """Load the parsed meta.json for one cache entry."""

--- a/src/ginkgo/runtime/dry_run.py
+++ b/src/ginkgo/runtime/dry_run.py
@@ -9,13 +9,14 @@ environment prepared, and no cached output materialised into the workspace.
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from ginkgo.runtime.caching.cache import MISSING
 
 if TYPE_CHECKING:
-    from ginkgo.runtime.evaluator import ConcurrentEvaluator, _TaskNode
+    from ginkgo.runtime.evaluator import ConcurrentEvaluator, TaskNode
 
 CacheStatus = Literal["cached", "will_run", "unknown"]
 
@@ -156,7 +157,7 @@ def build_dry_run_plan(*, evaluator: ConcurrentEvaluator, workflow_label: str) -
     DryRunPlan
         The structured plan, grouped into dependency waves.
     """
-    nodes = evaluator._nodes
+    nodes = evaluator.task_nodes
     waves_by_node = _assign_waves(nodes)
     topo_order = sorted(nodes, key=lambda node_id: (waves_by_node[node_id], node_id))
     cache_status = _resolve_cache_status(evaluator=evaluator, topo_order=topo_order)
@@ -200,7 +201,7 @@ def build_dry_run_plan(*, evaluator: ConcurrentEvaluator, workflow_label: str) -
     )
 
 
-def _assign_waves(nodes: dict[int, _TaskNode]) -> dict[int, int]:
+def _assign_waves(nodes: Mapping[int, TaskNode]) -> dict[int, int]:
     """Assign each node a 0-based wave (longest dependency path to a root)."""
     indegree = {node_id: len(node.dependency_ids) for node_id, node in nodes.items()}
     dependents: dict[int, list[int]] = {node_id: [] for node_id in nodes}
@@ -229,7 +230,7 @@ def _resolve_cache_status(
     every dependency is a confirmed cache hit; once the chain breaks, the node
     and everything below it is ``unknown``.
     """
-    nodes = evaluator._nodes
+    nodes = evaluator.task_nodes
     status: dict[int, CacheStatus] = {}
     for node_id in topo_order:
         status[node_id] = _probe_node(evaluator=evaluator, node=nodes[node_id], status=status)
@@ -237,7 +238,7 @@ def _resolve_cache_status(
 
 
 def _probe_node(
-    *, evaluator: ConcurrentEvaluator, node: _TaskNode, status: dict[int, CacheStatus]
+    *, evaluator: ConcurrentEvaluator, node: TaskNode, status: dict[int, CacheStatus]
 ) -> CacheStatus:
     """Return the cache status of one node, given resolved upstream statuses."""
     # Downstream of anything not known-cached: the cache key cannot be
@@ -250,15 +251,9 @@ def _probe_node(
     if node.task_def.kind in _DRIVER_KINDS:
         return "unknown"
 
-    cache_store = evaluator._cache_store
+    cache_store = evaluator.cache_store
     try:
-        resolved_args = evaluator._resolve_task_args(
-            expr=node.expr,
-            task_def=node.task_def,
-            node=node,
-            include_tmp_dirs=False,
-            stage_remote_refs=False,
-        )
+        resolved_args = evaluator.resolve_probe_args(node=node)
         cache_key, _ = cache_store.build_cache_key(
             task_def=node.task_def,
             resolved_args=resolved_args,
@@ -283,7 +278,7 @@ def _probe_node(
     return "cached"
 
 
-def _task_label(node: _TaskNode) -> str:
+def _task_label(node: TaskNode) -> str:
     """Return a display label, including resolved fan-out parameters."""
     base_name = node.task_def.name.rsplit(".", 1)[-1]
     parts = node.expr.display_label_parts

--- a/src/ginkgo/runtime/evaluator.py
+++ b/src/ginkgo/runtime/evaluator.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import time
 import builtins
+from collections.abc import Mapping
 from contextlib import ExitStack, suppress
 from concurrent.futures import (
     FIRST_COMPLETED,
@@ -184,8 +185,13 @@ def evaluate(
 
 
 @dataclass(kw_only=True)
-class _TaskNode:
-    """Internal task node tracked by the concurrent scheduler."""
+class TaskNode:
+    """One task in the evaluator's dependency graph.
+
+    Nodes are created and mutated by :class:`ConcurrentEvaluator` as it
+    schedules work. Read-only consumers (such as the dry-run planner)
+    access them through :attr:`ConcurrentEvaluator.task_nodes`.
+    """
 
     node_id: int
     expr: Expr
@@ -239,7 +245,7 @@ class ConcurrentEvaluator:
     profiler: ProfileRecorder | None = None
     _cache_store: CacheStore = field(init=False, repr=False)
     _asset_store: AssetStore = field(init=False, repr=False)
-    _nodes: dict[int, _TaskNode] = field(default_factory=dict, init=False, repr=False)
+    _nodes: dict[int, TaskNode] = field(default_factory=dict, init=False, repr=False)
     _expr_nodes: dict[int, int] = field(default_factory=dict, init=False, repr=False)
     _running_futures: dict[Future[Any], tuple[int, str]] = field(
         default_factory=dict,
@@ -337,6 +343,47 @@ class ConcurrentEvaluator:
             asset_store=self._asset_store,
             run_id_provider=lambda: self._run_id,
             live_payloads=self._live_payloads,
+        )
+
+    @property
+    def cache_store(self) -> CacheStore:
+        """The cache store backing this evaluator."""
+        return self._cache_store
+
+    @property
+    def task_nodes(self) -> Mapping[int, TaskNode]:
+        """Read-only view of the task graph, keyed by scheduler node id.
+
+        Populated once the graph has been built (after :meth:`validate` or
+        during :meth:`evaluate`). Intended for read-only consumers such as
+        the dry-run planner.
+        """
+        return self._nodes
+
+    def resolve_probe_args(self, *, node: TaskNode) -> dict[str, Any]:
+        """Resolve one node's concrete arguments without side effects.
+
+        Read-only companion to the internal argument resolver, for cache
+        probing: no scratch directories are created and no remote
+        references are staged.
+
+        Parameters
+        ----------
+        node : TaskNode
+            A node whose dependencies have all completed (for example from
+            cache hits recorded by a previous probe).
+
+        Returns
+        -------
+        dict[str, Any]
+            The resolved keyword arguments for the task call.
+        """
+        return self._resolve_task_args(
+            expr=node.expr,
+            task_def=node.task_def,
+            node=node,
+            include_tmp_dirs=False,
+            stage_remote_refs=False,
         )
 
     def evaluate(self, expr: Any) -> Any:
@@ -507,7 +554,7 @@ class ConcurrentEvaluator:
                 task_path=next_task_path,
             )
 
-        self._nodes[node_id] = _TaskNode(
+        self._nodes[node_id] = TaskNode(
             node_id=node_id,
             expr=expr,
             dependency_ids=dependency_ids,
@@ -554,7 +601,7 @@ class ConcurrentEvaluator:
             if not progressed:
                 return
 
-    def _prepare_node(self, node: _TaskNode) -> None:
+    def _prepare_node(self, node: TaskNode) -> None:
         """Resolve non-ephemeral inputs, then either cache-hit or ready the task."""
         prepare_started = time.perf_counter()
         resolved_args = self._resolve_task_args(
@@ -618,7 +665,7 @@ class ConcurrentEvaluator:
             )
         )
 
-    def _prepare_task_environment(self, *, node: _TaskNode) -> None:
+    def _prepare_task_environment(self, *, node: TaskNode) -> None:
         """Materialize any external execution environment required by a task."""
         if node.task_def.env is None or self.backend is None:
             return
@@ -788,7 +835,7 @@ class ConcurrentEvaluator:
     def _handle_completed_worker_phase(
         self,
         *,
-        node: _TaskNode,
+        node: TaskNode,
         completed_value: Any,
         remote_job_id: str | None = None,
     ) -> None:
@@ -797,7 +844,7 @@ class ConcurrentEvaluator:
         node.remote_job_id = remote_job_id
         self._handle_task_body_result(node=node, completed_value=completed_value)
 
-    def _handle_completed_staging_phase(self, *, node: _TaskNode, completed_value: Any) -> None:
+    def _handle_completed_staging_phase(self, *, node: TaskNode, completed_value: Any) -> None:
         """Start task execution after remote inputs have been staged locally."""
         if not isinstance(completed_value, dict):
             raise TypeError("Expected staged task arguments from staging phase")
@@ -811,16 +858,16 @@ class ConcurrentEvaluator:
             shell_executor=self._executors.shell,
         )
 
-    def _handle_completed_driver_phase(self, *, node: _TaskNode, completed_value: Any) -> None:
+    def _handle_completed_driver_phase(self, *, node: TaskNode, completed_value: Any) -> None:
         """Handle the result returned from a driver-executed task wrapper."""
         self._handle_task_body_result(node=node, completed_value=completed_value)
 
-    def _handle_completed_shell_phase(self, *, node: _TaskNode, completed_value: Any) -> None:
+    def _handle_completed_shell_phase(self, *, node: TaskNode, completed_value: Any) -> None:
         """Handle the result produced by the shell executor."""
         final_value = self._finalize_result_value(node=node, value=completed_value)
         self._complete_node(node=node, value=final_value, tmp_paths=node.tmp_paths)
 
-    def _handle_task_exception(self, *, node: _TaskNode, exc: BaseException) -> None:
+    def _handle_task_exception(self, *, node: TaskNode, exc: BaseException) -> None:
         """Either retry a failed task attempt or fail the run."""
         sanitized_exc = sanitize_exception(exc=exc, secret_values=node.secret_values)
         if self._failure is None and self._should_retry(node=node, exc=sanitized_exc):
@@ -846,13 +893,13 @@ class ConcurrentEvaluator:
             )
         )
 
-    def _should_retry(self, *, node: _TaskNode, exc: BaseException) -> bool:
+    def _should_retry(self, *, node: TaskNode, exc: BaseException) -> bool:
         """Return whether the current failed attempt should be retried."""
         if node.attempt > node.task_def.retries:
             return False
         return node.task_def.should_retry_exception(exc=exc)
 
-    def _schedule_retry(self, *, node: _TaskNode, exc: BaseException) -> None:
+    def _schedule_retry(self, *, node: TaskNode, exc: BaseException) -> None:
         """Reset node state so the scheduler can rerun the task from scratch."""
         self._cleanup_transport(node)
 
@@ -908,7 +955,7 @@ class ConcurrentEvaluator:
             )
         )
 
-    def _complete_node(self, *, node: _TaskNode, value: Any, tmp_paths: list[Path]) -> None:
+    def _complete_node(self, *, node: TaskNode, value: Any, tmp_paths: list[Path]) -> None:
         """Persist and mark a task node as fully completed."""
         finalize_started = time.perf_counter()
         self._cleanup_transport(node)
@@ -981,7 +1028,7 @@ class ConcurrentEvaluator:
         *,
         expr: Expr,
         task_def: TaskDef,
-        node: _TaskNode | None = None,
+        node: TaskNode | None = None,
         include_tmp_dirs: bool,
         stage_remote_refs: bool = True,
         existing_args: dict[str, Any] | None = None,
@@ -1029,7 +1076,7 @@ class ConcurrentEvaluator:
 
         return resolved_args
 
-    def _resolve_execution_args(self, *, node: _TaskNode) -> dict[str, Any]:
+    def _resolve_execution_args(self, *, node: TaskNode) -> dict[str, Any]:
         """Resolve runtime-only inputs such as secret references."""
         assert node.resolved_args is not None
         if self.secret_resolver is None:
@@ -1162,7 +1209,7 @@ class ConcurrentEvaluator:
         """Return the core footprint of currently running tasks."""
         return sum(self._nodes[node_id].threads for node_id, _ in self._running_futures.values())
 
-    def _available_group_slots(self, *, ready_nodes: list[_TaskNode]) -> dict[str, int]:
+    def _available_group_slots(self, *, ready_nodes: list[TaskNode]) -> dict[str, int]:
         """Return the remaining concurrency budget per active group.
 
         For each named concurrency group represented in the ready set, the
@@ -1199,7 +1246,7 @@ class ConcurrentEvaluator:
     def _start_task_execution(
         self,
         *,
-        node: _TaskNode,
+        node: TaskNode,
         python_executor: ProcessPoolExecutor | ThreadPoolExecutor,
         shell_executor: ThreadPoolExecutor,
     ) -> None:
@@ -1321,7 +1368,7 @@ class ConcurrentEvaluator:
         future = python_executor.submit(run_task, payload)
         self._running_futures[future] = (node.node_id, "python")
 
-    def _poll_remote_job(self, handle: RemoteJobHandle, *, node: _TaskNode) -> dict[str, Any]:
+    def _poll_remote_job(self, handle: RemoteJobHandle, *, node: TaskNode) -> dict[str, Any]:
         """Poll a remote job handle until it reaches a terminal state.
 
         Called on a watcher thread — blocks until the remote job finishes.
@@ -1407,7 +1454,7 @@ class ConcurrentEvaluator:
     def _warn_on_access_fallback(
         self,
         *,
-        node: _TaskNode,
+        node: TaskNode,
         access_stats: dict[str, Any],
     ) -> None:
         """Surface a user-visible notice when fuse mounts fell back to staging.
@@ -1434,7 +1481,7 @@ class ConcurrentEvaluator:
             )
         )
 
-    def _capture_remote_logs(self, *, node: _TaskNode, handle: RemoteJobHandle) -> None:
+    def _capture_remote_logs(self, *, node: TaskNode, handle: RemoteJobHandle) -> None:
         """Fetch pod logs and write them to the standard task log paths."""
         try:
             logs = handle.logs_tail(lines=10000)
@@ -1590,7 +1637,7 @@ class ConcurrentEvaluator:
 
         return memory_gb
 
-    def _build_worker_payload(self, *, node: _TaskNode) -> dict[str, Any]:
+    def _build_worker_payload(self, *, node: TaskNode) -> dict[str, Any]:
         """Encode task inputs into a transport payload for the process pool."""
         assert node.transport_path is not None
         assert node.execution_args is not None
@@ -1616,7 +1663,7 @@ class ConcurrentEvaluator:
             "transport_dir": str(node.transport_path),
         }
 
-    def _decode_worker_result(self, *, node: _TaskNode, payload: dict[str, Any]) -> Any:
+    def _decode_worker_result(self, *, node: TaskNode, payload: dict[str, Any]) -> Any:
         """Decode a process-pool worker response."""
         if not payload["ok"]:
             self._cleanup_transport(node)
@@ -1639,7 +1686,7 @@ class ConcurrentEvaluator:
         assert node.transport_path is not None
         return decode_value(payload["result"], base_dir=node.transport_path)
 
-    def _cleanup_transport(self, node: _TaskNode) -> None:
+    def _cleanup_transport(self, node: TaskNode) -> None:
         """Remove temporary transport artifacts for a task node."""
         if node.transport_path is None:
             return
@@ -1647,7 +1694,7 @@ class ConcurrentEvaluator:
             shutil.rmtree(node.transport_path)
         node.transport_path = None
 
-    def _finalize_result_value(self, *, node: _TaskNode, value: Any) -> Any:
+    def _finalize_result_value(self, *, node: TaskNode, value: Any) -> Any:
         """Coerce and validate a fully resolved task result."""
         coerced = self._validator.coerce_return_value(task_def=node.task_def, value=value)
         finalized = self._asset_registrar.materialize_results(node=node, value=coerced)
@@ -1660,7 +1707,7 @@ class ConcurrentEvaluator:
             return self.provenance.root_dir.parent
         return Path.cwd() / ".ginkgo"
 
-    def _emit_notebook_notice(self, node: _TaskNode, message: str) -> None:
+    def _emit_notebook_notice(self, node: TaskNode, message: str) -> None:
         """Surface a notebook runner notice (e.g. ipykernel install) as an event."""
         self._emit_event(
             TaskNotice(
@@ -1705,7 +1752,7 @@ class ConcurrentEvaluator:
 
         return True
 
-    def _try_prepare_cache_hit(self, *, node: _TaskNode) -> bool:
+    def _try_prepare_cache_hit(self, *, node: TaskNode) -> bool:
         """Attempt to complete a node from cache during preparation.
 
         This fast path only runs when cache identity can be decided without
@@ -1719,7 +1766,7 @@ class ConcurrentEvaluator:
 
         return self._try_content_cache_hit(node=node)
 
-    def _try_content_cache_hit(self, *, node: _TaskNode) -> bool:
+    def _try_content_cache_hit(self, *, node: TaskNode) -> bool:
         """Attempt a content-addressed cache hit for one prepared node."""
         assert node.resolved_args is not None
         cache_lookup_started = time.perf_counter()
@@ -1759,7 +1806,7 @@ class ConcurrentEvaluator:
         self._mark_node_cached(node=node, value=cached_result, cache_key=node.cache_key)
         return True
 
-    def _try_stat_index_hit(self, *, node: _TaskNode) -> bool:
+    def _try_stat_index_hit(self, *, node: TaskNode) -> bool:
         """Attempt a stat-index cache hit for ``--trust-workspace`` mode.
 
         Returns ``True`` if the hit succeeded and the node was marked
@@ -1805,7 +1852,7 @@ class ConcurrentEvaluator:
         self._mark_node_cached(node=node, value=cached_result, cache_key=content_key)
         return True
 
-    def _record_stat_index_entry(self, *, node: _TaskNode, cache_key: str) -> None:
+    def _record_stat_index_entry(self, *, node: TaskNode, cache_key: str) -> None:
         """Record a stat-index entry for a completed task."""
         if node.resolved_args is None:
             return
@@ -1822,14 +1869,14 @@ class ConcurrentEvaluator:
         Called on cache hits so that downstream tasks can skip re-hashing
         file outputs that this task produced.
         """
-        artifact_ids = self._cache_store._load_artifact_ids(cache_key=cache_key)
+        artifact_ids = self._cache_store.load_artifact_ids(cache_key=cache_key)
         if artifact_ids is None:
             return
         for path_str, artifact_id in artifact_ids.items():
             resolved_key = str(Path(path_str).resolve())
             self._known_digests[resolved_key] = artifact_id
 
-    def _mark_node_cached(self, *, node: _TaskNode, value: Any, cache_key: str) -> None:
+    def _mark_node_cached(self, *, node: TaskNode, value: Any, cache_key: str) -> None:
         """Mark one node complete from cache and emit cached completion events."""
         if node.attempt == 0:
             node.attempt = 1
@@ -1880,7 +1927,7 @@ class ConcurrentEvaluator:
     def _record_task_metadata(
         self,
         *,
-        node: _TaskNode,
+        node: TaskNode,
         include_env_metadata: bool = True,
     ) -> None:
         """Update provenance inputs and environment copies for a task node."""
@@ -1934,7 +1981,7 @@ class ConcurrentEvaluator:
             seconds=time.perf_counter() - started,
         )
 
-    def _record_task_failure(self, *, node: _TaskNode, exc: BaseException) -> None:
+    def _record_task_failure(self, *, node: TaskNode, exc: BaseException) -> None:
         """Persist task failure details to the run manifest."""
         if self.provenance is None:
             return
@@ -1946,7 +1993,7 @@ class ConcurrentEvaluator:
             failure=classify_failure(exc=exc),
         )
 
-    def _display_label_for(self, *, node: _TaskNode) -> str | None:
+    def _display_label_for(self, *, node: TaskNode) -> str | None:
         """Return a richer CLI label for mapped tasks once args are resolved."""
         if not node.expr.mapped or node.resolved_args is None:
             return None
@@ -1966,7 +2013,7 @@ class ConcurrentEvaluator:
         base_name = node.task_def.name.rsplit(".", 1)[-1]
         return f"{base_name}[{rendered}]"
 
-    def _output_summary_for(self, *, node: _TaskNode, value: Any) -> list[dict[str, Any]]:
+    def _output_summary_for(self, *, node: TaskNode, value: Any) -> list[dict[str, Any]]:
         """Return a compact typed output summary for one task result."""
         annotation = node.task_def.type_hints.get(
             "return", node.task_def.signature.return_annotation
@@ -1990,7 +2037,7 @@ class ConcurrentEvaluator:
             with self.profiler.timed("event_emit"):
                 self.event_bus.emit(event)
 
-    def _run_driver_task(self, *, node: _TaskNode) -> Any:
+    def _run_driver_task(self, *, node: TaskNode) -> Any:
         """Run a driver-task wrapper on the scheduler process.
 
         For notebook and script tasks the body was already evaluated eagerly
@@ -2011,7 +2058,7 @@ class ConcurrentEvaluator:
         ):
             return node.task_def.fn(**node.execution_args)
 
-    def _handle_task_body_result(self, *, node: _TaskNode, completed_value: Any) -> None:
+    def _handle_task_body_result(self, *, node: TaskNode, completed_value: Any) -> None:
         """Advance a task after its driver wrapper has finished."""
         if self._failure is not None and (
             isinstance(completed_value, ExecutionDirective)

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -354,3 +354,23 @@ class TestStorageLayout:
         assert (root / "blobs").is_dir()
         assert (root / "trees").is_dir()
         assert (root / "refs").is_dir()
+
+
+class TestRecordAccess:
+    def test_load_record_returns_stored_metadata(self, store):
+        record = store.store_bytes(data=b"payload", extension="txt")
+
+        loaded = store.load_record(artifact_id=record.artifact_id)
+        assert loaded is not None
+        assert loaded.artifact_id == record.artifact_id
+        assert loaded.digest_hex == record.digest_hex
+
+    def test_load_record_missing_returns_none(self, store):
+        assert store.load_record(artifact_id="missing") is None
+
+    def test_list_artifact_ids(self, store):
+        assert store.list_artifact_ids() == []
+
+        first = store.store_bytes(data=b"one", extension="txt")
+        second = store.store_bytes(data=b"two", extension="txt")
+        assert store.list_artifact_ids() == sorted([first.artifact_id, second.artifact_id])

--- a/tests/test_asset_store.py
+++ b/tests/test_asset_store.py
@@ -51,6 +51,31 @@ class TestAssetStore:
         assert latest.version_id == version.version_id
         assert store.list_asset_keys() == [key]
 
+    def test_list_aliases(self, tmp_path: Path) -> None:
+        store = AssetStore(root=tmp_path / ".ginkgo" / "assets")
+        key, version = _make_version(
+            name="prepared_data", suffix="1", run_id="run-1", producer="tests.writer"
+        )
+        store.register_version(version=version)
+
+        assert store.list_aliases(key=key) == {}
+
+        store.set_alias(key=key, alias="latest", version_id=version.version_id)
+        assert store.list_aliases(key=key) == {"latest": version.version_id}
+
+    def test_referenced_artifact_ids(self, tmp_path: Path) -> None:
+        store = AssetStore(root=tmp_path / ".ginkgo" / "assets")
+        _, first = _make_version(
+            name="prepared_data", suffix="1", run_id="run-1", producer="tests.writer"
+        )
+        _, second = _make_version(
+            name="transformed_data", suffix="2", run_id="run-2", producer="tests.transformer"
+        )
+        store.register_version(version=first)
+        store.register_version(version=second)
+
+        assert store.referenced_artifact_ids() == {"artifact-1", "artifact-2"}
+
     def test_record_lineage(self, tmp_path: Path) -> None:
         store = AssetStore(root=tmp_path / ".ginkgo" / "assets")
         parent_key, parent_version = _make_version(


### PR DESCRIPTION
## Summary

Converts every private reach-in flagged in #106 to a declared public API. The stores now own their on-disk formats end to end; the CLI, reporting, and dry-run modules go through public methods instead of parsing store layouts or calling underscore internals.

### New public surface

**`AssetStore`**
- `list_aliases(key)` — alias → version-id mapping; `ginkgo asset versions` now uses it instead of `_load_index`.
- `referenced_artifact_ids()` — artifact IDs referenced by every catalogued asset version (moved from the CLI's `_asset_artifact_ids`, which re-parsed `meta.yaml` and hard-coded the catalog layout).

**`CacheStore`**
- `load_artifact_ids(cache_key)` — promoted from `_load_artifact_ids`, mirroring the existing public `load_extra_meta`; the evaluator's `_propagate_known_digests` and `validate_cached_outputs` now call it.
- `referenced_artifact_ids()` — artifact IDs referenced by surviving cache entries (moved from the CLI's `_cache_artifact_ids`, which re-parsed `meta.json`).

**`LocalArtifactStore`**
- `load_record(artifact_id) -> ArtifactRecord | None` — reporting's `_artifact_record` helper (which reached into `_refs_dir`) is deleted in favour of this; the raising `_load_record` is now a thin wrapper over it.
- `list_artifact_ids()` — replaces the CLI GC's direct walk of `artifacts/refs/`.

`_gc_orphan_artifacts` in the cache CLI is now a thin composition of the three stores: each reports its live IDs and the artifact store enumerates and deletes orphans.

**`ConcurrentEvaluator`** (read-only surface for dry-run)
- `cache_store` property, `task_nodes` property (`Mapping[int, TaskNode]`), and `resolve_probe_args(node)` — a side-effect-free argument resolver for cache probing (no tmp dirs, no remote staging).
- `_TaskNode` is renamed to `TaskNode` since it is now part of the evaluator's declared surface; `dry_run.py` no longer touches any underscore attribute of the evaluator. (Its `state` field is untouched — #101.)

### Tests

- Direct coverage added for `AssetStore.list_aliases` / `referenced_artifact_ids` and `LocalArtifactStore.load_record` / `list_artifact_ids`.
- Existing GC regression tests (`test_cache_prune_assets.py`) exercise the new store-backed GC path unchanged.
- Full suite: 710 passed, 5 skipped. `pixi run lint` and `pixi run format-check` clean.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
